### PR TITLE
Change default lighty-rnc configuration

### DIFF
--- a/lighty-examples/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/values.yaml
+++ b/lighty-examples/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/values.yaml
@@ -18,7 +18,7 @@ lighty:
   restconf:
     restconfPort: 8888
     restconfPath: "/restconf"
-    useHttps: true
+    useHttps: false
     keyStorePassword: "8pgETwat"
     keyStoreType: "JKS"
     keyStoreDirectory: "keystore"
@@ -44,7 +44,7 @@ lighty:
 
   aaa:
     # If true, AAA lighty.io component will be enabled
-    enableAAA: true
+    enableAAA: false
 
 nodePort:
   # If switched to "true", NodePort service will be created; If switched to "false", ClusterIp service will be created
@@ -54,7 +54,7 @@ nodePort:
   managementNodePort: 30558
 
 ingress:
-  useIngress: false
+  useIngress: true
   restconfHost: "restconf.lighty.io"
   exposeManagement: false
   managementHost: "management.lighty.io"

--- a/lighty-examples/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/resources/configuration.json
+++ b/lighty-examples/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/resources/configuration.json
@@ -73,7 +73,7 @@
         "webSocketPort": 8185,
         "restconfServletContextPath":"/restconf",
         "jsonRestconfServiceType": "DRAFT_18",
-        "useHttps": true,
+        "useHttps": false,
         "keyStorePassword":"8pgETwat",
         "keyStoreType":"JKS",
         "keyStoreFilePath":"keystore/lightyio.jks"
@@ -93,7 +93,7 @@
         "topologyId":"topology-netconf"
     },
     "aaa": {
-        "enableAAA": true,
+        "enableAAA": false,
         "moonEndpointPath" : "/moon",
         "dbPassword" : "bar",
         "dbUsername" : "foo"

--- a/lighty-examples/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/rnc/module/config/RncAAAConfiguration.java
+++ b/lighty-examples/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/rnc/module/config/RncAAAConfiguration.java
@@ -22,7 +22,7 @@ public class RncAAAConfiguration {
     @JsonIgnore
     private DatastoreConfig datastoreConf;
 
-    private boolean enableAAA = true;
+    private boolean enableAAA = false;
 
     // These are default configuration and that should be rewritten
     private String moonEndpointPath = "/moon";

--- a/lighty-examples/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/rnc/module/config/RncRestConfConfiguration.java
+++ b/lighty-examples/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/rnc/module/config/RncRestConfConfiguration.java
@@ -20,7 +20,7 @@ public class RncRestConfConfiguration extends RestConfConfiguration {
     private String keyStorePassword = "8pgETwat";
     private String keyStoreType = "JKS";
     private String keyStoreFilePath = "keystore/lightyio.jks";
-    private boolean useHttps = true;
+    private boolean useHttps = false;
 
     public RncRestConfConfiguration() {
         super();

--- a/lighty-examples/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/java/io/lighty/rnc/module/config/RncLightyModuleConfigUtilsTest.java
+++ b/lighty-examples/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/java/io/lighty/rnc/module/config/RncLightyModuleConfigUtilsTest.java
@@ -73,7 +73,7 @@ public class RncLightyModuleConfigUtilsTest {
         assertEquals(restconfConfig.getHttpPort(), 8888);
         assertEquals(restconfConfig.getRestconfServletContextPath(), "/restconf");
         assertEquals(restconfConfig.getJsonRestconfServiceType(), JsonRestConfServiceType.DRAFT_18);
-        assertTrue(restconfConfig.isUseHttps());
+        assertFalse(restconfConfig.isUseHttps());
         assertEquals(restconfConfig.getKeyStoreFilePath(), "keystore/lightyio.jks");
         checkDefaultKeystoreConfig(restconfConfig);
 
@@ -106,6 +106,7 @@ public class RncLightyModuleConfigUtilsTest {
         assertEquals(aaaConfig.getMoonEndpointPath(), "/moon");
         assertEquals(aaaConfig.getDbPassword(), "bar");
         assertEquals(aaaConfig.getDbUsername(), "foo");
+        assertFalse(aaaConfig.isEnableAAA());
     }
 
     private void checkDefaultKeystoreConfig(RncRestConfConfiguration restconfConfig) {

--- a/lighty-examples/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/config.json
+++ b/lighty-examples/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/config.json
@@ -93,7 +93,7 @@
         "topologyId":"topology-netconf-test"
     },
     "aaa": {
-        "enableAAA": true,
+        "enableAAA": false,
         "moonEndpointPath" : "/moon",
         "dbPassword" : "bar",
         "dbUsername" : "foo"


### PR DESCRIPTION
Disable HTTPS by default
Disable AAA by default
Enable Helm NodePort by default
Enable Helm Ingress by default

Signed-off-by: Samuel Kontris <samuel.kontris@pantheon.tech>