### PR TITLE
Refactor @AfterAll tests methods [12.2.x]

### DIFF
--- a/lighty-core/lighty-controller-guice-di/src/test/java/io/lighty/core/controller/guice/tests/GuiceDITest.java
+++ b/lighty-core/lighty-controller-guice-di/src/test/java/io/lighty/core/controller/guice/tests/GuiceDITest.java
@@ -7,7 +7,6 @@
  */
 package io.lighty.core.controller.guice.tests;
 
-import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertNotNull;
 
 import com.google.inject.Guice;
@@ -19,11 +18,14 @@ import io.lighty.core.controller.impl.config.ConfigurationException;
 import io.lighty.core.controller.impl.config.ControllerConfiguration;
 import io.lighty.core.controller.impl.util.ControllerConfigUtils;
 import java.util.concurrent.ExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class GuiceDITest {
+    private static final Logger LOG = LoggerFactory.getLogger(GuiceDITest.class);
 
     private LightyController lightyController;
     private TestService testService;
@@ -51,8 +53,7 @@ public class GuiceDITest {
                 lightyController.shutdown();
             }
         } catch (Exception e) {
-            // FIXME: this is ugly, find a nicer solution
-            fail();
+            LOG.error("Shutdown of LightyController failed", e);
         }
     }
 

--- a/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerTestBase.java
+++ b/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerTestBase.java
@@ -25,6 +25,7 @@ public abstract class LightyControllerTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(LightyControllerTestBase.class);
     public static final long SHUTDOWN_TIMEOUT_MILLIS = 15_000;
+    public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 1_000;
 
     private LightyController lightyController;
 
@@ -58,6 +59,7 @@ public abstract class LightyControllerTestBase {
             LOG.info("Shutting down Lighty controller");
             try {
                 lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (Exception e) {
                 LOG.error("Shutdown of LightyController failed", e);
             }

--- a/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerTestBase.java
+++ b/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerTestBase.java
@@ -12,6 +12,7 @@ import io.lighty.core.controller.api.LightyController;
 import io.lighty.core.controller.impl.LightyControllerBuilder;
 import io.lighty.core.controller.impl.util.ControllerConfigUtils;
 import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.ITestResult;
@@ -23,6 +24,7 @@ import org.testng.annotations.BeforeMethod;
 public abstract class LightyControllerTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(LightyControllerTestBase.class);
+    public static final long SHUTDOWN_TIMEOUT_MILLIS = 60_000;
     public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 1_000;
 
     private LightyController lightyController;
@@ -56,7 +58,7 @@ public abstract class LightyControllerTestBase {
         if (lightyController != null) {
             LOG.info("Shutting down Lighty controller");
             try {
-                lightyController.shutdown().get();
+                lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
                 Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (Exception e) {
                 LOG.error("Shutdown of LightyController failed", e);

--- a/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerTestBase.java
+++ b/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerTestBase.java
@@ -12,6 +12,7 @@ import io.lighty.core.controller.api.LightyController;
 import io.lighty.core.controller.impl.LightyControllerBuilder;
 import io.lighty.core.controller.impl.util.ControllerConfigUtils;
 import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.ITestResult;
@@ -23,6 +24,7 @@ import org.testng.annotations.BeforeMethod;
 public abstract class LightyControllerTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(LightyControllerTestBase.class);
+    public static final long SHUTDOWN_TIMEOUT_MILLIS = 15_000;
 
     private LightyController lightyController;
 
@@ -49,13 +51,16 @@ public abstract class LightyControllerTestBase {
                 result.getName(), parseTestNGStatus(result.getStatus()), result.getThrowable());
     }
 
+    @SuppressWarnings("checkstyle:illegalCatch")
     @AfterClass
-    public void shutdownLighty() throws Exception {
+    public void shutdownLighty() {
         if (lightyController != null) {
             LOG.info("Shutting down Lighty controller");
-            ListenableFuture<Boolean> shutdown = lightyController.shutdown();
-            shutdown.get();
-            Thread.sleep(1_000);
+            try {
+                lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            } catch (Exception e) {
+                LOG.error("Shutdown of LightyController failed", e);
+            }
         }
     }
 

--- a/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerTestBase.java
+++ b/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerTestBase.java
@@ -24,7 +24,6 @@ import org.testng.annotations.BeforeMethod;
 public abstract class LightyControllerTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(LightyControllerTestBase.class);
-    public static final long SHUTDOWN_TIMEOUT_MILLIS = 15_000;
     public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 1_000;
 
     private LightyController lightyController;
@@ -58,7 +57,7 @@ public abstract class LightyControllerTestBase {
         if (lightyController != null) {
             LOG.info("Shutting down Lighty controller");
             try {
-                lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                lightyController.shutdown().get();
                 Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (Exception e) {
                 LOG.error("Shutdown of LightyController failed", e);

--- a/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerTestBase.java
+++ b/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerTestBase.java
@@ -12,7 +12,6 @@ import io.lighty.core.controller.api.LightyController;
 import io.lighty.core.controller.impl.LightyControllerBuilder;
 import io.lighty.core.controller.impl.util.ControllerConfigUtils;
 import java.lang.reflect.Method;
-import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.ITestResult;

--- a/lighty-examples/lighty-community-restconf-netconf-app/src/test/java/io/lighty/examples/controllers/restconfapp/tests/RestconfAppTest.java
+++ b/lighty-examples/lighty-community-restconf-netconf-app/src/test/java/io/lighty/examples/controllers/restconfapp/tests/RestconfAppTest.java
@@ -77,9 +77,8 @@ public class RestconfAppTest {
         restconfApp.shutdown();
         try {
             restClient.close();
-            Thread.sleep(3_000);
         } catch (Exception e) {
-            LOG.error("Error: ", e);
+            LOG.error("Shutdown of restClient failed", e);
         }
     }
 

--- a/lighty-examples/lighty-community-restconf-netconf-app/src/test/java/io/lighty/examples/controllers/restconfapp/tests/RestconfAppTest.java
+++ b/lighty-examples/lighty-community-restconf-netconf-app/src/test/java/io/lighty/examples/controllers/restconfapp/tests/RestconfAppTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.Test;
 public class RestconfAppTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(RestconfAppTest.class);
+    public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 3_000;
 
     private static Main restconfApp;
     private static RestClient restClient;
@@ -77,6 +78,7 @@ public class RestconfAppTest {
         restconfApp.shutdown();
         try {
             restClient.close();
+            Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
         } catch (Exception e) {
             LOG.error("Shutdown of restClient failed", e);
         }

--- a/lighty-examples/lighty-controller-springboot-netconf/src/test/java/io/lighty/core/controller/springboot/test/SpringBootAppTest.java
+++ b/lighty-examples/lighty-controller-springboot-netconf/src/test/java/io/lighty/core/controller/springboot/test/SpringBootAppTest.java
@@ -92,6 +92,7 @@ public class SpringBootAppTest {
         Assert.assertEquals(contentResponse.getStatus(), 200);
     }
 
+    @SuppressWarnings("checkstyle:illegalCatch")
     @AfterClass
     public static void shutdown() {
         if (appContext != null) {
@@ -100,9 +101,8 @@ public class SpringBootAppTest {
         if (restClient != null) {
             try {
                 restClient.close();
-                Thread.sleep(1_000);
             } catch (Exception e) {
-                LOG.error("Exception: ", e);
+                LOG.error("Shutdown of restClient failed", e);
             }
         }
     }

--- a/lighty-examples/lighty-controller-springboot-netconf/src/test/java/io/lighty/core/controller/springboot/test/SpringBootAppTest.java
+++ b/lighty-examples/lighty-controller-springboot-netconf/src/test/java/io/lighty/core/controller/springboot/test/SpringBootAppTest.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 public class SpringBootAppTest {
 
     final private static Logger LOG = LoggerFactory.getLogger(SpringBootAppTest.class);
+    public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 1_000;
 
     private static ConfigurableApplicationContext appContext;
     private static RestClient restClient;
@@ -101,6 +102,7 @@ public class SpringBootAppTest {
         if (restClient != null) {
             try {
                 restClient.close();
+                Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (Exception e) {
                 LOG.error("Shutdown of restClient failed", e);
             }

--- a/lighty-modules/integration-tests-aaa/src/test/java/io/lighty/kit/examples/community/tests/AAATestIT.java
+++ b/lighty-modules/integration-tests-aaa/src/test/java/io/lighty/kit/examples/community/tests/AAATestIT.java
@@ -40,7 +40,7 @@ import org.testng.annotations.Test;
 public class AAATestIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(AAATestIT.class);
-    public static final long SHUTDOWN_TIMEOUT_MILLIS = 15_000;
+    public static final long SHUTDOWN_TIMEOUT_MILLIS = 60_000;
 
     private static final String PATH_PREFIX = "http://localhost:8888/";
     private static final String AUTH = "Authorization";

--- a/lighty-modules/integration-tests-aaa/src/test/java/io/lighty/kit/examples/community/tests/AAATestIT.java
+++ b/lighty-modules/integration-tests-aaa/src/test/java/io/lighty/kit/examples/community/tests/AAATestIT.java
@@ -12,6 +12,7 @@ import static org.testng.Assert.assertEquals;
 
 import io.lighty.kit.examples.community.aaa.restconf.Main;
 import java.io.File;
+import java.io.IOException;
 import java.util.Base64;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -39,6 +40,8 @@ import org.testng.annotations.Test;
 public class AAATestIT {
 
     private static final Logger LOG = LoggerFactory.getLogger(AAATestIT.class);
+    public static final long SHUTDOWN_TIMEOUT_MILLIS = 15_000;
+
     private static final String PATH_PREFIX = "http://localhost:8888/";
     private static final String AUTH = "Authorization";
     private static final String USERS_PATH = "auth/v1/users/";
@@ -361,17 +364,26 @@ public class AAATestIT {
     }
 
     @AfterClass
-    public void shutdown() throws Exception {
+    public void shutdown() {
         LOG.info("removing db files");
         File currentDirFile = new File(".");
         String lightyTestsPath = currentDirFile.getAbsolutePath();
-        FileUtils.deleteDirectory(new File(lightyTestsPath + "/configuration"));
-        FileUtils.deleteDirectory(new File(lightyTestsPath + "/data"));
+        try {
+            FileUtils.deleteDirectory(new File(lightyTestsPath + "/configuration"));
+            FileUtils.deleteDirectory(new File(lightyTestsPath + "/data"));
+        } catch (IOException e) {
+            LOG.error("Deletion of directory failed", e);
+        }
+
 
         LOG.info("shutdown.");
         final ExecutorService executorService = Executors.newFixedThreadPool(5);
         executorService.shutdown();
-        executorService.awaitTermination(15, TimeUnit.SECONDS);
+        try {
+            executorService.awaitTermination(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            LOG.error("Interrupted while shutting down", e);
+        }
     }
 
     private static class Connection {

--- a/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/CallhomePluginTest.java
+++ b/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/CallhomePluginTest.java
@@ -20,8 +20,6 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;

--- a/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/CallhomePluginTest.java
+++ b/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/CallhomePluginTest.java
@@ -32,7 +32,6 @@ import org.testng.annotations.Test;
 public class CallhomePluginTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(CallhomePluginTest.class);
-    public static final long SHUTDOWN_TIMEOUT_MILLIS = 15_000;
     public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 3_000;
 
     private LightyController lightyController;
@@ -55,7 +54,7 @@ public class CallhomePluginTest {
         if (netconfPlugin != null) {
             LOG.info("Shutting down Netconf topology Plugin");
             try {
-                netconfPlugin.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                netconfPlugin.shutdown().get();
             } catch (Exception e) {
                 LOG.error("Shutdown of Netconf topology Plugin failed", e);
             }
@@ -63,12 +62,10 @@ public class CallhomePluginTest {
         if (restConf != null) {
             LOG.info("Shutting down CommunityRestConf");
             try {
-                restConf.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                restConf.shutdown().get();
                 Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (InterruptedException e) {
                 LOG.error("Interrupted while shutting down CommunityRestConf", e);
-            } catch (TimeoutException e) {
-                LOG.error("Timeout while shutting down Lighty Swagger", e);
             } catch (ExecutionException e) {
                 LOG.error("Execution of CommunityRestConf shutdown failed", e);
             }
@@ -76,7 +73,7 @@ public class CallhomePluginTest {
         if (lightyController != null) {
             LOG.info("Shutting down LightyController");
             try {
-                lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                lightyController.shutdown().get();
                 Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (Exception e) {
                 LOG.error("Shutdown of LightyController failed", e);

--- a/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/CallhomePluginTest.java
+++ b/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/CallhomePluginTest.java
@@ -33,6 +33,7 @@ public class CallhomePluginTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(CallhomePluginTest.class);
     public static final long SHUTDOWN_TIMEOUT_MILLIS = 15_000;
+    public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 3_000;
 
     private LightyController lightyController;
     private CommunityRestConf restConf;
@@ -63,6 +64,7 @@ public class CallhomePluginTest {
             LOG.info("Shutting down CommunityRestConf");
             try {
                 restConf.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (InterruptedException e) {
                 LOG.error("Interrupted while shutting down CommunityRestConf", e);
             } catch (TimeoutException e) {
@@ -75,6 +77,7 @@ public class CallhomePluginTest {
             LOG.info("Shutting down LightyController");
             try {
                 lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (Exception e) {
                 LOG.error("Shutdown of LightyController failed", e);
             }

--- a/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/CallhomePluginTest.java
+++ b/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/CallhomePluginTest.java
@@ -20,6 +20,8 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
@@ -30,6 +32,7 @@ import org.testng.annotations.Test;
 public class CallhomePluginTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(CallhomePluginTest.class);
+    public static final long SHUTDOWN_TIMEOUT_MILLIS = 60_000;
     public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 3_000;
 
     private LightyController lightyController;
@@ -52,7 +55,7 @@ public class CallhomePluginTest {
         if (netconfPlugin != null) {
             LOG.info("Shutting down Netconf topology Plugin");
             try {
-                netconfPlugin.shutdown().get();
+                netconfPlugin.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
             } catch (Exception e) {
                 LOG.error("Shutdown of Netconf topology Plugin failed", e);
             }
@@ -60,10 +63,12 @@ public class CallhomePluginTest {
         if (restConf != null) {
             LOG.info("Shutting down CommunityRestConf");
             try {
-                restConf.shutdown().get();
+                restConf.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
                 Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (InterruptedException e) {
                 LOG.error("Interrupted while shutting down CommunityRestConf", e);
+            } catch (TimeoutException e) {
+                LOG.error("Timeout while shutting down Lighty Swagger", e);
             } catch (ExecutionException e) {
                 LOG.error("Execution of CommunityRestConf shutdown failed", e);
             }
@@ -71,7 +76,7 @@ public class CallhomePluginTest {
         if (lightyController != null) {
             LOG.info("Shutting down LightyController");
             try {
-                lightyController.shutdown().get();
+                lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
                 Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (Exception e) {
                 LOG.error("Shutdown of LightyController failed", e);

--- a/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/CallhomePluginTest.java
+++ b/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/CallhomePluginTest.java
@@ -7,7 +7,6 @@
  */
 package io.lighty.modules.southbound.netconf.tests;
 
-import com.google.common.util.concurrent.ListenableFuture;
 import io.lighty.core.controller.api.LightyController;
 import io.lighty.core.controller.api.LightyModule;
 import io.lighty.core.controller.impl.config.ConfigurationException;
@@ -20,6 +19,9 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
@@ -30,6 +32,8 @@ import org.testng.annotations.Test;
 public class CallhomePluginTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(CallhomePluginTest.class);
+    public static final long SHUTDOWN_TIMEOUT_MILLIS = 15_000;
+
     private LightyController lightyController;
     private CommunityRestConf restConf;
     private LightyModule netconfPlugin;
@@ -44,24 +48,36 @@ public class CallhomePluginTest {
         netconfPlugin = NetconfCallhomePluginBuilder.from(configuration, lightyController.getServices()).build();
     }
 
+    @SuppressWarnings("checkstyle:illegalCatch")
     @AfterClass
-    public void afterClass() throws Exception {
+    public void afterClass() {
         if (netconfPlugin != null) {
             LOG.info("Shutting down Netconf topology Plugin");
-            final ListenableFuture<Boolean> shutdown = netconfPlugin.shutdown();
-            shutdown.get();
+            try {
+                netconfPlugin.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            } catch (Exception e) {
+                LOG.error("Shutdown of Netconf topology Plugin failed", e);
+            }
         }
         if (restConf != null) {
             LOG.info("Shutting down CommunityRestConf");
-            final ListenableFuture<Boolean> shutdown = restConf.shutdown();
-            shutdown.get();
-            Thread.sleep(3_000);
+            try {
+                restConf.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                LOG.error("Interrupted while shutting down CommunityRestConf", e);
+            } catch (TimeoutException e) {
+                LOG.error("Timeout while shutting down Lighty Swagger", e);
+            } catch (ExecutionException e) {
+                LOG.error("Execution of CommunityRestConf shutdown failed", e);
+            }
         }
         if (lightyController != null) {
             LOG.info("Shutting down LightyController");
-            final ListenableFuture<Boolean> shutdown = lightyController.shutdown();
-            shutdown.get();
-            Thread.sleep(1_000);
+            try {
+                lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            } catch (Exception e) {
+                LOG.error("Shutdown of LightyController failed", e);
+            }
         }
     }
 

--- a/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/TopologyPluginsTest.java
+++ b/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/TopologyPluginsTest.java
@@ -58,6 +58,7 @@ public class TopologyPluginsTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(TopologyPluginsTest.class);
     public static final long SHUTDOWN_TIMEOUT_MILLIS = 15_000;
+    public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 3_000;
 
     private LightyController lightyController;
     private CommunityRestConf restConf;
@@ -103,6 +104,7 @@ public class TopologyPluginsTest {
             LOG.info("Shutting down CommunityRestConf");
             try {
                 this.restConf.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (InterruptedException e) {
                 LOG.error("Interrupted while shutting down CommunityRestConf", e);
             } catch (TimeoutException e) {
@@ -115,6 +117,7 @@ public class TopologyPluginsTest {
             LOG.info("Shutting down LightyController");
             try {
                 this.lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (Exception e) {
                 LOG.error("Shutdown of LightyController failed", e);
             }

--- a/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/TopologyPluginsTest.java
+++ b/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/TopologyPluginsTest.java
@@ -22,6 +22,8 @@ import io.lighty.modules.southbound.netconf.impl.config.NetconfConfiguration;
 import io.lighty.modules.southbound.netconf.impl.util.NetconfConfigUtils;
 import io.netty.util.concurrent.Future;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opendaylight.controller.md.sal.binding.api.DataBroker;
@@ -55,6 +57,7 @@ import org.testng.annotations.Test;
 public class TopologyPluginsTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(TopologyPluginsTest.class);
+    public static final long SHUTDOWN_TIMEOUT_MILLIS = 60_000;
     public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 3_000;
 
     private LightyController lightyController;
@@ -92,7 +95,7 @@ public class TopologyPluginsTest {
         if (this.netconfPlugin != null) {
             LOG.info("Shutting down Netconf topology Plugin");
             try {
-                this.netconfPlugin.shutdown().get();
+                this.netconfPlugin.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
             } catch (Exception e) {
                 LOG.error("Shutdown of Netconf topology Plugin failed", e);
             }
@@ -100,10 +103,12 @@ public class TopologyPluginsTest {
         if (this.restConf != null) {
             LOG.info("Shutting down CommunityRestConf");
             try {
-                this.restConf.shutdown().get();
+                this.restConf.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
                 Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (InterruptedException e) {
                 LOG.error("Interrupted while shutting down CommunityRestConf", e);
+            } catch (TimeoutException e) {
+                LOG.error("Timeout while shutting down CommunityRestConf", e);
             } catch (ExecutionException e) {
                 LOG.error("Execution of CommunityRestConf shutdown failed", e);
             }
@@ -111,7 +116,7 @@ public class TopologyPluginsTest {
         if (this.lightyController != null) {
             LOG.info("Shutting down LightyController");
             try {
-                this.lightyController.shutdown().get();
+                this.lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
                 Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (Exception e) {
                 LOG.error("Shutdown of LightyController failed", e);

--- a/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/TopologyPluginsTest.java
+++ b/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/TopologyPluginsTest.java
@@ -57,7 +57,6 @@ import org.testng.annotations.Test;
 public class TopologyPluginsTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(TopologyPluginsTest.class);
-    public static final long SHUTDOWN_TIMEOUT_MILLIS = 15_000;
     public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 3_000;
 
     private LightyController lightyController;
@@ -95,7 +94,7 @@ public class TopologyPluginsTest {
         if (this.netconfPlugin != null) {
             LOG.info("Shutting down Netconf topology Plugin");
             try {
-                this.netconfPlugin.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                this.netconfPlugin.shutdown().get();
             } catch (Exception e) {
                 LOG.error("Shutdown of Netconf topology Plugin failed", e);
             }
@@ -103,12 +102,10 @@ public class TopologyPluginsTest {
         if (this.restConf != null) {
             LOG.info("Shutting down CommunityRestConf");
             try {
-                this.restConf.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                this.restConf.shutdown().get();
                 Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (InterruptedException e) {
                 LOG.error("Interrupted while shutting down CommunityRestConf", e);
-            } catch (TimeoutException e) {
-                LOG.error("Timeout while shutting down CommunityRestConf", e);
             } catch (ExecutionException e) {
                 LOG.error("Execution of CommunityRestConf shutdown failed", e);
             }
@@ -116,7 +113,7 @@ public class TopologyPluginsTest {
         if (this.lightyController != null) {
             LOG.info("Shutting down LightyController");
             try {
-                this.lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                this.lightyController.shutdown().get();
                 Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (Exception e) {
                 LOG.error("Shutdown of LightyController failed", e);

--- a/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/TopologyPluginsTest.java
+++ b/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/TopologyPluginsTest.java
@@ -22,7 +22,6 @@ import io.lighty.modules.southbound.netconf.impl.config.NetconfConfiguration;
 import io.lighty.modules.southbound.netconf.impl.util.NetconfConfigUtils;
 import io.netty.util.concurrent.Future;
 import java.util.concurrent.ExecutionException;
-
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opendaylight.controller.md.sal.binding.api.DataBroker;

--- a/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/TopologyPluginsTest.java
+++ b/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/TopologyPluginsTest.java
@@ -22,8 +22,7 @@ import io.lighty.modules.southbound.netconf.impl.config.NetconfConfiguration;
 import io.lighty.modules.southbound.netconf.impl.util.NetconfConfigUtils;
 import io.netty.util.concurrent.Future;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opendaylight.controller.md.sal.binding.api.DataBroker;

--- a/lighty-modules/lighty-openflow-sb/src/test/java/io/lighty/modules/southbound/openflow/tests/OpenflowSouthboundPluginTestBase.java
+++ b/lighty-modules/lighty-openflow-sb/src/test/java/io/lighty/modules/southbound/openflow/tests/OpenflowSouthboundPluginTestBase.java
@@ -37,6 +37,7 @@ public abstract class OpenflowSouthboundPluginTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(OpenflowSouthboundPluginTestBase.class);
     public static final long SHUTDOWN_TIMEOUT_MILLIS = 15_000;
+    public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 5_000;
 
     private LightyController lightyController;
     private CommunityRestConf communityRestConf;
@@ -114,6 +115,7 @@ public abstract class OpenflowSouthboundPluginTestBase {
             LOG.info("Shutting down CommunityRestConf");
             try {
                 this.communityRestConf.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (InterruptedException e) {
                 LOG.error("Interrupted while shutting down CommunityRestConf", e);
             } catch (TimeoutException e) {
@@ -126,6 +128,7 @@ public abstract class OpenflowSouthboundPluginTestBase {
             LOG.info("Shutting down LightyController");
             try {
                 this.lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (Exception e) {
                 LOG.error("Shutdown of LightyController failed", e);
             }

--- a/lighty-modules/lighty-openflow-sb/src/test/java/io/lighty/modules/southbound/openflow/tests/OpenflowSouthboundPluginTestBase.java
+++ b/lighty-modules/lighty-openflow-sb/src/test/java/io/lighty/modules/southbound/openflow/tests/OpenflowSouthboundPluginTestBase.java
@@ -37,7 +37,7 @@ public abstract class OpenflowSouthboundPluginTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(OpenflowSouthboundPluginTestBase.class);
     public static final long SHUTDOWN_TIMEOUT_MILLIS = 15_000;
-    public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 5_000;
+    public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 10_000;
 
     private LightyController lightyController;
     private CommunityRestConf communityRestConf;

--- a/lighty-modules/lighty-openflow-sb/src/test/java/io/lighty/modules/southbound/openflow/tests/OpenflowSouthboundPluginTestBase.java
+++ b/lighty-modules/lighty-openflow-sb/src/test/java/io/lighty/modules/southbound/openflow/tests/OpenflowSouthboundPluginTestBase.java
@@ -36,7 +36,6 @@ import org.testng.annotations.BeforeMethod;
 public abstract class OpenflowSouthboundPluginTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(OpenflowSouthboundPluginTestBase.class);
-    public static final long SHUTDOWN_TIMEOUT_MILLIS = 15_000;
     public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 10_000;
 
     private LightyController lightyController;
@@ -102,11 +101,9 @@ public abstract class OpenflowSouthboundPluginTestBase {
         if (this.ofplugin != null) {
             LOG.info("Shutting down openflow");
             try {
-                this.ofplugin.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                this.ofplugin.shutdown().get();
             } catch (InterruptedException e) {
                 LOG.error("Interrupted while shutting down openflow", e);
-            } catch (TimeoutException e) {
-                LOG.error("Timeout while shutting down openflow", e);
             } catch (ExecutionException e) {
                 LOG.error("Execution of openflow shutdown failed", e);
             }
@@ -114,12 +111,10 @@ public abstract class OpenflowSouthboundPluginTestBase {
         if (this.communityRestConf != null) {
             LOG.info("Shutting down CommunityRestConf");
             try {
-                this.communityRestConf.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                this.communityRestConf.shutdown().get();
                 Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (InterruptedException e) {
                 LOG.error("Interrupted while shutting down CommunityRestConf", e);
-            } catch (TimeoutException e) {
-                LOG.error("Timeout while shutting down CommunityRestConf", e);
             } catch (ExecutionException e) {
                 LOG.error("Execution of CommunityRestConf shutdown failed", e);
             }
@@ -127,7 +122,7 @@ public abstract class OpenflowSouthboundPluginTestBase {
         if (this.lightyController != null) {
             LOG.info("Shutting down LightyController");
             try {
-                this.lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                this.lightyController.shutdown().get();
                 Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (Exception e) {
                 LOG.error("Shutdown of LightyController failed", e);

--- a/lighty-modules/lighty-openflow-sb/src/test/java/io/lighty/modules/southbound/openflow/tests/OpenflowSouthboundPluginTestBase.java
+++ b/lighty-modules/lighty-openflow-sb/src/test/java/io/lighty/modules/southbound/openflow/tests/OpenflowSouthboundPluginTestBase.java
@@ -22,8 +22,6 @@ import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import org.opendaylight.yangtools.yang.binding.YangModuleInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/lighty-modules/lighty-openflow-sb/src/test/java/io/lighty/modules/southbound/openflow/tests/OpenflowSouthboundPluginTestBase.java
+++ b/lighty-modules/lighty-openflow-sb/src/test/java/io/lighty/modules/southbound/openflow/tests/OpenflowSouthboundPluginTestBase.java
@@ -22,6 +22,8 @@ import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.opendaylight.yangtools.yang.binding.YangModuleInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +36,7 @@ import org.testng.annotations.BeforeMethod;
 public abstract class OpenflowSouthboundPluginTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(OpenflowSouthboundPluginTestBase.class);
+    public static final long SHUTDOWN_TIMEOUT_MILLIS = 60_000;
     public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 10_000;
 
     private LightyController lightyController;
@@ -99,9 +102,11 @@ public abstract class OpenflowSouthboundPluginTestBase {
         if (this.ofplugin != null) {
             LOG.info("Shutting down openflow");
             try {
-                this.ofplugin.shutdown().get();
+                this.ofplugin.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
             } catch (InterruptedException e) {
                 LOG.error("Interrupted while shutting down openflow", e);
+            } catch (TimeoutException e) {
+                LOG.error("Timeout while shutting down openflow", e);
             } catch (ExecutionException e) {
                 LOG.error("Execution of openflow shutdown failed", e);
             }
@@ -109,10 +114,12 @@ public abstract class OpenflowSouthboundPluginTestBase {
         if (this.communityRestConf != null) {
             LOG.info("Shutting down CommunityRestConf");
             try {
-                this.communityRestConf.shutdown().get();
+                this.communityRestConf.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
                 Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (InterruptedException e) {
                 LOG.error("Interrupted while shutting down CommunityRestConf", e);
+            } catch (TimeoutException e) {
+                LOG.error("Timeout while shutting down CommunityRestConf", e);
             } catch (ExecutionException e) {
                 LOG.error("Execution of CommunityRestConf shutdown failed", e);
             }
@@ -120,7 +127,7 @@ public abstract class OpenflowSouthboundPluginTestBase {
         if (this.lightyController != null) {
             LOG.info("Shutting down LightyController");
             try {
-                this.lightyController.shutdown().get();
+                this.lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
                 Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (Exception e) {
                 LOG.error("Shutdown of LightyController failed", e);

--- a/lighty-modules/lighty-restconf-nb-community/src/test/java/io/lighty/modules/northbound/restconf/community/impl/tests/CommunityRestConfTestBase.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/test/java/io/lighty/modules/northbound/restconf/community/impl/tests/CommunityRestConfTestBase.java
@@ -32,7 +32,7 @@ import org.testng.annotations.BeforeMethod;
 public abstract class CommunityRestConfTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(CommunityRestConfTestBase.class);
-    public static final long SHUTDOWN_TIMEOUT_MILLIS = 15_000;
+    public static final long SHUTDOWN_TIMEOUT_MILLIS = 60_000;
     public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 3_000;
 
     private LightyController lightyController;

--- a/lighty-modules/lighty-restconf-nb-community/src/test/java/io/lighty/modules/northbound/restconf/community/impl/tests/CommunityRestConfTestBase.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/test/java/io/lighty/modules/northbound/restconf/community/impl/tests/CommunityRestConfTestBase.java
@@ -33,6 +33,7 @@ public abstract class CommunityRestConfTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(CommunityRestConfTestBase.class);
     public static final long SHUTDOWN_TIMEOUT_MILLIS = 15_000;
+    public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 3_000;
 
     private LightyController lightyController;
     private CommunityRestConf communityRestConf;
@@ -78,6 +79,7 @@ public abstract class CommunityRestConfTestBase {
             LOG.info("Shutting down CommunityRestConf");
             try {
                 communityRestConf.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (InterruptedException e) {
                 LOG.error("Interrupted while shutting down CommunityRestConf ", e);
             } catch (TimeoutException e) {
@@ -91,6 +93,7 @@ public abstract class CommunityRestConfTestBase {
             LOG.info("Shutting down LightyController");
             try {
                 lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS,TimeUnit.MILLISECONDS);
+                Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (Exception e) {
                 LOG.error("Shutdown of LightyController failed", e);
             }

--- a/lighty-modules/lighty-restconf-nb-community/src/test/java/io/lighty/modules/northbound/restconf/community/impl/tests/CommunityRestConfTestBase.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/test/java/io/lighty/modules/northbound/restconf/community/impl/tests/CommunityRestConfTestBase.java
@@ -15,6 +15,9 @@ import io.lighty.modules.northbound.restconf.community.impl.CommunityRestConf;
 import io.lighty.modules.northbound.restconf.community.impl.CommunityRestConfBuilder;
 import io.lighty.modules.northbound.restconf.community.impl.util.RestConfConfigUtils;
 import java.lang.reflect.Method;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.ITestResult;
@@ -29,6 +32,7 @@ import org.testng.annotations.BeforeMethod;
 public abstract class CommunityRestConfTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(CommunityRestConfTestBase.class);
+    public static final long SHUTDOWN_TIMEOUT_MILLIS = 15_000;
 
     private LightyController lightyController;
     private CommunityRestConf communityRestConf;
@@ -67,19 +71,29 @@ public abstract class CommunityRestConfTestBase {
                 result.getName(), parseTestNGStatus(result.getStatus()), result.getThrowable());
     }
 
+    @SuppressWarnings("checkstyle:illegalCatch")
     @AfterClass
-    public void shutdownLighty() throws Exception {
+    public void shutdownLighty() {
         if (communityRestConf != null) {
             LOG.info("Shutting down CommunityRestConf");
-            ListenableFuture<Boolean> shutdown = communityRestConf.shutdown();
-            shutdown.get();
-            Thread.sleep(3_000);
+            try {
+                communityRestConf.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                LOG.error("Interrupted while shutting down CommunityRestConf ", e);
+            } catch (TimeoutException e) {
+                LOG.error("Timeout while shutting down CommunityRestConf ", e);
+            } catch (ExecutionException e) {
+                LOG.error("Execution of CommunityRestConf shutdown failed", e);
+            }
+
         }
         if (lightyController != null) {
             LOG.info("Shutting down LightyController");
-            ListenableFuture<Boolean> shutdown = lightyController.shutdown();
-            shutdown.get();
-            Thread.sleep(1_000);
+            try {
+                lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS,TimeUnit.MILLISECONDS);
+            } catch (Exception e) {
+                LOG.error("Shutdown of LightyController failed", e);
+            }
         }
     }
 

--- a/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyTestBase.java
+++ b/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyTestBase.java
@@ -35,7 +35,6 @@ import org.testng.annotations.BeforeMethod;
 public abstract class SwaggerLightyTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(SwaggerLightyTestBase.class);
-    public static final long SHUTDOWN_TIMEOUT_MILLIS = 15_000;
     public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 3_000;
 
     private LightyController lightyController;
@@ -92,19 +91,17 @@ public abstract class SwaggerLightyTestBase {
         if (swaggerModule != null) {
             LOG.info("Shutting down Lighty Swagger");
             try {
-                swaggerModule.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                swaggerModule.shutdown().get();
                 Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (InterruptedException e) {
                 LOG.error("Interrupted while shutting down Lighty Swagger", e);
-            } catch (TimeoutException e) {
-                LOG.error("Timeout while shutting down Lighty Swagger", e);
             } catch (ExecutionException e) {
                 LOG.error("Execution of Lighty Swagger shutdown failed", e);
             }
             if (lightyController != null) {
                 LOG.info("Shutting down LightyController");
                 try {
-                    lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                    lightyController.shutdown().get();
                     Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
                 } catch (Exception e) {
                     LOG.error("Shutdown of LightyController failed", e);

--- a/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyTestBase.java
+++ b/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyTestBase.java
@@ -19,6 +19,8 @@ import io.lighty.server.LightyServerBuilder;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.ITestResult;
@@ -33,6 +35,7 @@ import org.testng.annotations.BeforeMethod;
 public abstract class SwaggerLightyTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(SwaggerLightyTestBase.class);
+    public static final long SHUTDOWN_TIMEOUT_MILLIS = 60_000;
     public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 3_000;
 
     private LightyController lightyController;
@@ -89,17 +92,19 @@ public abstract class SwaggerLightyTestBase {
         if (swaggerModule != null) {
             LOG.info("Shutting down Lighty Swagger");
             try {
-                swaggerModule.shutdown().get();
+                swaggerModule.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
                 Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (InterruptedException e) {
                 LOG.error("Interrupted while shutting down Lighty Swagger", e);
+            } catch (TimeoutException e) {
+                LOG.error("Timeout while shutting down Lighty Swagger", e);
             } catch (ExecutionException e) {
                 LOG.error("Execution of Lighty Swagger shutdown failed", e);
             }
             if (lightyController != null) {
                 LOG.info("Shutting down LightyController");
                 try {
-                    lightyController.shutdown().get();
+                    lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
                     Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
                 } catch (Exception e) {
                     LOG.error("Shutdown of LightyController failed", e);

--- a/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyTestBase.java
+++ b/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyTestBase.java
@@ -36,6 +36,7 @@ public abstract class SwaggerLightyTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(SwaggerLightyTestBase.class);
     public static final long SHUTDOWN_TIMEOUT_MILLIS = 15_000;
+    public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 3_000;
 
     private LightyController lightyController;
     private SwaggerLighty swaggerModule;
@@ -92,6 +93,7 @@ public abstract class SwaggerLightyTestBase {
             LOG.info("Shutting down Lighty Swagger");
             try {
                 swaggerModule.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (InterruptedException e) {
                 LOG.error("Interrupted while shutting down Lighty Swagger", e);
             } catch (TimeoutException e) {
@@ -103,6 +105,7 @@ public abstract class SwaggerLightyTestBase {
                 LOG.info("Shutting down LightyController");
                 try {
                     lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                    Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
                 } catch (Exception e) {
                     LOG.error("Shutdown of LightyController failed", e);
                 }

--- a/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyTestBase.java
+++ b/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyTestBase.java
@@ -19,8 +19,6 @@ import io.lighty.server.LightyServerBuilder;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.ITestResult;


### PR DESCRIPTION
Use timeout blocking .get()
Handle exceptions inside the method
Format and add logging for caught exceptions

Signed-off-by: marekzatko <Marek.Zatko@pantheon.tech>