### PR TITLE
Include rnc-polyglot-app docker artifact to default build structure

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -39,7 +39,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Maven install + build docker image
-        run: mvn install -Pdocker -DskipTests -B -V -Psource-quality
+        run: mvn install -DskipTests -B -V -Psource-quality
       - name: Start app in docker container
         run: |
           image_name=$(mvn help:evaluate -f ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-docker/pom.xml -Dexpression=image.name -q -DforceStdout)

--- a/.github/workflows/publish-docker-helm.yml
+++ b/.github/workflows/publish-docker-helm.yml
@@ -57,7 +57,7 @@ jobs:
           DOCKER_IMAGE_NAME_TAG=$(echo $DOCKER_IMAGE_NAME:${{ github.event.inputs.image-tag }})
           echo "DOCKER_IMAGE_NAME_TAG=$(echo $DOCKER_IMAGE_NAME_TAG)" >> $GITHUB_ENV
       - name: Build docker image
-        run: mvn install -B -pl :${{ github.event.inputs.app-name }},:${{ github.event.inputs.app-name }}-docker -am -P docker
+        run: mvn install -B -pl :${{ github.event.inputs.app-name }},:${{ github.event.inputs.app-name }}-docker -am
       - name: Rename image to desired
         run: |
           image_name=$(mvn help:evaluate -f ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-docker/pom.xml -Dexpression=image.name -q -DforceStdout)

--- a/lighty-applications/lighty-rnc-app-aggregator/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/pom.xml
@@ -22,14 +22,7 @@
     <modules>
         <module>lighty-rnc-app</module>
         <module>lighty-rnc-module</module>
+        <module>lighty-rnc-app-docker</module>
     </modules>
 
-    <profiles>
-        <profile>
-            <id>docker</id>
-            <modules>
-                <module>lighty-rnc-app-docker</module>
-            </modules>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
`lighty-rnc-app-docker` artifact is included only in `docker` maven profile, which caused that it was forgotten to bump version when `maven-release-plugin`. The plugin skipped this artifact and result was that release tag contains artifact with wrong version.

This PR solve this by adding the artifact into default maven build tree, so next time when `maven-release-plugin` will proceed the versions updating, the artifact will be included in these changes.