### PR TITLE
Add lighty application test workflow

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -1,0 +1,135 @@
+name: Test lighty application
+on:
+  workflow_dispatch:
+    inputs:
+      app-name:
+        description: Name of the application in /lighty-applications
+        default: lighty-rnc-app
+        required: true
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      app-aggregator-dir: lighty-applications/${{ github.event.inputs.app-name }}-aggregator
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
+      SONAR_PROJECT_KEY: ${{ secrets.SONAR_PROJECT_KEY}}
+    name: Setup, Install and Test
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v2
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Maven install + build docker image (skip test)
+        run: mvn install -Pdocker -DskipTests -B -V -Psource-quality
+      - name: Maven test + SonarCloud
+        if: ${{ env.SONAR_TOKEN != 0 }}
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+          -Dsonar.java.source=1.11
+          -Dsonar.projectKey=${{ env.SONAR_PROJECT_KEY }}
+          -Dsonar.organization=${{ env.SONAR_ORGANIZATION }}
+          -Dsonar.host.url=https://sonarcloud.io
+      - name: Maven test no SonarCloud
+        if: ${{ env.SONAR_TOKEN == 0 }}
+        run: mvn -B verify
+      - name: Upload surefire test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: Surefire-Test-Results
+          path: ~/**/surefire-reports/**/*.txt
+      - name: Start app in docker container
+        run: |
+          image_name=$(mvn help:evaluate -f ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-docker/pom.xml -Dexpression=image.name -q -DforceStdout)
+          echo $image_name
+          docker run -d --name ${{ github.event.inputs.app-name }} --network host --rm $image_name
+          sleep 35 # Wait for app to start
+      - name: Docker container restconf/operations healthcheck
+        run: |
+          curl --user admin:admin -H "Content-Type: application/json" --insecure http://localhost:8888/restconf/operations
+      - name: Stop docker container
+        run: |
+          docker kill ${{ github.event.inputs.app-name }}
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.3.0
+        with:
+          minikube version: 'v1.17.1'
+          kubernetes version: 'v1.15.11'
+      - name: Start Minikube cluster
+        run: |
+          minikube start
+      - name: Install helm v2.17.0
+        uses: azure/setup-helm@v1
+        with:
+          version: '2.17.0'
+      - name: Install socat
+        run: |
+          sudo apt-get -y install socat
+      - name: Init helm
+        run: |
+          minikube kubectl -- create serviceaccount tiller --namespace kube-system
+          minikube kubectl -- create clusterrolebinding tiller-cluster-rule \
+          --clusterrole=cluster-admin \
+          --serviceaccount=kube-system:tiller
+          helm init --stable-repo-url https://charts.helm.sh/stable --service-account tiller --wait
+      - name: Helm version
+        run: |
+          helm version
+      - name: Kubernetes versions
+        run: |
+          minikube kubectl -- version
+      - name: Load image to minikube
+        run: |
+          echo "Exporting Docker image to .tar ..."
+          image_name=$(mvn help:evaluate -f ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-docker/pom.xml -Dexpression=image.name -q -DforceStdout)
+          docker save --output="./${{ github.event.inputs.app-name }}.tar" $image_name
+          echo "Loading docker image to minikube"
+          docker load --input ./${{ github.event.inputs.app-name }}.tar
+          rm ./${{ github.event.inputs.app-name }}.tar
+      - name: Install app helm chart
+        run: |
+          helm install ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-helm/helm/${{ github.event.inputs.app-name }}-helm --name ${{ github.event.inputs.app-name }}
+          sleep 35 # Wait for app to start
+      - name: List pods
+        run: |
+          minikube kubectl -- get pods
+      - name: Cluster state (:8558/cluster/members)
+        run: |
+          pod_names=$(minikube kubectl -- get pods --no-headers -o custom-columns=":metadata.name")
+          for pod_name in $pod_names; \
+          do \
+            pod_ip=$(minikube kubectl -- get pod $pod_name --template={{.status.podIP}}) && \
+            curl --user admin:admin -H "Content-Type: application/json" --insecure http://$pod_ip:8558/cluster/members \
+          ;done
+      - name: Logs pods
+        run: |
+          pod_names=$(minikube kubectl -- get pods --no-headers -o custom-columns=":metadata.name")
+          for pod_name in $pod_names; \
+          do \
+            minikube kubectl -- logs $pod_name \
+          ;done
+      - name: Pods healthcheck (:8888/restconf/operations)
+        run: |
+          pod_names=$(minikube kubectl -- get pods --no-headers -o custom-columns=":metadata.name")
+          for pod_name in $pod_names; \
+          do \
+            pod_ip=$(minikube kubectl -- get pod $pod_name --template={{.status.podIP}}) && \
+            curl --user admin:admin -H "Content-Type: application/json" --insecure http://$pod_ip:8888/restconf/operations \
+          ;done
+      - name: List Services
+        run: |
+          minikube kubectl -- get services
+      - name: Service healthcheck (:30888/restconf/operations)
+        run: |
+          minikube_ip=$(minikube ip)
+          curl --user admin:admin -H "Content-Type: application/json" --insecure http://$minikube_ip:30888/restconf/operations

--- a/.github/workflows/publish-docker-helm.yml
+++ b/.github/workflows/publish-docker-helm.yml
@@ -1,0 +1,75 @@
+name: Publish docker image and helm chart
+on:
+  workflow_dispatch:
+    inputs:
+      app-name:
+        description: Name of the application in /lighty-applications
+        default: lighty-rnc-app
+        required: true
+      image-name:
+        description: Desired name of the built image
+        default: lighty-rnc
+        required: true
+      image-tag:
+        description: Desired tag of the built image
+        default: latest
+        required: true
+jobs:
+  publish-docker-helm:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      app-aggregator-dir: lighty-applications/${{ github.event.inputs.app-name }}-aggregator
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_REPO: ${{ github.repository }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
+      SONAR_PROJECT_KEY: ${{ secrets.SONAR_PROJECT_KEY}}
+      GHCR_KEY: ${{ secrets.PACKAGE_REGISTRY_KEY}}
+    name: Setup, Install and Test
+    steps:
+      - name: Print env
+        run: |
+          echo ${{ github.event.inputs.image-name }}:${{ github.event.inputs.image-tag }}
+      - name: Clone Repository
+        uses: actions/checkout@v2
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Log in docker
+        run: |
+          echo ${{ env.GHCR_KEY}} | docker login  --username marekzatko --password-stdin ghcr.io
+      - name: Build docker image
+        run: mvn install -pl :lighty-rnc-app,:lighty-rnc-app-docker -am -P docker
+#        run: docker build -t ${{ github.event.inputs.image-name }}:${{ github.event.inputs.image-tag }} f ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-docker/
+      - name: Rename image to desired
+        run: |
+          image_name=$(mvn help:evaluate -f ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-docker/pom.xml -Dexpression=image.name -q -DforceStdout)
+          image_tag=$(mvn help:evaluate -f ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-docker/pom.xml -Dexpression=image.version -q -DforceStdout)
+          echo Old IMAGE name:tag: $image_name:$image_tag
+          docker images
+          echo Renaming
+          DOCKER_IMAGE_NAME=$(echo ghcr.io/marekzatko/${{ github.event.inputs.image-name }})
+          DOCKER_IMAGE_NAME_TAG=$(echo $DOCKER_IMAGE_NAME:${{ github.event.inputs.image-tag }})
+          echo "DOCKER_IMAGE_NAME_TAG=$(echo $DOCKER_IMAGE_NAME_TAG)" >> $GITHUB_ENV
+          docker tag $image_name:$image_tag $DOCKER_IMAGE_NAME_TAG
+          docker images
+      - name: Test
+        run: echo $DOCKER_IMAGE_NAME
+      - name: List docker images
+        run: |
+          docker images
+      - name: Publish to packages
+        run: |
+          echo $DOCKER_IMAGE_NAME_TAG
+          docker push $DOCKER_IMAGE_NAME_TAG
+

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <image.name>lighty-rnc</image.name>
+        <image.version>latest</image.version>
         <lighty.app.name>lighty-rnc-app-${project.version}</lighty.app.name>
         <lighty.app.zip>${lighty.app.name}-bin.zip</lighty.app.zip>
         <lighty.app.jar>${lighty.app.name}.jar</lighty.app.jar>
@@ -95,7 +96,7 @@
                 <configuration>
                     <images>
                         <image>
-                            <name>${image.name}</name>
+                            <name>${image.name}:${image.version}</name>
                             <build>
                                 <cleanup>try</cleanup>
                                 <contextDir>${basedir}/target/docker-stage</contextDir>

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/configmaps.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/configmaps.yaml
@@ -174,6 +174,10 @@ data:
 
         journal.leveldb.dir = "target/journal"
         snapshot-store.local.dir = "target/snapshots"
+        # Use lz4 compression for LocalSnapshotStore snapshots
+        snapshot-store.local.use-lz4-compression = false
+        # Size of blocks for lz4 compression: 64KB, 256KB, 1MB or 4MB
+        snapshot-store.local.lz4-blocksize = 256KB
 
         journal {
           leveldb {


### PR DESCRIPTION
Add manual triggered workflow which install and tests lighty application located in /lighty-applications/:
- as standalone docker container (docker run ...)
- as deployed via provided helm chart in minikube cluster

- testing is done via curl commands on restconf endpoints

You can check run of the workflow here: https://github.com/marekzatko/lighty-core/runs/1830620495?check_suite_focus=true 

Fix clustering in rnc-app:
- there was an exception (missing l4z compression setting in akka config) when the application is deployed in a cluster

Signed-off-by: marekzatko <Marek.Zatko@pantheon.tech>