### PR TITLE
Prepare for 12.3.0 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ assignees: ''
 A clear and concise description of what the bug is.
 
 **Branch**
-lighty.io branch [eg. 12.2.x]
+lighty.io branch [eg. 12.3.x]
 
 **To Reproduce**
 Steps to reproduce the behavior:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Software-Defined Networking (SDN) solutions in Java. Developed by [PANTHEON.tech
 
 It utilizes core [OpenDaylight](https://www.opendaylight.org/) components, which are available as a set of libraries and are adapted to run in a __plain Java SE environment__.
 
-[![Build Status](https://github.com/PANTHEONtech/lighty/workflows/Build/badge.svg?branch=12.2.x)](https://github.com/PANTHEONtech/lighty/actions)
+[![Build Status](https://github.com/PANTHEONtech/lighty/workflows/Build/badge.svg?branch=12.3.x)](https://github.com/PANTHEONtech/lighty/actions)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.lighty.core/lighty-bom/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.lighty.core/lighty-bom)
 [![License](https://img.shields.io/badge/License-EPL%201.0-blue.svg)](https://opensource.org/licenses/EPL-1.0)
 

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.lighty.core</groupId>
     <artifactId>dependency-versions</artifactId>
-    <version>12.2.3-SNAPSHOT</version>
+    <version>12.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
-                <version>6.0.11</version>
+                <version>6.0.13</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -34,63 +34,63 @@
             <dependency>
                 <groupId>org.opendaylight.aaa</groupId>
                 <artifactId>aaa-artifacts</artifactId>
-                <version>0.11.2</version>
+                <version>0.11.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>config-artifacts</artifactId>
-                <version>0.12.2</version>
+                <version>0.12.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>1.11.2</version>
+                <version>1.11.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.infrautils</groupId>
                 <artifactId>infrautils-artifacts</artifactId>
-                <version>1.7.2</version>
+                <version>1.7.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.mdsal</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>5.0.14</version>
+                <version>5.0.16</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>netconf-artifacts</artifactId>
-                <version>1.8.2</version>
+                <version>1.8.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.openflowplugin</groupId>
                 <artifactId>openflowplugin-artifacts</artifactId>
-                <version>0.10.2</version>
+                <version>0.10.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.serviceutils</groupId>
                 <artifactId>serviceutils-artifacts</artifactId>
-                <version>0.5.2</version>
+                <version>0.5.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yangtools-artifacts</artifactId>
-                <version>4.0.13</version>
+                <version>4.0.15</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-app-parent/pom.xml
+++ b/lighty-core/lighty-app-parent/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -54,12 +54,12 @@
             <plugin>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yang-maven-plugin</artifactId>
-                <version>4.0.13</version>
+                <version>4.0.15</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.opendaylight.mdsal</groupId>
                         <artifactId>maven-sal-api-gen-plugin</artifactId>
-                        <version>3.0.14</version>
+                        <version>3.0.16</version>
                         <type>jar</type>
                     </dependency>
                 </dependencies>

--- a/lighty-core/lighty-bom/pom.xml
+++ b/lighty-core/lighty-bom/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-bom</artifactId>
-    <version>12.2.3-SNAPSHOT</version>
+    <version>12.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -26,103 +26,103 @@
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-codecs</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-common</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-controller</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-clustering</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
             </dependency>
 
             <!-- DI framework integrations -->
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-controller-guice-di</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-controller-spring-di</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
             </dependency>
 
             <!-- Modules -->
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-aaa</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-jetty-server</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-netconf-sb</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-restconf-nb-community</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-swagger</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-openflow-sb</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
             </dependency>
 
             <!-- Utility resources -->
             <dependency>
                 <groupId>io.lighty.resources</groupId>
                 <artifactId>controller-application-assembly</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>io.lighty.resources</groupId>
                 <artifactId>singlenode-configuration</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.resources</groupId>
                 <artifactId>start-script</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
             </dependency>
 
             <!-- Dependencies and resources which should not normally leak into production -->
             <dependency>
                 <groupId>io.lighty.models.test</groupId>
                 <artifactId>lighty-test-models</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>io.lighty.models.test</groupId>
                 <artifactId>lighty-toaster</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>io.lighty.resources</groupId>
                 <artifactId>log4j-properties</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/lighty-core/lighty-clustering/pom.xml
+++ b/lighty-core/lighty-clustering/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-codecs/pom.xml
+++ b/lighty-core/lighty-codecs/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-common/pom.xml
+++ b/lighty-core/lighty-common/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-controller-guice-di/pom.xml
+++ b/lighty-core/lighty-controller-guice-di/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-controller-spring-di/pom.xml
+++ b/lighty-core/lighty-controller-spring-di/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-controller/README.md
+++ b/lighty-core/lighty-controller/README.md
@@ -17,7 +17,7 @@ To use Lighty controller in your project:
   <dependency>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-controller</artifactId>
-    <version>12.3.0-SNAPSHOT</version>
+    <version>12.3.0</version>
   </dependency>
 ```
 

--- a/lighty-core/lighty-controller/README.md
+++ b/lighty-core/lighty-controller/README.md
@@ -17,7 +17,7 @@ To use Lighty controller in your project:
   <dependency>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-controller</artifactId>
-    <version>12.2.2-SNAPSHOT</version>
+    <version>12.3.0-SNAPSHOT</version>
   </dependency>
 ```
 

--- a/lighty-core/lighty-controller/pom.xml
+++ b/lighty-core/lighty-controller/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-minimal-parent/pom.xml
+++ b/lighty-core/lighty-minimal-parent/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-minimal-parent</artifactId>
-    <version>12.2.3-SNAPSHOT</version>
+    <version>12.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -29,14 +29,14 @@
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>dependency-versions</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-bom</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -174,7 +174,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>6.0.11</version>
+                            <version>6.0.13</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -191,7 +191,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>spotbugs</artifactId>
-                            <version>6.0.11</version>
+                            <version>6.0.12</version>
                         </dependency>
                         <dependency>
                             <!-- The SpotBugs Maven plugin uses SLF4J 1.8 beta 2 -->

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-minimal-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../lighty-minimal-parent</relativePath>
     </parent>
 

--- a/lighty-core/pom.xml
+++ b/lighty-core/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-core-aggregator</artifactId>
-    <version>12.2.3-SNAPSHOT</version>
+    <version>12.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-examples/README.md
+++ b/lighty-examples/README.md
@@ -17,7 +17,7 @@ ODL core services represent MD-SAL layer, controller, DataStore, global schema c
    <dependency>
       <groupId>io.lighty.core.parents</groupId>
       <artifactId>lighty-dependency-artifacts</artifactId>
-      <version>12.2.2-SNAPSHOT</version>
+      <version>12.3.0-SNAPSHOT</version>
       <type>pom</type>
       <scope>import</scope>
    </dependency>

--- a/lighty-examples/README.md
+++ b/lighty-examples/README.md
@@ -17,7 +17,7 @@ ODL core services represent MD-SAL layer, controller, DataStore, global schema c
    <dependency>
       <groupId>io.lighty.core.parents</groupId>
       <artifactId>lighty-dependency-artifacts</artifactId>
-      <version>12.3.0-SNAPSHOT</version>
+      <version>12.3.0</version>
       <type>pom</type>
       <scope>import</scope>
    </dependency>

--- a/lighty-examples/lighty-cluster-app/Dockerfile.k8s
+++ b/lighty-examples/lighty-cluster-app/Dockerfile.k8s
@@ -1,9 +1,9 @@
 FROM openjdk:11-jre-slim
 
-COPY target/lighty-cluster-app-12.3.0-SNAPSHOT-bin.zip /
+COPY target/lighty-cluster-app-12.3.0-bin.zip /
 
 RUN apt-get update && apt-get install unzip \
-    && unzip /lighty-cluster-app-12.3.0-SNAPSHOT-bin.zip \
-    && rm /lighty-cluster-app-12.3.0-SNAPSHOT-bin.zip
+    && unzip /lighty-cluster-app-12.3.0-bin.zip \
+    && rm /lighty-cluster-app-12.3.0-bin.zip
 
-ENTRYPOINT ["/lighty-cluster-app-12.3.0-SNAPSHOT/start-controller-node-k8s.sh"]
+ENTRYPOINT ["/lighty-cluster-app-12.3.0/start-controller-node-k8s.sh"]

--- a/lighty-examples/lighty-cluster-app/Dockerfile.k8s
+++ b/lighty-examples/lighty-cluster-app/Dockerfile.k8s
@@ -1,9 +1,9 @@
 FROM openjdk:11-jre-slim
 
-COPY target/lighty-cluster-app-12.2.2-SNAPSHOT-bin.zip /
+COPY target/lighty-cluster-app-12.3.0-SNAPSHOT-bin.zip /
 
 RUN apt-get update && apt-get install unzip \
-    && unzip /lighty-cluster-app-12.2.2-SNAPSHOT-bin.zip \
-    && rm /lighty-cluster-app-12.2.2-SNAPSHOT-bin.zip
+    && unzip /lighty-cluster-app-12.3.0-SNAPSHOT-bin.zip \
+    && rm /lighty-cluster-app-12.3.0-SNAPSHOT-bin.zip
 
-ENTRYPOINT ["/lighty-cluster-app-12.2.2-SNAPSHOT/start-controller-node-k8s.sh"]
+ENTRYPOINT ["/lighty-cluster-app-12.3.0-SNAPSHOT/start-controller-node-k8s.sh"]

--- a/lighty-examples/lighty-cluster-app/pom.xml
+++ b/lighty-examples/lighty-cluster-app/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-app-parent</relativePath>
     </parent>
 

--- a/lighty-examples/lighty-cluster-app/src/main/assembly/resources/start-controller-node-k8s.sh
+++ b/lighty-examples/lighty-cluster-app/src/main/assembly/resources/start-controller-node-k8s.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 #start controller
-cd /lighty-cluster-app-12.2.2-SNAPSHOT
-java -ms128m -mx128m -XX:MaxMetaspaceSize=128m -jar lighty-cluster-app-12.2.2-SNAPSHOT.jar -n 0 -k
+cd /lighty-cluster-app-12.3.0-SNAPSHOT
+java -ms128m -mx128m -XX:MaxMetaspaceSize=128m -jar lighty-cluster-app-12.3.0-SNAPSHOT.jar -n 0 -k

--- a/lighty-examples/lighty-cluster-app/src/main/assembly/resources/start-controller-node-k8s.sh
+++ b/lighty-examples/lighty-cluster-app/src/main/assembly/resources/start-controller-node-k8s.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 #start controller
-cd /lighty-cluster-app-12.3.0-SNAPSHOT
-java -ms128m -mx128m -XX:MaxMetaspaceSize=128m -jar lighty-cluster-app-12.3.0-SNAPSHOT.jar -n 0 -k
+cd /lighty-cluster-app-12.3.0
+java -ms128m -mx128m -XX:MaxMetaspaceSize=128m -jar lighty-cluster-app-12.3.0.jar -n 0 -k

--- a/lighty-examples/lighty-community-aaa-restconf-app/pom.xml
+++ b/lighty-examples/lighty-community-aaa-restconf-app/pom.xml
@@ -12,13 +12,13 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-app-parent</relativePath>
     </parent>
 
     <groupId>io.lighty.kit.examples.controllers</groupId>
     <artifactId>lighty-community-aaa-restconf-app</artifactId>
-    <version>12.2.3-SNAPSHOT</version>
+    <version>12.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/lighty-examples/lighty-community-netconf-quarkus-app/README.md
+++ b/lighty-examples/lighty-community-netconf-quarkus-app/README.md
@@ -30,7 +30,7 @@ mvn clean compile quarkus:dev
 ## Build package & Run
 ```
 mvn clean package
-java -Xms128m -Xmx128m -XX:MaxMetaspaceSize=128m -jar target/lighty-quarkus-netconf-app-12.3.0-SNAPSHOT-runner.jar
+java -Xms128m -Xmx128m -XX:MaxMetaspaceSize=128m -jar target/lighty-quarkus-netconf-app-12.3.0-runner.jar
 ```
 
 ## Build native image

--- a/lighty-examples/lighty-community-netconf-quarkus-app/README.md
+++ b/lighty-examples/lighty-community-netconf-quarkus-app/README.md
@@ -30,7 +30,7 @@ mvn clean compile quarkus:dev
 ## Build package & Run
 ```
 mvn clean package
-java -Xms128m -Xmx128m -XX:MaxMetaspaceSize=128m -jar target/lighty-quarkus-netconf-app-12.2.2-SNAPSHOT-runner.jar
+java -Xms128m -Xmx128m -XX:MaxMetaspaceSize=128m -jar target/lighty-quarkus-netconf-app-12.3.0-SNAPSHOT-runner.jar
 ```
 
 ## Build native image

--- a/lighty-examples/lighty-community-netconf-quarkus-app/pom.xml
+++ b/lighty-examples/lighty-community-netconf-quarkus-app/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.lighty.quarkus</groupId>
   <artifactId>lighty-quarkus-netconf-app</artifactId>
-  <version>12.2.2-SNAPSHOT</version>
+  <version>12.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -15,7 +15,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
     <application.attach.zip>true</application.attach.zip>
-    <lighty.version>12.2.2-SNAPSHOT</lighty.version>
+    <lighty.version>12.3.0-SNAPSHOT</lighty.version>
   </properties>
 
   <dependencyManagement>

--- a/lighty-examples/lighty-community-restconf-netconf-app/README.md
+++ b/lighty-examples/lighty-community-restconf-netconf-app/README.md
@@ -21,12 +21,12 @@ build the project: ```mvn clean install```
 ### Start this demo example
 * build the project using ```mvn clean install```
 * go to target directory ```cd lighty-examples/lighty-community-restconf-netconf-app/target``` 
-* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-12.2.2-SNAPSHOT-bin.zip```
-* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-12.2.2-SNAPSHOT```
-* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-12.2.2-SNAPSHOT.jar``` 
+* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-12.3.0-SNAPSHOT-bin.zip```
+* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-12.3.0-SNAPSHOT```
+* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-12.3.0-SNAPSHOT.jar``` 
 
 ### Test example application
-Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-12.2.2-SNAPSHOT.jar``` 
+Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-12.3.0-SNAPSHOT.jar``` 
 RESTCONF web interface is available at URL ```http://localhost:8888/restconf/*```
 
 ##### URLs to start with
@@ -47,7 +47,7 @@ URLs for Swagger RESTCONF [draft02](https://tools.ietf.org/html/draft-bierman-ne
 
 ### Use custom config files
 There are two separated config files: for NETCONF SBP single node and for cluster.
-`java -jar lighty-community-restconf-netconf-app-12.2.2-SNAPSHOT.jar /path/to/singleNodeConfig.json`
+`java -jar lighty-community-restconf-netconf-app-12.3.0-SNAPSHOT.jar /path/to/singleNodeConfig.json`
 
 Example configuration for single node is [here](src/main/assembly/resources/sampleConfigSingleNode.json)
 

--- a/lighty-examples/lighty-community-restconf-netconf-app/README.md
+++ b/lighty-examples/lighty-community-restconf-netconf-app/README.md
@@ -21,12 +21,12 @@ build the project: ```mvn clean install```
 ### Start this demo example
 * build the project using ```mvn clean install```
 * go to target directory ```cd lighty-examples/lighty-community-restconf-netconf-app/target``` 
-* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-12.3.0-SNAPSHOT-bin.zip```
-* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-12.3.0-SNAPSHOT```
-* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-12.3.0-SNAPSHOT.jar``` 
+* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-12.3.0-bin.zip```
+* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-12.3.0```
+* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-12.3.0.jar``` 
 
 ### Test example application
-Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-12.3.0-SNAPSHOT.jar``` 
+Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-12.3.0.jar``` 
 RESTCONF web interface is available at URL ```http://localhost:8888/restconf/*```
 
 ##### URLs to start with
@@ -47,7 +47,7 @@ URLs for Swagger RESTCONF [draft02](https://tools.ietf.org/html/draft-bierman-ne
 
 ### Use custom config files
 There are two separated config files: for NETCONF SBP single node and for cluster.
-`java -jar lighty-community-restconf-netconf-app-12.3.0-SNAPSHOT.jar /path/to/singleNodeConfig.json`
+`java -jar lighty-community-restconf-netconf-app-12.3.0.jar /path/to/singleNodeConfig.json`
 
 Example configuration for single node is [here](src/main/assembly/resources/sampleConfigSingleNode.json)
 

--- a/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-app-parent</relativePath>
     </parent>
 

--- a/lighty-examples/lighty-community-restconf-ofp-app/Dockerfile
+++ b/lighty-examples/lighty-community-restconf-ofp-app/Dockerfile
@@ -1,15 +1,15 @@
 FROM openjdk:8u191-jre-alpine3.9
 
-COPY ./target/lighty-community-restconf-ofp-app-12.3.0-SNAPSHOT-bin.zip /
+COPY ./target/lighty-community-restconf-ofp-app-12.3.0-bin.zip /
 
-RUN unzip /lighty-community-restconf-ofp-app-12.3.0-SNAPSHOT-bin.zip && rm /lighty-community-restconf-ofp-app-12.3.0-SNAPSHOT-bin.zip
+RUN unzip /lighty-community-restconf-ofp-app-12.3.0-bin.zip && rm /lighty-community-restconf-ofp-app-12.3.0-bin.zip
 
 ##libstdc++ is required by leveldbjni-1.8 (Akka dispatcher)
 #Uncaught error from thread [opendaylight-cluster-data-akka.persistence.dispatchers.default-plugin-dispatcher-22]: Could not load library. Reasons: [no leveldbjni64-1.8 in java.library.path, no leveldbjni-1.8 in java.library.path, no leveldbjni in java.library.path, /tmp/libleveldbjni-64-1-3166161234556196376.8: Error loading shared library libstdc++.so.6: No such file or directory (needed by /tmp/libleveldbjni-64-1-3166161234556196376.8)], shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled for ActorSystem[opendaylight-cluster-data]
 RUN apk add --update libstdc++ curl && \
     rm -rf /var/cache/apk/*
 
-WORKDIR /lighty-community-restconf-ofp-app-12.3.0-SNAPSHOT
+WORKDIR /lighty-community-restconf-ofp-app-12.3.0
 
 EXPOSE 8888
 EXPOSE 8185
@@ -18,4 +18,4 @@ EXPOSE 6653
 EXPOSE 2550
 EXPOSE 80
 
-CMD java -jar lighty-community-restconf-ofp-app-12.3.0-SNAPSHOT.jar sampleConfigSingleNode.json
+CMD java -jar lighty-community-restconf-ofp-app-12.3.0.jar sampleConfigSingleNode.json

--- a/lighty-examples/lighty-community-restconf-ofp-app/Dockerfile
+++ b/lighty-examples/lighty-community-restconf-ofp-app/Dockerfile
@@ -1,15 +1,15 @@
 FROM openjdk:8u191-jre-alpine3.9
 
-COPY ./target/lighty-community-restconf-ofp-app-12.2.2-SNAPSHOT-bin.zip /
+COPY ./target/lighty-community-restconf-ofp-app-12.3.0-SNAPSHOT-bin.zip /
 
-RUN unzip /lighty-community-restconf-ofp-app-12.2.2-SNAPSHOT-bin.zip && rm /lighty-community-restconf-ofp-app-12.2.2-SNAPSHOT-bin.zip
+RUN unzip /lighty-community-restconf-ofp-app-12.3.0-SNAPSHOT-bin.zip && rm /lighty-community-restconf-ofp-app-12.3.0-SNAPSHOT-bin.zip
 
 ##libstdc++ is required by leveldbjni-1.8 (Akka dispatcher)
 #Uncaught error from thread [opendaylight-cluster-data-akka.persistence.dispatchers.default-plugin-dispatcher-22]: Could not load library. Reasons: [no leveldbjni64-1.8 in java.library.path, no leveldbjni-1.8 in java.library.path, no leveldbjni in java.library.path, /tmp/libleveldbjni-64-1-3166161234556196376.8: Error loading shared library libstdc++.so.6: No such file or directory (needed by /tmp/libleveldbjni-64-1-3166161234556196376.8)], shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled for ActorSystem[opendaylight-cluster-data]
 RUN apk add --update libstdc++ curl && \
     rm -rf /var/cache/apk/*
 
-WORKDIR /lighty-community-restconf-ofp-app-12.2.2-SNAPSHOT
+WORKDIR /lighty-community-restconf-ofp-app-12.3.0-SNAPSHOT
 
 EXPOSE 8888
 EXPOSE 8185
@@ -18,4 +18,4 @@ EXPOSE 6653
 EXPOSE 2550
 EXPOSE 80
 
-CMD java -jar lighty-community-restconf-ofp-app-12.2.2-SNAPSHOT.jar sampleConfigSingleNode.json
+CMD java -jar lighty-community-restconf-ofp-app-12.3.0-SNAPSHOT.jar sampleConfigSingleNode.json

--- a/lighty-examples/lighty-community-restconf-ofp-app/README.md
+++ b/lighty-examples/lighty-community-restconf-ofp-app/README.md
@@ -12,7 +12,7 @@ Build the project using maven command: ```mvn clean install```.
 This will create *.zip* archive in target directory. Extract this archive
 and run *.jar* file using java with command:
 ```
-java -jar lighty-community-restconf-ofp-app-12.2.2-SNAPSHOT.jar
+java -jar lighty-community-restconf-ofp-app-12.3.0-SNAPSHOT.jar
 ```
 
 ### Use custom config files
@@ -24,7 +24,7 @@ after build.
 
 When running application pass path to configuration file as argument:
 ```
-java -jar lighty-community-restconf-ofp-app-12.2.2-SNAPSHOT.jar sampleConfigSingleNode.json
+java -jar lighty-community-restconf-ofp-app-12.3.0-SNAPSHOT.jar sampleConfigSingleNode.json
 ```
 
 ### Building and running Docker Image

--- a/lighty-examples/lighty-community-restconf-ofp-app/README.md
+++ b/lighty-examples/lighty-community-restconf-ofp-app/README.md
@@ -12,7 +12,7 @@ Build the project using maven command: ```mvn clean install```.
 This will create *.zip* archive in target directory. Extract this archive
 and run *.jar* file using java with command:
 ```
-java -jar lighty-community-restconf-ofp-app-12.3.0-SNAPSHOT.jar
+java -jar lighty-community-restconf-ofp-app-12.3.0.jar
 ```
 
 ### Use custom config files
@@ -24,7 +24,7 @@ after build.
 
 When running application pass path to configuration file as argument:
 ```
-java -jar lighty-community-restconf-ofp-app-12.3.0-SNAPSHOT.jar sampleConfigSingleNode.json
+java -jar lighty-community-restconf-ofp-app-12.3.0.jar sampleConfigSingleNode.json
 ```
 
 ### Building and running Docker Image

--- a/lighty-examples/lighty-community-restconf-ofp-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-ofp-app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-app-parent</relativePath>
     </parent>
 

--- a/lighty-examples/lighty-controller-springboot-netconf/README.md
+++ b/lighty-examples/lighty-controller-springboot-netconf/README.md
@@ -46,7 +46,7 @@ mvn spring-boot:run
 or
 
 ```
-java -jar target/lighty-controller-springboot-12.3.0-SNAPSHOT.jar
+java -jar target/lighty-controller-springboot-12.3.0.jar
 ```
 
 or in any IDE, run main in 

--- a/lighty-examples/lighty-controller-springboot-netconf/README.md
+++ b/lighty-examples/lighty-controller-springboot-netconf/README.md
@@ -46,7 +46,7 @@ mvn spring-boot:run
 or
 
 ```
-java -jar target/lighty-controller-springboot-12.2.2-SNAPSHOT.jar
+java -jar target/lighty-controller-springboot-12.3.0-SNAPSHOT.jar
 ```
 
 or in any IDE, run main in 

--- a/lighty-examples/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/lighty-controller-springboot-netconf/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-controller-springboot</artifactId>
-    <version>12.2.3-SNAPSHOT</version>
+    <version>12.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <description>Demo lighty.io project for SpringBoot</description>
 
@@ -35,14 +35,14 @@
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>dependency-versions</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-bom</artifactId>
-                <version>12.2.3-SNAPSHOT</version>
+                <version>12.3.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-examples/pom.xml
+++ b/lighty-examples/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.kit.examples</groupId>
     <artifactId>example-applications-aggregator</artifactId>
-    <version>12.2.3-SNAPSHOT</version>
+    <version>12.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-models/README.md
+++ b/lighty-models/README.md
@@ -56,7 +56,7 @@ my-model/pom.xml
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>12.2.2-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/lighty-models/README.md
+++ b/lighty-models/README.md
@@ -56,7 +56,7 @@ my-model/pom.xml
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>12.3.0-SNAPSHOT</version>
+        <version>12.3.0</version>
         <relativePath/>
     </parent>
 

--- a/lighty-models/pom.xml
+++ b/lighty-models/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.models</groupId>
     <artifactId>lighty-models-aggregator</artifactId>
-    <version>12.2.3-SNAPSHOT</version>
+    <version>12.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-models/test/lighty-example-data-center/pom.xml
+++ b/lighty-models/test/lighty-example-data-center/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../../../lighty-core/lighty-binding-parent/</relativePath>
     </parent>
 

--- a/lighty-models/test/lighty-test-models/pom.xml
+++ b/lighty-models/test/lighty-test-models/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../../../lighty-core/lighty-binding-parent/</relativePath>
     </parent>
 

--- a/lighty-models/test/lighty-toaster/pom.xml
+++ b/lighty-models/test/lighty-toaster/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../../../lighty-core/lighty-binding-parent/</relativePath>
     </parent>
 

--- a/lighty-models/test/pom.xml
+++ b/lighty-models/test/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.models.test</groupId>
     <artifactId>lighty-models-test-aggregator</artifactId>
-    <version>12.2.3-SNAPSHOT</version>
+    <version>12.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-modules/integration-tests-aaa/pom.xml
+++ b/lighty-modules/integration-tests-aaa/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/integration-tests/pom.xml
+++ b/lighty-modules/integration-tests/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-aaa/pom.xml
+++ b/lighty-modules/lighty-aaa/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-jetty-server/pom.xml
+++ b/lighty-modules/lighty-jetty-server/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-netconf-sb/README.md
+++ b/lighty-modules/lighty-netconf-sb/README.md
@@ -42,7 +42,7 @@ To use NETCONF in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-netconf-sb</artifactId>
-    <version>12.2.2-SNAPSHOT</version>
+    <version>12.3.0-SNAPSHOT</version>
   </dependency>  
 ```
 2. Initialize and start an instance of NETCONF SBP in your code:

--- a/lighty-modules/lighty-netconf-sb/README.md
+++ b/lighty-modules/lighty-netconf-sb/README.md
@@ -42,7 +42,7 @@ To use NETCONF in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-netconf-sb</artifactId>
-    <version>12.3.0-SNAPSHOT</version>
+    <version>12.3.0</version>
   </dependency>  
 ```
 2. Initialize and start an instance of NETCONF SBP in your code:

--- a/lighty-modules/lighty-netconf-sb/pom.xml
+++ b/lighty-modules/lighty-netconf-sb/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-openflow-sb/README.md
+++ b/lighty-modules/lighty-openflow-sb/README.md
@@ -10,7 +10,7 @@ is Lighty's version of openflow plugin.
 <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-openflow-sb</artifactId>
-    <version>12.2.2-SNAPSHOT</version>
+    <version>12.3.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/lighty-modules/lighty-openflow-sb/README.md
+++ b/lighty-modules/lighty-openflow-sb/README.md
@@ -10,7 +10,7 @@ is Lighty's version of openflow plugin.
 <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-openflow-sb</artifactId>
-    <version>12.3.0-SNAPSHOT</version>
+    <version>12.3.0</version>
 </dependency>
 ```
 

--- a/lighty-modules/lighty-openflow-sb/pom.xml
+++ b/lighty-modules/lighty-openflow-sb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-restconf-nb-community/README.md
+++ b/lighty-modules/lighty-restconf-nb-community/README.md
@@ -12,7 +12,7 @@ To use RESTCONF in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-restconf-nb-community</artifactId>
-    <version>12.3.0-SNAPSHOT</version>
+    <version>12.3.0</version>
   </dependency>
 ```
 

--- a/lighty-modules/lighty-restconf-nb-community/README.md
+++ b/lighty-modules/lighty-restconf-nb-community/README.md
@@ -12,7 +12,7 @@ To use RESTCONF in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-restconf-nb-community</artifactId>
-    <version>12.2.2-SNAPSHOT</version>
+    <version>12.3.0-SNAPSHOT</version>
   </dependency>
 ```
 

--- a/lighty-modules/lighty-restconf-nb-community/pom.xml
+++ b/lighty-modules/lighty-restconf-nb-community/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-swagger/pom.xml
+++ b/lighty-modules/lighty-swagger/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/pom.xml
+++ b/lighty-modules/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-modules-aggregator</artifactId>
-    <version>12.2.3-SNAPSHOT</version>
+    <version>12.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
 

--- a/lighty-resources/controller-application-assembly/pom.xml
+++ b/lighty-resources/controller-application-assembly/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-resources/log4j-properties/pom.xml
+++ b/lighty-resources/log4j-properties/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-resources/pom.xml
+++ b/lighty-resources/pom.xml
@@ -12,7 +12,7 @@
     <groupId>io.lighty.resources</groupId>
     <artifactId>lighty-resources-aggregator</artifactId>
     <packaging>pom</packaging>
-    <version>12.2.3-SNAPSHOT</version>
+    <version>12.3.0-SNAPSHOT</version>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/lighty-resources/singlenode-configuration/pom.xml
+++ b/lighty-resources/singlenode-configuration/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>12.2.3-SNAPSHOT</version>
+        <version>12.3.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-resources/start-script/pom.xml
+++ b/lighty-resources/start-script/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-parent</artifactId>
-    <version>12.2.3-SNAPSHOT</version>
+    <version>12.3.0-SNAPSHOT</version>
     <relativePath>../../lighty-core/lighty-parent</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty</groupId>
     <artifactId>lighty-aggregator</artifactId>
-    <version>12.2.3-SNAPSHOT</version>
+    <version>12.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>lighty</name>
 


### PR DESCRIPTION
Release notes:
Update upstream dependencies to latest Magnesium SR3 versions:

- odl parent 6.0.13
- yangtools-artifacts 4.0.15
- mdsal 5.0.16
- controller 1.11.3
- conroller.config-artifacts 0.12.3
- aaa 0.11.3
- netconf 1.8.3
- infrautils  1.7.3
- openflow 0.10.3
- serviceutils 0.5.3
- maven-sal-api-gen-plugin 3.0.16
