### PR TITLE
Revert "include rnc-polyglot-app docker artifact to default build structure"

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -39,7 +39,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Maven install + build docker image
-        run: mvn install -DskipTests -B -V -Psource-quality
+        run: mvn install -Pdocker -DskipTests -B -V -Psource-quality
       - name: Start app in docker container
         run: |
           image_name=$(mvn help:evaluate -f ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-docker/pom.xml -Dexpression=image.name -q -DforceStdout)

--- a/.github/workflows/publish-docker-helm.yml
+++ b/.github/workflows/publish-docker-helm.yml
@@ -57,7 +57,7 @@ jobs:
           DOCKER_IMAGE_NAME_TAG=$(echo $DOCKER_IMAGE_NAME:${{ github.event.inputs.image-tag }})
           echo "DOCKER_IMAGE_NAME_TAG=$(echo $DOCKER_IMAGE_NAME_TAG)" >> $GITHUB_ENV
       - name: Build docker image
-        run: mvn install -B -pl :${{ github.event.inputs.app-name }},:${{ github.event.inputs.app-name }}-docker -am
+        run: mvn install -B -pl :${{ github.event.inputs.app-name }},:${{ github.event.inputs.app-name }}-docker -am -P docker
       - name: Rename image to desired
         run: |
           image_name=$(mvn help:evaluate -f ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-docker/pom.xml -Dexpression=image.name -q -DforceStdout)

--- a/lighty-applications/lighty-rnc-app-aggregator/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/pom.xml
@@ -24,7 +24,14 @@
     <modules>
         <module>lighty-rnc-app</module>
         <module>lighty-rnc-module</module>
-        <module>lighty-rnc-app-docker</module>
     </modules>
 
+    <profiles>
+        <profile>
+            <id>docker</id>
+            <modules>
+                <module>lighty-rnc-app-docker</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
This reverts commit 1bb929e8

to do not require docker for every build, docker will be used only when `docker` profile will be activated

Signed-off-by: Michal Banik <michal.banik@pantheon.tech>