### PR TITLE
Bump maven-resources-plugin in lighty-parent artifact

### DIFF
--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -60,7 +60,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
maven-resources-plugin from 13.1.0 to 13.2.0 in lighty-parent artifact
Signed-off-by: Ivan Caladi <ivan.caladi@pantheon.tech>