### PR TITLE
prepare lighty-rnc-app-docker for release 13.2.1

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -39,7 +39,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Maven install + build docker image
-        run: mvn install -DskipTests -B -V -Psource-quality
+        run: mvn install -Pdocker -DskipTests -B -V -Psource-quality
       - name: Start app in docker container
         run: |
           image_name=$(mvn help:evaluate -f ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-docker/pom.xml -Dexpression=image.name -q -DforceStdout)

--- a/.github/workflows/publish-docker-helm.yml
+++ b/.github/workflows/publish-docker-helm.yml
@@ -57,7 +57,7 @@ jobs:
           DOCKER_IMAGE_NAME_TAG=$(echo $DOCKER_IMAGE_NAME:${{ github.event.inputs.image-tag }})
           echo "DOCKER_IMAGE_NAME_TAG=$(echo $DOCKER_IMAGE_NAME_TAG)" >> $GITHUB_ENV
       - name: Build docker image
-        run: mvn install -B -pl :${{ github.event.inputs.app-name }},:${{ github.event.inputs.app-name }}-docker -am
+        run: mvn install -B -pl :${{ github.event.inputs.app-name }},:${{ github.event.inputs.app-name }}-docker -am -P docker
       - name: Rename image to desired
         run: |
           image_name=$(mvn help:evaluate -f ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-docker/pom.xml -Dexpression=image.name -q -DforceStdout)

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.applications.rnc</groupId>
     <artifactId>lighty-rnc-app-docker</artifactId>
-    <version>13.2.1-SNAPSHOT</version>
+    <version>13.2.1</version>
 
     <properties>
         <image.name>lighty-rnc</image.name>

--- a/lighty-applications/lighty-rnc-app-aggregator/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/pom.xml
@@ -22,7 +22,14 @@
     <modules>
         <module>lighty-rnc-app</module>
         <module>lighty-rnc-module</module>
-        <module>lighty-rnc-app-docker</module>
     </modules>
 
+    <profiles>
+        <profile>
+            <id>docker</id>
+            <modules>
+                <module>lighty-rnc-app-docker</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
lighty-rnc-app-docker will be skipped by mvn-release-plugin, so this
 prepares the maven module for release manually

Signed-off-by: Michal Banik <michal.banik@pantheon.tech>