### PR TITLE
Fix lighty-rnc-app-aggregator

### DIFF
--- a/lighty-applications/lighty-rnc-app-aggregator/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/pom.xml
@@ -16,6 +16,11 @@
     <version>13.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
+    </properties>
+
     <modules>
         <module>lighty-rnc-app</module>
         <module>lighty-rnc-module</module>


### PR DESCRIPTION
Aggregators should never be deployed/installed, fix that.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>