### PR TITLE
rename lighty-core repository references to lighty

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,7 +16,7 @@ lighty.io branch [eg. 12.2.x]
 **To Reproduce**
 Steps to reproduce the behavior:
 1. git checkout https://...
-2. cd lighty-core
+2. cd lighty
 3. mvn clean install
 4. See error
 

--- a/CONTRIBUTIONS
+++ b/CONTRIBUTIONS
@@ -1,4 +1,4 @@
-Contributions to lighty-core
+Contributions to lighty
 ----------------------------
 
 This software is distributed under Eclipse Public License 1.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Software-Defined Networking (SDN) solutions in Java. Developed by [PANTHEON.tech
 
 It utilizes core [OpenDaylight](https://www.opendaylight.org/) components, which are available as a set of libraries and are adapted to run in a __plain Java SE environment__.
 
-[![Build Status](https://travis-ci.com/PANTHEONtech/lighty-core.svg?branch=master)](https://travis-ci.com/PANTHEONtech/lighty-core)
+[![Build Status](https://travis-ci.com/PANTHEONtech/lighty.svg?branch=master)](https://travis-ci.com/PANTHEONtech/lighty)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.lighty.core/lighty-bom/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.lighty.core/lighty-bom)
 [![License](https://img.shields.io/badge/License-EPL%201.0-blue.svg)](https://opensource.org/licenses/EPL-1.0)
 

--- a/docs/ODL-migration-guide.md
+++ b/docs/ODL-migration-guide.md
@@ -1,5 +1,5 @@
 # How-To migrate from ODL to lighty.io
-This guide describes migration procedure of SDN application from [OpenDaylight](https://www.opendaylight.org/)/[Karaf](https://karaf.apache.org/) to [lighty.io](https://github.com/PantheonTechnologies/lighty-core).
+This guide describes migration procedure of SDN application from [OpenDaylight](https://www.opendaylight.org/)/[Karaf](https://karaf.apache.org/) to [lighty.io](https://github.com/PANTHEONtech/lighty).
 It contains summary of practical experiences based on real-life ODL project migrations.
 
 ### 1. ODL application review

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -14,7 +14,7 @@
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
     <description>
         This artifact contains dependencyManagement declarations of upstream
         versions.
@@ -147,9 +147,9 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/PANTHEONtech/lighty-core.git</connection>
-        <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty-core.git</developerConnection>
-        <url>https://github.com/PANTHEONtech/lighty-core</url>
+        <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
+        <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
+        <url>https://github.com/PANTHEONtech/lighty</url>
       <tag>HEAD</tag>
   </scm>
     <developers>

--- a/lighty-core/lighty-app-parent/pom.xml
+++ b/lighty-core/lighty-app-parent/pom.xml
@@ -21,7 +21,7 @@
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
     <description>
         Utility parent for packaging final controller applications.
     </description>

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -24,7 +24,7 @@
     <artifactId>lighty-binding-parent</artifactId>
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
 
     <properties>
         <salGeneratorPath>target/generated-sources/mdsal-binding</salGeneratorPath>

--- a/lighty-core/lighty-bom/pom.xml
+++ b/lighty-core/lighty-bom/pom.xml
@@ -14,7 +14,7 @@
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
     <description>
         This artifact contains dependencyManagement declarations of all published
         Lighty components.
@@ -155,9 +155,9 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/PANTHEONtech/lighty-core.git</connection>
-        <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty-core.git</developerConnection>
-        <url>https://github.com/PANTHEONtech/lighty-core</url>
+        <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
+        <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
+        <url>https://github.com/PANTHEONtech/lighty</url>
       <tag>HEAD</tag>
   </scm>
     <developers>

--- a/lighty-core/lighty-codecs/pom.xml
+++ b/lighty-core/lighty-codecs/pom.xml
@@ -21,7 +21,7 @@
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
 
     <dependencies>
         <dependency>

--- a/lighty-core/lighty-common/pom.xml
+++ b/lighty-core/lighty-common/pom.xml
@@ -20,7 +20,7 @@
     <artifactId>lighty-common</artifactId>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
 
     <dependencies>
         <dependency>

--- a/lighty-core/lighty-controller-guice-di/pom.xml
+++ b/lighty-core/lighty-controller-guice-di/pom.xml
@@ -20,7 +20,7 @@
     <artifactId>lighty-controller-guice-di</artifactId>
 
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
 
     <dependencies>
         <dependency>

--- a/lighty-core/lighty-controller-spring-di/pom.xml
+++ b/lighty-core/lighty-controller-spring-di/pom.xml
@@ -20,7 +20,7 @@
     <artifactId>lighty-controller-spring-di</artifactId>
 
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
 
     <dependencyManagement>
         <dependencies>

--- a/lighty-core/lighty-controller/pom.xml
+++ b/lighty-core/lighty-controller/pom.xml
@@ -20,7 +20,7 @@
     <artifactId>lighty-controller</artifactId>
 
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
 
     <dependencies>
         <dependency>

--- a/lighty-core/lighty-minimal-parent/pom.xml
+++ b/lighty-core/lighty-minimal-parent/pom.xml
@@ -14,7 +14,7 @@
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
     <description>
         Minimal parent pom, which only defines source encoding and imports
         lighty's dependencies.
@@ -100,9 +100,9 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/PANTHEONtech/lighty-core.git</connection>
-        <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty-core.git</developerConnection>
-        <url>https://github.com/PANTHEONtech/lighty-core</url>
+        <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
+        <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
+        <url>https://github.com/PANTHEONtech/lighty</url>
       <tag>HEAD</tag>
   </scm>
     <developers>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -22,7 +22,7 @@
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
     <description>
         Parent pom for code artifacts using Lighty.io.
     </description>

--- a/lighty-examples/lighty-community-netconf-quarkus-app/src/main/java/io/lighty/examples/controllers/quarkus/QuarkusApp.java
+++ b/lighty-examples/lighty-community-netconf-quarkus-app/src/main/java/io/lighty/examples/controllers/quarkus/QuarkusApp.java
@@ -56,7 +56,7 @@ public class QuarkusApp {
         LOG.info("        /_____/     \\/      \\/      \\/                     \\/         \\/         \\/");
         LOG.info("Starting lighty.io quarkus.io-NETCONF example application ...");
         LOG.info("https://lighty.io/");
-        LOG.info("https://github.com/PANTHEONtech/lighty-core");
+        LOG.info("https://github.com/PANTHEONtech/lighty");
         try {
             LOG.info("using default configuration ...");
             //1. get controller configuration

--- a/lighty-examples/lighty-community-restconf-netconf-app/src/main/java/io/lighty/examples/controllers/restconfapp/Main.java
+++ b/lighty-examples/lighty-community-restconf-netconf-app/src/main/java/io/lighty/examples/controllers/restconfapp/Main.java
@@ -60,7 +60,7 @@ public class Main {
         LOG.info("        /_____/     \\/      \\/      \\/                     \\/         \\/         \\/");
         LOG.info("Starting lighty.io RESTCONF-NETCONF example application ...");
         LOG.info("https://lighty.io/");
-        LOG.info("https://github.com/PANTHEONtech/lighty-core");
+        LOG.info("https://github.com/PANTHEONtech/lighty");
         try {
             if (args.length > 0) {
                 Path configPath = Paths.get(args[0]);

--- a/lighty-examples/lighty-community-restconf-ofp-app/src/main/java/io/lighty/examples/controllers/restconf/ofp/Main.java
+++ b/lighty-examples/lighty-community-restconf-ofp-app/src/main/java/io/lighty/examples/controllers/restconf/ofp/Main.java
@@ -48,7 +48,7 @@ public final class Main {
         LOG.info("       /_____/      \\/      \\/      \\/                     \\/     \\/    ");
         LOG.info("Starting lighty.io RESTCONF-OPENFLOW example application ...");
         LOG.info("https://lighty.io/");
-        LOG.info("https://github.com/PANTHEONtech/lighty-core");
+        LOG.info("https://github.com/PANTHEONtech/lighty");
         try {
             final ControllerConfiguration controllerConfiguration;
             final RestConfConfiguration restConfConfiguration;

--- a/lighty-models/test/lighty-example-data-center/pom.xml
+++ b/lighty-models/test/lighty-example-data-center/pom.xml
@@ -20,6 +20,6 @@
     <artifactId>example-data-center</artifactId>
 
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
 
 </project>

--- a/lighty-models/test/lighty-test-models/pom.xml
+++ b/lighty-models/test/lighty-test-models/pom.xml
@@ -20,6 +20,6 @@
     <artifactId>lighty-test-models</artifactId>
 
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
 
 </project>

--- a/lighty-models/test/lighty-toaster/pom.xml
+++ b/lighty-models/test/lighty-toaster/pom.xml
@@ -20,6 +20,6 @@
     <artifactId>lighty-toaster</artifactId>
 
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
 
 </project>

--- a/lighty-modules/lighty-aaa/pom.xml
+++ b/lighty-modules/lighty-aaa/pom.xml
@@ -19,7 +19,7 @@
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-aaa</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
 
     <dependencies>
         <dependency>

--- a/lighty-modules/lighty-jetty-server/pom.xml
+++ b/lighty-modules/lighty-jetty-server/pom.xml
@@ -19,7 +19,7 @@
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-jetty-server</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
 
     <dependencies>
         <dependency>

--- a/lighty-modules/lighty-netconf-sb/pom.xml
+++ b/lighty-modules/lighty-netconf-sb/pom.xml
@@ -18,7 +18,7 @@
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-netconf-sb</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
 
     <dependencies>
         <dependency>

--- a/lighty-modules/lighty-restconf-nb-community/pom.xml
+++ b/lighty-modules/lighty-restconf-nb-community/pom.xml
@@ -20,7 +20,7 @@
     <artifactId>lighty-restconf-nb-community</artifactId>
 
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
 
     <dependencies>
         <dependency>

--- a/lighty-modules/lighty-swagger/pom.xml
+++ b/lighty-modules/lighty-swagger/pom.xml
@@ -19,7 +19,7 @@
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-swagger</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
 
     <dependencies>
         <dependency>

--- a/lighty-resources/controller-application-assembly/pom.xml
+++ b/lighty-resources/controller-application-assembly/pom.xml
@@ -21,6 +21,6 @@
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
 
 </project>

--- a/lighty-resources/log4j-properties/pom.xml
+++ b/lighty-resources/log4j-properties/pom.xml
@@ -21,6 +21,6 @@
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
 
 </project>

--- a/lighty-resources/singlenode-configuration/pom.xml
+++ b/lighty-resources/singlenode-configuration/pom.xml
@@ -21,6 +21,6 @@
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty-core</url>
+    <url>https://github.com/PANTHEONtech/lighty</url>
 
 </project>

--- a/lighty-resources/start-script/pom.xml
+++ b/lighty-resources/start-script/pom.xml
@@ -21,6 +21,6 @@
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>
-  <url>https://github.com/PANTHEONtech/lighty-core</url>
+  <url>https://github.com/PANTHEONtech/lighty</url>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>lighty-aggregator</artifactId>
     <version>14.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>lighty-core</name>
+    <name>lighty</name>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
@@ -55,9 +55,9 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:https://github.com/PANTHEONtech/lighty-core.git</connection>
-        <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty-core.git</developerConnection>
-        <url>https://github.com/PANTHEONtech/lighty-core</url>
+        <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
+        <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
+        <url>https://github.com/PANTHEONtech/lighty</url>
       <tag>HEAD</tag>
   </scm>
     <developers>


### PR DESCRIPTION
Rename "lighty-core" github references in sources to new repository name "lighty"