### PR TITLE
Bump odl aaa-artifacts version

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -34,7 +34,7 @@
             <dependency>
                 <groupId>org.opendaylight.aaa</groupId>
                 <artifactId>aaa-artifacts</artifactId>
-                <version>0.12.0</version>
+                <version>0.12.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
bump version to 0.12.1 fixing class not found error during aaa-app startup

Signed-off-by: Peter Valka <Peter.Valka@pantheon.tech>