### PR TITLE
Fix older java versions (bump to 11)

### DIFF
--- a/lighty-examples/lighty-community-netconf-quarkus-app/src/main/docker/Dockerfile.jvm
+++ b/lighty-examples/lighty-community-netconf-quarkus-app/src/main/docker/Dockerfile.jvm
@@ -14,6 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/lighty-quarkus-jvm
 #
 ###
+# TODO Once quarkus-app is added to the build, bump the java jdk to 11 try to use (FROM openjdk:11-jre-slim).
 FROM fabric8/java-jboss-openjdk8-jdk
 ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
 COPY target/lib/* /deployments/lib/

--- a/lighty-examples/lighty-community-restconf-ofp-app/Dockerfile
+++ b/lighty-examples/lighty-community-restconf-ofp-app/Dockerfile
@@ -1,13 +1,14 @@
-FROM openjdk:8u191-jre-alpine3.9
+FROM openjdk:11-jre-slim
 
 COPY ./target/lighty-community-restconf-ofp-app-14.0.0-SNAPSHOT-bin.zip /
+RUN apt-get update && apt-get install unzip \
+    && unzip /lighty-community-restconf-ofp-app-14.0.0-SNAPSHOT-bin.zip \
+    && rm /lighty-community-restconf-ofp-app-14.0.0-SNAPSHOT-bin.zip
 
-RUN unzip /lighty-community-restconf-ofp-app-14.0.0-SNAPSHOT-bin.zip && rm /lighty-community-restconf-ofp-app-14.0.0-SNAPSHOT-bin.zip
 
 ##libstdc++ is required by leveldbjni-1.8 (Akka dispatcher)
 #Uncaught error from thread [opendaylight-cluster-data-akka.persistence.dispatchers.default-plugin-dispatcher-22]: Could not load library. Reasons: [no leveldbjni64-1.8 in java.library.path, no leveldbjni-1.8 in java.library.path, no leveldbjni in java.library.path, /tmp/libleveldbjni-64-1-3166161234556196376.8: Error loading shared library libstdc++.so.6: No such file or directory (needed by /tmp/libleveldbjni-64-1-3166161234556196376.8)], shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled for ActorSystem[opendaylight-cluster-data]
-RUN apk add --update libstdc++ curl && \
-    rm -rf /var/cache/apk/*
+RUN apt-get install libstdc++6
 
 WORKDIR /lighty-community-restconf-ofp-app-14.0.0-SNAPSHOT
 

--- a/lighty-examples/lighty-community-restconf-ofp-app/src/main/assembly/resources/sampleConfigSingleNode.json
+++ b/lighty-examples/lighty-community-restconf-ofp-app/src/main/assembly/resources/sampleConfigSingleNode.json
@@ -121,6 +121,7 @@
     "frmBundleBasedReconciliationEnabled": false,
     "nonZeroUint32Type": 900000,
     "enableForwardingRulesManager": true,
+    "deviceConnectionHoldTimeInSeconds": 0,
     "switchConfig": {
       "instanceName": "openflow-switch-connection-provider-default-impl",
       "port": 6653,

--- a/lighty-examples/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/lighty-controller-springboot-netconf/pom.xml
@@ -24,8 +24,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>1.8</java.version>
-
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 


### PR DESCRIPTION
There were some examples in which we still used java 8. This PR bumps these versions.

Signed-off-by: marekzatko <Marek.Zatko@pantheon.tech>