### PR TITLE
Root resource discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Software-Defined Networking (SDN) solutions in Java. Developed by [PANTHEON.tech
 
 It utilizes core [OpenDaylight](https://www.opendaylight.org/) components, which are available as a set of libraries and are adapted to run in a __plain Java SE environment__.
 
-[![Build Status](https://github.com/PANTHEONtech/lighty/workflows/Build/badge.svg?branch=13.0.x)](https://github.com/PANTHEONtech/lighty/actions)
+[![Build Status](https://github.com/PANTHEONtech/lighty/workflows/Build/badge.svg?branch=13.2.x)](https://github.com/PANTHEONtech/lighty/actions)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.lighty.core/lighty-bom/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.lighty.core/lighty-bom)
 [![License](https://img.shields.io/badge/License-EPL%201.0-blue.svg)](https://opensource.org/licenses/EPL-1.0)
 

--- a/lighty-applications/lighty-rnc-app-aggregator/README.md
+++ b/lighty-applications/lighty-rnc-app-aggregator/README.md
@@ -2,15 +2,15 @@
 Lighty Restconf Netconf application allows to easily initialize, start and use most used OpenDaylight services and optionally add custom business logic.
 
 Most important lighty.io components used are:
-- [lighty.io controller](https://github.com/PANTHEONtech/lighty/tree/13.1.x/lighty-core/lighty-controller)
+- [lighty.io controller](https://github.com/PANTHEONtech/lighty/tree/13.2.x/lighty-core/lighty-controller)
   provides core ODL services (like MDSAL, yangtools, global schema context,...) that are required
   for other services or plugins.
-- [RESTCONF northbound plugin](https://github.com/PANTHEONtech/lighty/tree/13.1.x/lighty-modules/lighty-restconf-nb-community)
+- [RESTCONF northbound plugin](https://github.com/PANTHEONtech/lighty/tree/13.2.x/lighty-modules/lighty-restconf-nb-community)
   provides the RESTCONF interface that is used to communicate with the application using the RESTCONF protocol over the HTTP.
-- [NETCONF southbound plugin](https://github.com/PANTHEONtech/lighty/tree/13.1.x/lighty-modules/lighty-netconf-sb)
+- [NETCONF southbound plugin](https://github.com/PANTHEONtech/lighty/tree/13.2.x/lighty-modules/lighty-netconf-sb)
   enables application to connect to the NETCONF devices using the NETCONF protocol and read/write configuration
   from them or execute RPCs.
-- [AAA module](https://github.com/PANTHEONtech/lighty/tree/13.1.x/lighty-modules/lighty-aaa) provides authorization,
+- [AAA module](https://github.com/PANTHEONtech/lighty/tree/13.2.x/lighty-modules/lighty-aaa) provides authorization,
   authentication and accounting which for example enables to use Basic Authentication for RESTCONF northbound interface.
   This module is optional and can be turned ON/OFF using application configuration.
 

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.applications.rnc</groupId>
     <artifactId>lighty-rnc-app-docker</artifactId>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0-SNAPSHOT</version>
 
     <properties>
         <image.name>lighty-rnc</image.name>

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/pom.xml
@@ -12,13 +12,13 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../../../lighty-core/lighty-app-parent/pom.xml</relativePath>
     </parent>
 
     <groupId>io.lighty.applications.rnc</groupId>
     <artifactId>lighty-rnc-app</artifactId>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/pom.xml
@@ -12,13 +12,13 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../../../lighty-core/lighty-parent/pom.xml</relativePath>
     </parent>
 
     <groupId>io.lighty.applications.rnc</groupId>
     <artifactId>lighty-rnc-module</artifactId>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/lighty-applications/lighty-rnc-app-aggregator/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>io.lighty.applications.rnc</groupId>
     <artifactId>lighty-rnc-aggregator</artifactId>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/lighty-applications/pom.xml
+++ b/lighty-applications/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.applications</groupId>
     <artifactId>lighty-applications-aggregator</artifactId>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
-                <version>7.0.7</version>
+                <version>7.0.8</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -34,42 +34,42 @@
             <dependency>
                 <groupId>org.opendaylight.aaa</groupId>
                 <artifactId>aaa-artifacts</artifactId>
-                <version>0.12.1</version>
+                <version>0.12.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>controller-artifacts</artifactId>
-                <version>2.0.6</version>
+                <version>2.0.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.infrautils</groupId>
                 <artifactId>infrautils-artifacts</artifactId>
-                <version>1.8.2</version>
+                <version>1.8.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.mdsal</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>6.0.7</version>
+                <version>6.0.8</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>netconf-artifacts</artifactId>
-                <version>1.9.1</version>
+                <version>1.9.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yangtools-artifacts</artifactId>
-                <version>5.0.7</version>
+                <version>5.0.8</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -77,14 +77,14 @@
             <dependency>
                 <groupId>org.opendaylight.openflowplugin</groupId>
                 <artifactId>openflowplugin-artifacts</artifactId>
-                <version>0.11.1</version>
+                <version>0.11.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.serviceutils</groupId>
                 <artifactId>serviceutils-artifacts</artifactId>
-                <version>0.6.1</version>
+                <version>0.6.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.lighty.core</groupId>
     <artifactId>dependency-versions</artifactId>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/lighty-core/lighty-app-parent/pom.xml
+++ b/lighty-core/lighty-app-parent/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -54,12 +54,12 @@
             <plugin>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yang-maven-plugin</artifactId>
-                <version>5.0.7</version>
+                <version>5.0.8</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.opendaylight.mdsal</groupId>
                         <artifactId>maven-sal-api-gen-plugin</artifactId>
-                        <version>6.0.7</version>
+                        <version>6.0.8</version>
                         <type>jar</type>
                     </dependency>
                 </dependencies>

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-bom/pom.xml
+++ b/lighty-core/lighty-bom/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-bom</artifactId>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -26,103 +26,103 @@
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-codecs</artifactId>
-                <version>13.1.1-SNAPSHOT</version>
+                <version>13.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-common</artifactId>
-                <version>13.1.1-SNAPSHOT</version>
+                <version>13.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-controller</artifactId>
-                <version>13.1.1-SNAPSHOT</version>
+                <version>13.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-clustering</artifactId>
-                <version>13.1.1-SNAPSHOT</version>
+                <version>13.2.0-SNAPSHOT</version>
             </dependency>
 
             <!-- DI framework integrations -->
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-controller-guice-di</artifactId>
-                <version>13.1.1-SNAPSHOT</version>
+                <version>13.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-controller-spring-di</artifactId>
-                <version>13.1.1-SNAPSHOT</version>
+                <version>13.2.0-SNAPSHOT</version>
             </dependency>
 
             <!-- Modules -->
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-aaa</artifactId>
-                <version>13.1.1-SNAPSHOT</version>
+                <version>13.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-jetty-server</artifactId>
-                <version>13.1.1-SNAPSHOT</version>
+                <version>13.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-netconf-sb</artifactId>
-                <version>13.1.1-SNAPSHOT</version>
+                <version>13.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-restconf-nb-community</artifactId>
-                <version>13.1.1-SNAPSHOT</version>
+                <version>13.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-swagger</artifactId>
-                <version>13.1.1-SNAPSHOT</version>
+                <version>13.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-openflow-sb</artifactId>
-                <version>13.1.1-SNAPSHOT</version>
+                <version>13.2.0-SNAPSHOT</version>
             </dependency>
 
             <!-- Utility resources -->
             <dependency>
                 <groupId>io.lighty.resources</groupId>
                 <artifactId>controller-application-assembly</artifactId>
-                <version>13.1.1-SNAPSHOT</version>
+                <version>13.2.0-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>io.lighty.resources</groupId>
                 <artifactId>singlenode-configuration</artifactId>
-                <version>13.1.1-SNAPSHOT</version>
+                <version>13.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.resources</groupId>
                 <artifactId>start-script</artifactId>
-                <version>13.1.1-SNAPSHOT</version>
+                <version>13.2.0-SNAPSHOT</version>
             </dependency>
 
             <!-- Dependencies and resources which should not normally leak into production -->
             <dependency>
                 <groupId>io.lighty.models.test</groupId>
                 <artifactId>lighty-test-models</artifactId>
-                <version>13.1.1-SNAPSHOT</version>
+                <version>13.2.0-SNAPSHOT</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>io.lighty.models.test</groupId>
                 <artifactId>lighty-toaster</artifactId>
-                <version>13.1.1-SNAPSHOT</version>
+                <version>13.2.0-SNAPSHOT</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>io.lighty.resources</groupId>
                 <artifactId>log4j-properties</artifactId>
-                <version>13.1.1-SNAPSHOT</version>
+                <version>13.2.0-SNAPSHOT</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/lighty-core/lighty-clustering/pom.xml
+++ b/lighty-core/lighty-clustering/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-codecs/pom.xml
+++ b/lighty-core/lighty-codecs/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-common/pom.xml
+++ b/lighty-core/lighty-common/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-controller-guice-di/pom.xml
+++ b/lighty-core/lighty-controller-guice-di/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-controller-spring-di/pom.xml
+++ b/lighty-core/lighty-controller-spring-di/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-controller/README.md
+++ b/lighty-core/lighty-controller/README.md
@@ -17,7 +17,7 @@ To use Lighty controller in your project:
   <dependency>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-controller</artifactId>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0</version>
   </dependency>
 ```
 

--- a/lighty-core/lighty-controller/pom.xml
+++ b/lighty-core/lighty-controller/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-minimal-parent/pom.xml
+++ b/lighty-core/lighty-minimal-parent/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-minimal-parent</artifactId>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -29,14 +29,14 @@
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>dependency-versions</artifactId>
-                <version>13.1.1-SNAPSHOT</version>
+                <version>13.2.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-bom</artifactId>
-                <version>13.1.1-SNAPSHOT</version>
+                <version>13.2.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-minimal-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../lighty-minimal-parent</relativePath>
     </parent>
 

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -174,7 +174,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>7.0.5</version>
+                            <version>7.0.8</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -191,7 +191,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>spotbugs</artifactId>
-                            <version>7.0.5</version>
+                            <version>7.0.8</version>
                         </dependency>
                         <dependency>
                             <!-- The SpotBugs Maven plugin uses SLF4J 1.8 beta 2 -->

--- a/lighty-core/pom.xml
+++ b/lighty-core/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-core-aggregator</artifactId>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-examples/README.md
+++ b/lighty-examples/README.md
@@ -17,7 +17,7 @@ ODL core services represent MD-SAL layer, controller, DataStore, global schema c
    <dependency>
       <groupId>io.lighty.core.parents</groupId>
       <artifactId>lighty-dependency-artifacts</artifactId>
-      <version>13.1.1-SNAPSHOT</version>
+      <version>13.2.0</version>
       <type>pom</type>
       <scope>import</scope>
    </dependency>

--- a/lighty-examples/lighty-cluster-app/Dockerfile.k8s
+++ b/lighty-examples/lighty-cluster-app/Dockerfile.k8s
@@ -1,9 +1,9 @@
 FROM openjdk:11-jre-slim
 
-COPY target/lighty-cluster-app-13.1.1-SNAPSHOT-bin.zip /
+COPY target/lighty-cluster-app-13.2.0-bin.zip /
 
 RUN apt-get update && apt-get install unzip \
-    && unzip /lighty-cluster-app-13.1.1-SNAPSHOT-bin.zip \
-    && rm /lighty-cluster-app-13.1.1-SNAPSHOT-bin.zip
+    && unzip /lighty-cluster-app-13.2.0-bin.zip \
+    && rm /lighty-cluster-app-13.2.0-bin.zip
 
-ENTRYPOINT ["/lighty-cluster-app-13.1.1-SNAPSHOT/start-controller-node-k8s.sh"]
+ENTRYPOINT ["/lighty-cluster-app-13.2.0/start-controller-node-k8s.sh"]

--- a/lighty-examples/lighty-cluster-app/pom.xml
+++ b/lighty-examples/lighty-cluster-app/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-app-parent</relativePath>
     </parent>
 

--- a/lighty-examples/lighty-cluster-app/src/main/assembly/resources/start-controller-node-k8s.sh
+++ b/lighty-examples/lighty-cluster-app/src/main/assembly/resources/start-controller-node-k8s.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 #start controller
-cd /lighty-cluster-app-13.1.1-SNAPSHOT
-java -ms128m -mx128m -XX:MaxMetaspaceSize=128m -jar lighty-cluster-app-13.1.1-SNAPSHOT.jar -n 0 -k
+cd /lighty-cluster-app-13.2.0
+java -ms128m -mx128m -XX:MaxMetaspaceSize=128m -jar lighty-cluster-app-13.2.0.jar -n 0 -k

--- a/lighty-examples/lighty-community-aaa-restconf-app/pom.xml
+++ b/lighty-examples/lighty-community-aaa-restconf-app/pom.xml
@@ -12,13 +12,13 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-app-parent</relativePath>
     </parent>
 
     <groupId>io.lighty.kit.examples.controllers</groupId>
     <artifactId>lighty-community-aaa-restconf-app</artifactId>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/lighty-examples/lighty-community-netconf-quarkus-app/README.md
+++ b/lighty-examples/lighty-community-netconf-quarkus-app/README.md
@@ -30,7 +30,7 @@ mvn clean compile quarkus:dev
 ## Build package & Run
 ```
 mvn clean package
-java -Xms128m -Xmx128m -XX:MaxMetaspaceSize=128m -jar target/lighty-quarkus-netconf-app-13.1.1-SNAPSHOT-runner.jar
+java -Xms128m -Xmx128m -XX:MaxMetaspaceSize=128m -jar target/lighty-quarkus-netconf-app-13.2.0-runner.jar
 ```
 
 ## Build native image

--- a/lighty-examples/lighty-community-netconf-quarkus-app/pom.xml
+++ b/lighty-examples/lighty-community-netconf-quarkus-app/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.lighty.quarkus</groupId>
   <artifactId>lighty-quarkus-netconf-app</artifactId>
-  <version>13.1.1-SNAPSHOT</version>
+  <version>13.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -15,7 +15,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
     <application.attach.zip>true</application.attach.zip>
-    <lighty.version>13.1.1-SNAPSHOT</lighty.version>
+    <lighty.version>13.2.0-SNAPSHOT</lighty.version>
   </properties>
 
   <dependencyManagement>

--- a/lighty-examples/lighty-community-restconf-netconf-app/README.md
+++ b/lighty-examples/lighty-community-restconf-netconf-app/README.md
@@ -21,12 +21,12 @@ build the project: ```mvn clean install```
 ### Start this demo example
 * build the project using ```mvn clean install```
 * go to target directory ```cd lighty-examples/lighty-community-restconf-netconf-app/target``` 
-* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-13.1.1-SNAPSHOT-bin.zip```
-* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-13.1.1-SNAPSHOT```
-* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-13.1.1-SNAPSHOT.jar``` 
+* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-13.2.0-bin.zip```
+* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-13.2.0```
+* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-13.2.0.jar``` 
 
 ### Test example application
-Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-13.1.1-SNAPSHOT.jar``` 
+Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-13.2.0.jar``` 
 RESTCONF web interface is available at URL ```http://localhost:8888/restconf/*```
 
 ##### URLs to start with
@@ -43,7 +43,7 @@ URLs for Swagger (choose RESTCONF [draft18](https://tools.ietf.org/html/draft-ie
 
 ### Use custom config files
 There are two separated config files: for NETCONF SBP single node and for cluster.
-`java -jar lighty-community-restconf-netconf-app-13.1.1-SNAPSHOT.jar /path/to/singleNodeConfig.json`
+`java -jar lighty-community-restconf-netconf-app-13.2.0.jar /path/to/singleNodeConfig.json`
 
 Example configuration for single node is [here](src/main/assembly/resources/sampleConfigSingleNode.json)
 

--- a/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-app-parent</relativePath>
     </parent>
 

--- a/lighty-examples/lighty-community-restconf-ofp-app/Dockerfile
+++ b/lighty-examples/lighty-community-restconf-ofp-app/Dockerfile
@@ -1,16 +1,16 @@
 FROM openjdk:11-jre-slim
 
-COPY ./target/lighty-community-restconf-ofp-app-13.1.1-SNAPSHOT-bin.zip /
+COPY ./target/lighty-community-restconf-ofp-app-13.2.0-bin.zip /
 
 RUN apt-get update && apt-get install unzip \
-    && unzip /lighty-community-restconf-ofp-app-13.1.1-SNAPSHOT-bin.zip \
-    && rm /lighty-community-restconf-ofp-app-13.1.1-SNAPSHOT-bin.zip
+    && unzip /lighty-community-restconf-ofp-app-13.2.0-bin.zip \
+    && rm /lighty-community-restconf-ofp-app-13.2.0-bin.zip
 
 ##libstdc++ is required by leveldbjni-1.8 (Akka dispatcher)
 #Uncaught error from thread [opendaylight-cluster-data-akka.persistence.dispatchers.default-plugin-dispatcher-22]: Could not load library. Reasons: [no leveldbjni64-1.8 in java.library.path, no leveldbjni-1.8 in java.library.path, no leveldbjni in java.library.path, /tmp/libleveldbjni-64-1-3166161234556196376.8: Error loading shared library libstdc++.so.6: No such file or directory (needed by /tmp/libleveldbjni-64-1-3166161234556196376.8)], shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled for ActorSystem[opendaylight-cluster-data]
 RUN apt-get install libstdc++6
 
-WORKDIR /lighty-community-restconf-ofp-app-13.1.1-SNAPSHOT
+WORKDIR /lighty-community-restconf-ofp-app-13.2.0
 
 EXPOSE 8888
 EXPOSE 8185
@@ -19,4 +19,4 @@ EXPOSE 6653
 EXPOSE 2550
 EXPOSE 80
 
-CMD java -jar lighty-community-restconf-ofp-app-13.1.1-SNAPSHOT.jar sampleConfigSingleNode.json
+CMD java -jar lighty-community-restconf-ofp-app-13.2.0.jar sampleConfigSingleNode.json

--- a/lighty-examples/lighty-community-restconf-ofp-app/README.md
+++ b/lighty-examples/lighty-community-restconf-ofp-app/README.md
@@ -12,7 +12,7 @@ Build the project using maven command: ```mvn clean install```.
 This will create *.zip* archive in target directory. Extract this archive
 and run *.jar* file using java with command:
 ```
-java -jar lighty-community-restconf-ofp-app-13.1.1-SNAPSHOT.jar
+java -jar lighty-community-restconf-ofp-app-13.2.0.jar
 ```
 
 ### Use custom config files
@@ -24,7 +24,7 @@ after build.
 
 When running application pass path to configuration file as argument:
 ```
-java -jar lighty-community-restconf-ofp-app-13.1.1-SNAPSHOT.jar sampleConfigSingleNode.json
+java -jar lighty-community-restconf-ofp-app-13.2.0.jar sampleConfigSingleNode.json
 ```
 
 ### Building and running Docker Image

--- a/lighty-examples/lighty-community-restconf-ofp-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-ofp-app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-app-parent</relativePath>
     </parent>
 

--- a/lighty-examples/lighty-controller-springboot-netconf/README.md
+++ b/lighty-examples/lighty-controller-springboot-netconf/README.md
@@ -46,7 +46,7 @@ mvn spring-boot:run
 or
 
 ```
-java -jar target/lighty-controller-springboot-13.1.1-SNAPSHOT.jar
+java -jar target/lighty-controller-springboot-13.2.0.jar
 ```
 
 or in any IDE, run main in 

--- a/lighty-examples/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/lighty-controller-springboot-netconf/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-controller-springboot</artifactId>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <description>Demo lighty.io project for SpringBoot</description>
 
@@ -32,7 +32,7 @@
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-bom</artifactId>
-                <version>13.1.1-SNAPSHOT</version>
+                <version>13.2.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-examples/pom.xml
+++ b/lighty-examples/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.kit.examples</groupId>
     <artifactId>example-applications-aggregator</artifactId>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-models/README.md
+++ b/lighty-models/README.md
@@ -56,7 +56,7 @@ my-model/pom.xml
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0</version>
         <relativePath/>
     </parent>
 

--- a/lighty-models/pom.xml
+++ b/lighty-models/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.models</groupId>
     <artifactId>lighty-models-aggregator</artifactId>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-models/test/lighty-example-data-center/pom.xml
+++ b/lighty-models/test/lighty-example-data-center/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../../../lighty-core/lighty-binding-parent/</relativePath>
     </parent>
 

--- a/lighty-models/test/lighty-test-models/pom.xml
+++ b/lighty-models/test/lighty-test-models/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../../../lighty-core/lighty-binding-parent/</relativePath>
     </parent>
 

--- a/lighty-models/test/lighty-toaster/pom.xml
+++ b/lighty-models/test/lighty-toaster/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../../../lighty-core/lighty-binding-parent/</relativePath>
     </parent>
 

--- a/lighty-models/test/pom.xml
+++ b/lighty-models/test/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.models.test</groupId>
     <artifactId>lighty-models-test-aggregator</artifactId>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-modules/integration-tests-aaa/pom.xml
+++ b/lighty-modules/integration-tests-aaa/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/integration-tests/pom.xml
+++ b/lighty-modules/integration-tests/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-aaa/pom.xml
+++ b/lighty-modules/lighty-aaa/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-jetty-server/pom.xml
+++ b/lighty-modules/lighty-jetty-server/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-netconf-sb/README.md
+++ b/lighty-modules/lighty-netconf-sb/README.md
@@ -42,7 +42,7 @@ To use NETCONF in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-netconf-sb</artifactId>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0</version>
   </dependency>  
 ```
 2. Initialize and start an instance of NETCONF SBP in your code:

--- a/lighty-modules/lighty-netconf-sb/pom.xml
+++ b/lighty-modules/lighty-netconf-sb/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-openflow-sb/README.md
+++ b/lighty-modules/lighty-openflow-sb/README.md
@@ -10,7 +10,7 @@ is Lighty's version of openflow plugin.
 <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-openflow-sb</artifactId>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0</version>
 </dependency>
 ```
 

--- a/lighty-modules/lighty-openflow-sb/pom.xml
+++ b/lighty-modules/lighty-openflow-sb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-restconf-nb-community/README.md
+++ b/lighty-modules/lighty-restconf-nb-community/README.md
@@ -12,7 +12,7 @@ To use RESTCONF in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-restconf-nb-community</artifactId>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0</version>
   </dependency>
 ```
 

--- a/lighty-modules/lighty-restconf-nb-community/pom.xml
+++ b/lighty-modules/lighty-restconf-nb-community/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/CommunityRestConf.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/CommunityRestConf.java
@@ -11,6 +11,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Throwables;
 import io.lighty.core.controller.api.AbstractLightyModule;
 import io.lighty.modules.northbound.restconf.community.impl.config.JsonRestConfServiceType;
+import io.lighty.modules.northbound.restconf.community.impl.root.resource.discovery.RootFoundApplication;
 import io.lighty.modules.northbound.restconf.community.impl.util.RestConfConfigUtils;
 import io.lighty.server.LightyServerBuilder;
 import java.net.InetAddress;
@@ -173,6 +174,13 @@ public class CommunityRestConf extends AbstractLightyModule {
             final ServletContextHandler mainHandler =
                     new ServletContextHandler(contexts, this.restconfServletContextPath, true, false);
             mainHandler.addServlet(jaxrs, "/*");
+
+            // TODO registering of resources should be supported also for other resources
+            final ServletContextHandler rrdHandler =
+                    new ServletContextHandler(contexts, "/.well-known", true, false);
+            final RootFoundApplication rootDiscoveryApp = new RootFoundApplication(restconfServletContextPath);
+            rrdHandler.addServlet(new ServletHolder(new ServletContainer(ResourceConfig
+                    .forApplication(rootDiscoveryApp))), "/*");
 
             boolean startDefault = false;
             if (this.lightyServerBuilder == null) {

--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/CommunityRestConf.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/CommunityRestConf.java
@@ -175,12 +175,18 @@ public class CommunityRestConf extends AbstractLightyModule {
                     new ServletContextHandler(contexts, this.restconfServletContextPath, true, false);
             mainHandler.addServlet(jaxrs, "/*");
 
-            // TODO registering of resources should be supported also for other resources
-            final ServletContextHandler rrdHandler =
-                    new ServletContextHandler(contexts, "/.well-known", true, false);
-            final RootFoundApplication rootDiscoveryApp = new RootFoundApplication(restconfServletContextPath);
-            rrdHandler.addServlet(new ServletHolder(new ServletContainer(ResourceConfig
-                    .forApplication(rootDiscoveryApp))), "/*");
+            // FIXME resource registering should be supported also for other resources, not only for RESTCONF 8040
+            switch (this.jsonRestconfServiceType) {
+                case DRAFT_18:
+                    final ServletContextHandler rrdHandler =
+                            new ServletContextHandler(contexts, "/.well-known", true, false);
+                    final RootFoundApplication rootDiscoveryApp = new RootFoundApplication(restconfServletContextPath);
+                    rrdHandler.addServlet(new ServletHolder(new ServletContainer(ResourceConfig
+                            .forApplication(rootDiscoveryApp))), "/*");
+                    break;
+                default:
+                    LOG.info("Resource Discovery skipped for RESTCONF service type {}", jsonRestconfServiceType);
+            }
 
             boolean startDefault = false;
             if (this.lightyServerBuilder == null) {

--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/root/resource/discovery/RootFoundApplication.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/root/resource/discovery/RootFoundApplication.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2021 Pantheon Technologies, s.r.o. and others. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ */
+
+package io.lighty.modules.northbound.restconf.community.impl.root.resource.discovery;
+
+import java.util.Set;
+import org.opendaylight.restconf.nb.rfc8040.rests.services.api.RootResourceDiscoveryService;
+
+// FIXME remove once the upstream class is fixed
+public class RootFoundApplication extends org.opendaylight.restconf.nb.rfc8040.RootFoundApplication {
+    private final RootResourceDiscoveryService rrds;
+
+    public RootFoundApplication(final String restconfServletContextPath) {
+        this.rrds = new RootResourceDiscoveryServiceImpl(restconfServletContextPath);
+    }
+
+    @Override
+    public Set<Object> getSingletons() {
+        return Set.of(rrds);
+    }
+}

--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/root/resource/discovery/RootFoundApplication.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/root/resource/discovery/RootFoundApplication.java
@@ -9,14 +9,20 @@
 package io.lighty.modules.northbound.restconf.community.impl.root.resource.discovery;
 
 import java.util.Set;
+import javax.ws.rs.core.Application;
+import org.opendaylight.restconf.nb.rfc8040.jersey.providers.errors.RestconfDocumentedExceptionMapper;
 import org.opendaylight.restconf.nb.rfc8040.rests.services.api.RootResourceDiscoveryService;
 
-// FIXME remove once the upstream class is fixed
-public class RootFoundApplication extends org.opendaylight.restconf.nb.rfc8040.RootFoundApplication {
+public class RootFoundApplication extends Application {
     private final RootResourceDiscoveryService rrds;
 
     public RootFoundApplication(final String restconfServletContextPath) {
         this.rrds = new RootResourceDiscoveryServiceImpl(restconfServletContextPath);
+    }
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        return Set.of(RestconfDocumentedExceptionMapper.class);
     }
 
     @Override

--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/root/resource/discovery/RootResourceDiscoveryServiceImpl.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/root/resource/discovery/RootResourceDiscoveryServiceImpl.java
@@ -13,7 +13,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.opendaylight.restconf.nb.rfc8040.rests.services.api.RootResourceDiscoveryService;
 
-// FIXME remove once the upstream class is fixed
 @Path("/")
 public final class RootResourceDiscoveryServiceImpl implements RootResourceDiscoveryService {
 

--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/root/resource/discovery/RootResourceDiscoveryServiceImpl.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/root/resource/discovery/RootResourceDiscoveryServiceImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2021 Pantheon Technologies, s.r.o. and others. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ */
+
+package io.lighty.modules.northbound.restconf.community.impl.root.resource.discovery;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import org.opendaylight.restconf.nb.rfc8040.rests.services.api.RootResourceDiscoveryService;
+
+// FIXME remove once the upstream class is fixed
+@Path("/")
+public final class RootResourceDiscoveryServiceImpl implements RootResourceDiscoveryService {
+
+    private final String restconfServletContextPath;
+
+    public RootResourceDiscoveryServiceImpl(final String restconfServletContextPath) {
+        if (restconfServletContextPath.charAt(0) == '/') {
+            this.restconfServletContextPath = restconfServletContextPath.substring(1);
+        } else {
+            this.restconfServletContextPath = restconfServletContextPath;
+        }
+    }
+
+    @Override
+    public Response readXrdData() {
+        return Response.status(Status.OK)
+                .entity("<?xml version='1.0' encoding='UTF-8'?>\n"
+                        + "<XRD xmlns='http://docs.oasis-open.org/ns/xri/xrd-1.0'>\n"
+                        + "     <Link rel='restconf' href='/" + restconfServletContextPath + "'/>\n"
+                        + "</XRD>")
+                .build();
+    }
+
+    @Override
+    public Response readJsonData() {
+        return Response.status(Status.OK)
+                .entity("{\n"
+                        + " \"links\" :\n"
+                        + " {\n"
+                        + "     \"rel\" : \"restconf\",\n"
+                        + "     \"href\" : \"/" + restconfServletContextPath + "/\"\n"
+                        + " }\n"
+                        + "}")
+                .build();
+    }
+}
+

--- a/lighty-modules/lighty-swagger/pom.xml
+++ b/lighty-modules/lighty-swagger/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-modules/pom.xml
+++ b/lighty-modules/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-modules-aggregator</artifactId>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
 

--- a/lighty-resources/controller-application-assembly/pom.xml
+++ b/lighty-resources/controller-application-assembly/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-resources/log4j-properties/pom.xml
+++ b/lighty-resources/log4j-properties/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-resources/pom.xml
+++ b/lighty-resources/pom.xml
@@ -12,7 +12,7 @@
     <groupId>io.lighty.resources</groupId>
     <artifactId>lighty-resources-aggregator</artifactId>
     <packaging>pom</packaging>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0-SNAPSHOT</version>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/lighty-resources/singlenode-configuration/pom.xml
+++ b/lighty-resources/singlenode-configuration/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.1.1-SNAPSHOT</version>
+        <version>13.2.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent</relativePath>
     </parent>
 

--- a/lighty-resources/start-script/pom.xml
+++ b/lighty-resources/start-script/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-parent</artifactId>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0-SNAPSHOT</version>
     <relativePath>../../lighty-core/lighty-parent</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty</groupId>
     <artifactId>lighty-aggregator</artifactId>
-    <version>13.1.1-SNAPSHOT</version>
+    <version>13.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>lighty</name>
 


### PR DESCRIPTION
Add support for Root Resource Discovery

Integrate Root Resource Discovery feature introduced in [NETCONF-499](https://jira.opendaylight.org/browse/NETCONF-499)

Upstream implementation does not support passing resource-path as
 parameter to service, so new implementation of service was created.

This patch includes also fix which provides support for
 multiple requests on endpoint `/.well-known/`, where upstream
 implementation is currently broken, [NETCONF-757](https://jira.opendaylight.org/browse/NETCONF-757).



Example:
requesting `/.well-known/host-meta` for restconf8040 responds:
```
curl -u $USER:$PASSWORD -H "Accept:application/xrd+xml" http://127.0.0.1:8888/.well-known/host-meta
<?xml version='1.0' encoding='UTF-8'?>
<XRD xmlns='http://docs.oasis-open.org/ns/xri/xrd-1.0'>
     <Link rel='restconf' href='/restconf'/>
</XRD>
```
or for JSON:
```
curl -H "Accept:application/xrd+json" http://127.0.0.1:8888/.well-known/host-meta.json
{
 "links" :
 {
     "rel" : "restconf",
     "href" : "/restconf/"
 }
}
```