### PR TITLE
Mark lighty-codecs as deprecated 

### DIFF
--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/DataCodec.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/DataCodec.java
@@ -54,6 +54,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
+@Deprecated(forRemoval = true)
 public class DataCodec<T extends DataObject> implements Codec<T> {
 
     private static final XMLOutputFactory XML_FACTORY;

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/DeserializeIdentifierCodec.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/DeserializeIdentifierCodec.java
@@ -21,6 +21,13 @@ import org.opendaylight.yangtools.yang.model.api.ListSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.Module;
 import org.opendaylight.yangtools.yang.model.api.SchemaContext;
 
+/**
+ * Deserialize YangInstanceIdentifier.
+ *
+ * @deprecated This class can be replaced by the implementation of
+ * {@link org.opendaylight.yangtools.yang.data.util.AbstractStringInstanceIdentifierCodec}.
+ */
+@Deprecated(forRemoval = true)
 public class DeserializeIdentifierCodec {
 
     private final DataSchemaContextTree dataSchemaContextTree;

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/JsonNodeConverter.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/JsonNodeConverter.java
@@ -35,8 +35,10 @@ import org.opendaylight.yangtools.yang.model.api.SchemaNode;
  * The implementation of {@link NodeConverter} which serializes and deserializes binding independent
  * representation into/from JSON representation.
  *
+ * @deprecated This class is moved to lighty-codecs-util
  * @see XmlNodeConverter
  */
+@Deprecated(forRemoval = true)
 public class JsonNodeConverter implements NodeConverter {
 
     private final SchemaContext schemaContext;

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/SerializeIdentifierCodec.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/SerializeIdentifierCodec.java
@@ -25,6 +25,13 @@ import org.opendaylight.yangtools.yang.model.api.ListSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.Module;
 import org.opendaylight.yangtools.yang.model.api.SchemaContext;
 
+/**
+ * Serialize YangInstanceIdentifier.
+ *
+ * @deprecated This class can be replaced by the implementation of
+ * {@link org.opendaylight.yangtools.yang.data.util.AbstractStringInstanceIdentifierCodec}
+ */
+@Deprecated(forRemoval = true)
 public class SerializeIdentifierCodec {
 
     private final SchemaContext schemaContext;

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/XmlNodeConverter.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/XmlNodeConverter.java
@@ -46,8 +46,10 @@ import org.xml.sax.SAXException;
  * The implementation of {@link NodeConverter} which serializes and deserializes binding independent
  * representation into/from XML representation.
  *
+ * @deprecated This class is moved to lighty-codecs-util
  * @see JsonNodeConverter
  */
+@Deprecated(forRemoval = true)
 public class XmlNodeConverter implements NodeConverter {
 
     private static final Logger LOG = LoggerFactory.getLogger(XmlNodeConverter.class);

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Codec.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Codec.java
@@ -17,6 +17,7 @@ import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
  *
  * @param <BA> - type of Binding Aware data, RPC data or Notification data
  */
+@Deprecated(forRemoval = true)
 public interface Codec<BA extends DataObject> extends Serializer<BA>, Deserializer<BA> {
 
     /**

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/ConverterUtils.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/ConverterUtils.java
@@ -30,7 +30,10 @@ import org.xml.sax.SAXException;
 
 /**
  * A utility class which may be helpful while manipulating with binding independent nodes.
+ *
+ * @deprecated This class is moved to lighty-codecs-util
  */
+@Deprecated(forRemoval = true)
 public final class ConverterUtils {
     private ConverterUtils() {
         throw new UnsupportedOperationException("Do not create an instance of utility class");

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Deserializer.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Deserializer.java
@@ -21,6 +21,7 @@ import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
  *
  * @param <BA> Binding Aware object type data, RPC data or Notification data
  */
+@Deprecated(forRemoval = true)
 public interface Deserializer<BA extends DataObject> {
 
     /**

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/NodeConverter.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/NodeConverter.java
@@ -21,7 +21,10 @@ import org.opendaylight.yangtools.yang.model.api.SchemaNode;
  * This interface may be useful when (de)serializing {@link NormalizedNode}s (from)into its XML or
  * JSON representation. Currently there are two implementations {@link XmlNodeConverter} and
  * {@link JsonNodeConverter}.
+ *
+ * @deprecated This interface is moved to lighty-codecs-util
  */
+@Deprecated(forRemoval = true)
 public interface NodeConverter {
     /**
      * This method will serialize the given {@link NormalizedNode} into its string representation.

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/SerializationException.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/SerializationException.java
@@ -9,7 +9,10 @@ package io.lighty.codecs.api;
 
 /**
  * This exception should be thrown when serialization problem occurs.
+ *
+ * @deprecated This class is moved to lighty-codecs-util
  */
+@Deprecated(forRemoval = true)
 public class SerializationException extends Exception {
     private static final long serialVersionUID = 2053802415449540367L;
 

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Serializer.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Serializer.java
@@ -20,6 +20,7 @@ import org.opendaylight.yangtools.yang.model.api.SchemaPath;
  *
  * @param <BA>  Binding Aware object type of data, RPC data or Notification data
  */
+@Deprecated(forRemoval = true)
 public interface Serializer<BA extends DataObject> {
 
     YangInstanceIdentifier convertIdentifier(String identifier);

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/ConflictingVersionException.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/ConflictingVersionException.java
@@ -13,6 +13,7 @@ package io.lighty.codecs.xml;
  * transaction was committed after creating this transaction. Clients can create
  * new transaction and merge the changes.
  */
+@Deprecated(forRemoval = true)
 public class ConflictingVersionException extends Exception {
     private static final long serialVersionUID = 1L;
 

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/DocumentedException.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/DocumentedException.java
@@ -27,6 +27,7 @@ import org.w3c.dom.NodeList;
 /**
  * Checked exception to communicate an error that needs to be sent to the netconf client.
  */
+@Deprecated(forRemoval = true)
 public class DocumentedException extends Exception {
 
     public static final String RPC_ERROR = "rpc-error";

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/MissingNameSpaceException.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/MissingNameSpaceException.java
@@ -10,6 +10,7 @@ package io.lighty.codecs.xml;
 import java.util.Collections;
 import java.util.Map;
 
+@Deprecated(forRemoval = true)
 public class MissingNameSpaceException extends DocumentedException {
     private static final long serialVersionUID = 1L;
 

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/ModuleIdentifier.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/ModuleIdentifier.java
@@ -9,6 +9,7 @@ package io.lighty.codecs.xml;
 
 import org.opendaylight.yangtools.concepts.Identifier;
 
+@Deprecated(forRemoval = true)
 public class ModuleIdentifier implements Identifier {
     private static final long serialVersionUID = 1L;
     private final String factoryName;

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/UnexpectedElementException.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/UnexpectedElementException.java
@@ -10,6 +10,7 @@ package io.lighty.codecs.xml;
 import java.util.Collections;
 import java.util.Map;
 
+@Deprecated(forRemoval = true)
 public class UnexpectedElementException extends DocumentedException {
     private static final long serialVersionUID = 1L;
 

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/UnexpectedNamespaceException.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/UnexpectedNamespaceException.java
@@ -10,6 +10,7 @@ package io.lighty.codecs.xml;
 import java.util.Collections;
 import java.util.Map;
 
+@Deprecated(forRemoval = true)
 public class UnexpectedNamespaceException extends DocumentedException {
     private static final long serialVersionUID = 1L;
 

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/ValidationException.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/ValidationException.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+@Deprecated(forRemoval = true)
 public class ValidationException extends Exception {
     private static final long serialVersionUID = -6072893219820274247L;
 

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlElement.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlElement.java
@@ -29,6 +29,7 @@ import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
 import org.xml.sax.SAXException;
 
+@Deprecated(forRemoval = true)
 public final class XmlElement {
     public static final String DEFAULT_NAMESPACE_PREFIX = "";
 

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlMappingConstants.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlMappingConstants.java
@@ -7,6 +7,7 @@
  */
 package io.lighty.codecs.xml;
 
+@Deprecated(forRemoval = true)
 public final class XmlMappingConstants {
     public static final String RPC_REPLY_KEY = "rpc-reply";
     public static final String TYPE_KEY = "type";

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlUtil.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlUtil.java
@@ -37,6 +37,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
 
+@Deprecated(forRemoval = true)
 public final class XmlUtil {
 
     public static final String XMLNS_ATTRIBUTE_KEY = "xmlns";


### PR DESCRIPTION
All classes from lighty-codecs are marked as deprecated and for removal.
Lighty-codecs will be replaced by lighty-codecs-util.
Lighty-codecs duplicate some classes from ODL base.

Signed-off-by: Ivan Caladi <ivan.caladi@pantheon.tech>