### PR TITLE
Introduce Lighty-codecs-util

### DIFF
--- a/lighty-core/lighty-codecs-util/pom.xml
+++ b/lighty-core/lighty-codecs-util/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2018 Pantheon Technologies s.r.o. All Rights Reserved.
+
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License v1.0 which accompanies this distribution,
+  and is available at https://www.eclipse.org/legal/epl-v10.html
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.lighty.core</groupId>
+        <artifactId>lighty-parent</artifactId>
+        <version>13.2.1-SNAPSHOT</version>
+        <relativePath>../lighty-parent</relativePath>
+    </parent>
+
+    <groupId>io.lighty.core</groupId>
+    <artifactId>lighty-codecs-util</artifactId>
+    <packaging>jar</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+    <url>https://github.com/PANTHEONtech/lighty</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.opendaylight.mdsal</groupId>
+            <artifactId>mdsal-binding-runtime-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opendaylight.mdsal</groupId>
+            <artifactId>mdsal-binding-generator-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opendaylight.mdsal</groupId>
+            <artifactId>mdsal-binding-dom-adapter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opendaylight.netconf</groupId>
+            <artifactId>netconf-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opendaylight.yangtools</groupId>
+            <artifactId>yang-data-codec-xml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opendaylight.yangtools</groupId>
+            <artifactId>yang-data-codec-gson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opendaylight.netconf</groupId>
+            <artifactId>restconf-common</artifactId>
+        </dependency>
+
+        <!-- Test scoped dependencies -->
+        <dependency>
+            <groupId>io.lighty.models.test</groupId>
+            <artifactId>lighty-test-models</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.lighty.models.test</groupId>
+            <artifactId>lighty-toaster</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.opendaylight.netconf</groupId>
+            <artifactId>ietf-netconf</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.opendaylight.netconf</groupId>
+            <artifactId>ietf-restconf</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <failOnError>false</failOnError>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/lighty-core/lighty-codecs-util/pom.xml
+++ b/lighty-core/lighty-codecs-util/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2018 Pantheon Technologies s.r.o. All Rights Reserved.
+  Copyright (c) 2021 Pantheon Technologies s.r.o. All Rights Reserved.
 
   This program and the accompanying materials are made available under the
   terms of the Eclipse Public License v1.0 which accompanies this distribution,
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.2.1-SNAPSHOT</version>
+        <version>14.0.0-SNAPSHOT</version>
         <relativePath>../lighty-parent</relativePath>
     </parent>
 
@@ -56,8 +56,6 @@
             <groupId>org.opendaylight.netconf</groupId>
             <artifactId>restconf-common</artifactId>
         </dependency>
-
-        <!-- Test scoped dependencies -->
         <dependency>
             <groupId>io.lighty.models.test</groupId>
             <artifactId>lighty-test-models</artifactId>
@@ -66,7 +64,6 @@
             <groupId>io.lighty.models.test</groupId>
             <artifactId>lighty-toaster</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -76,6 +73,7 @@
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>
 
+        <!-- Test scoped dependencies -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -92,24 +90,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <failOnError>false</failOnError>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/ConverterUtils.java
+++ b/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/ConverterUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Pantheon Technologies s.r.o. All Rights Reserved.
+ * Copyright (c) 2021 Pantheon Technologies s.r.o. All Rights Reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/ConverterUtils.java
+++ b/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/ConverterUtils.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2018 Pantheon Technologies s.r.o. All Rights Reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ */
+package io.lighty.codecs.util;
+
+import com.google.common.base.Strings;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.opendaylight.netconf.api.DocumentedException;
+import org.opendaylight.netconf.api.xml.XmlElement;
+import org.opendaylight.netconf.api.xml.XmlUtil;
+import org.opendaylight.yangtools.yang.common.QName;
+import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier;
+import org.opendaylight.yangtools.yang.data.util.DataSchemaContextTree;
+import org.opendaylight.yangtools.yang.model.api.Module;
+import org.opendaylight.yangtools.yang.model.api.NotificationDefinition;
+import org.opendaylight.yangtools.yang.model.api.RpcDefinition;
+import org.opendaylight.yangtools.yang.model.api.SchemaContext;
+import org.opendaylight.yangtools.yang.model.api.SchemaNode;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+
+/**
+ * A utility class which may be helpful while manipulating with binding independent nodes.
+ */
+public final class ConverterUtils {
+    private ConverterUtils() {
+        throw new UnsupportedOperationException("Do not create an instance of utility class");
+    }
+
+    /**
+     * Returns the {@link RpcDefinition} from the given {@link SchemaContext} and given {@link QName}.
+     * The {@link QName} of a rpc can be constructed via
+     *
+     * <p>
+     * {@code
+     *  QName.create("http://netconfcentral.org/ns/toaster", "2009-11-20", "make-toast");
+     * } , where {@code "make-toast"} is the name of the RPC given in the yang model.
+     *
+     * <p>
+     * If the given RPC was found in the {@link SchemaContext} the {@link RpcDefinition} will be present
+     *
+     * @see QName
+     * @param schemaContext the schema context used for the RPC resolution
+     * @param rpcQName {@link QName} of the RPC
+     * @return {@link Optional} representation of the {@link RpcDefinition}
+     */
+    public static Optional<? extends RpcDefinition> loadRpc(final SchemaContext schemaContext, final QName rpcQName) {
+        Optional<Module> findModule = findModule(schemaContext, rpcQName);
+        if (!findModule.isPresent()) {
+            return Optional.empty();
+        }
+        return findDefinition(rpcQName, findModule.get().getRpcs());
+    }
+
+    /**
+     * Utility method to extract the {@link SchemaNode} for the given Notification.
+     *
+     * @param schemaContext to be used
+     * @param notificationQname yang RPC name
+     * @return {@link Optional} of {@link SchemaNode}
+     */
+    public static Optional<? extends NotificationDefinition> loadNotification(final SchemaContext schemaContext,
+            final QName notificationQname) {
+        Optional<Module> findModule = findModule(schemaContext, notificationQname);
+        if (!findModule.isPresent()) {
+            return Optional.empty();
+        }
+        return findDefinition(notificationQname, findModule.get().getNotifications());
+    }
+
+    /**
+     * This method extracts from the given {@link XmlElement} the name and namespace from the first
+     * element and creates a {@link QName}.
+     *
+     * @param xmlElement input data.
+     * @return {@link QName} for input data or empty.
+     */
+    public static Optional<QName> getRpcQName(final XmlElement xmlElement) {
+        Optional<String> optionalNamespace = xmlElement.getNamespaceOptionally();
+        String name = xmlElement.getName();
+        if (Strings.isNullOrEmpty(name)) {
+            return Optional.empty();
+        }
+        String revision = null;
+        String namespace;
+        if (optionalNamespace.isPresent() && !Strings.isNullOrEmpty(optionalNamespace.get())) {
+            String[] split = optionalNamespace.get().split("\\?");
+            if (split.length > 1 && split[1].contains("revision=")) {
+                revision = split[1].replace("revision=", "");
+
+            }
+            namespace = split[0];
+        } else {
+            return Optional.of(QName.create(name));
+        }
+        if (Strings.isNullOrEmpty(revision)) {
+            return Optional.of(QName.create(namespace, name));
+        } else {
+            return Optional.of(QName.create(namespace, revision, name));
+        }
+    }
+
+    /**
+     * Create RPC QName.
+     *
+     * @param inputString RPC name
+     * @return {@link QName} for RPC name or empty.
+     * @throws IllegalArgumentException if there was a problem during parsing the XML document
+     * @see ConverterUtils#getRpcQName(XmlElement)
+     */
+    public static Optional<QName> getRpcQName(final String inputString) {
+        try {
+            return getRpcQName(XmlElement.fromString(inputString));
+        } catch (DocumentedException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public static XmlElement rpcAsInput(final XmlElement inputXmlElement) {
+        return rpcAsInput(inputXmlElement, "");
+    }
+
+    /**
+     * Removes the first XML tag and replaces it with an {@code <input>} element. This method may be
+     * useful when converting the input of a rpc. The provided namespace will be used for the input tag
+     * document.
+     *
+     * @param inputXmlElement input xml data to wrap.
+     * @param namespace namespace
+     * @return wrapped xml data.
+     */
+    public static XmlElement rpcAsInput(final XmlElement inputXmlElement, final String namespace) {
+        return wrapNodes("input", namespace, inputXmlElement.getChildElements());
+    }
+
+    /**
+     * Calls the method {@link ConverterUtils#rpcAsOutput(XmlElement, String)} with an empty namespace.
+     *
+     * @see ConverterUtils#rpcAsOutput(XmlElement, String)
+     * @see XmlUtil
+     * @param inputXmlElement input rpc element data.
+     * @return wrapped xml element.
+     */
+    public static XmlElement rpcAsOutput(final XmlElement inputXmlElement) {
+        return rpcAsOutput(inputXmlElement, "");
+    }
+
+    /**
+     * Removes the first XML tag and replaces it with an {@code <output>} element. This method may be
+     * useful when the output rpc is created. The namespace will be used for the output tag.
+     *
+     * @see XmlUtil
+     * @param inputXmlElement input rpc element data.
+     * @param namespace namespace
+     * @return wrapped xml element.
+     */
+    public static XmlElement rpcAsOutput(final XmlElement inputXmlElement, final String namespace) {
+        return wrapNodes("output", namespace, inputXmlElement.getChildElements());
+    }
+
+    /**
+     * Creates an instance of {@link SchemaNode} for the given {@link QName} in the given {@link SchemaContext}.
+     *
+     * @see ConverterUtils#getSchemaNode(SchemaContext, String, String, String)
+     * @param schemaContext the given schema context which contains the {@link QName}
+     * @param qname the given {@link QName}
+     * @return instance of {@link SchemaNode}
+     */
+    public static SchemaNode getSchemaNode(final SchemaContext schemaContext, final QName qname) {
+        return DataSchemaContextTree.from(schemaContext).getChild(YangInstanceIdentifier.of(qname)).getDataSchemaNode();
+    }
+
+    public static SchemaNode getSchemaNode(final SchemaContext schemaContext,
+            final YangInstanceIdentifier yangInstanceIdentifier) {
+        return DataSchemaContextTree.from(schemaContext).getChild(yangInstanceIdentifier).getDataSchemaNode();
+    }
+
+    /**
+     * Creates an instance of {@link SchemaNode} for the given namespace, revision and localname. The
+     * namespace, revision and localname are used to construct the {@link QName} which must exist in the
+     * {@link SchemaContext}.
+     *
+     * @see ConverterUtils#getSchemaNode(SchemaContext, QName)
+     * @param schemaContext given schema context
+     * @param namespace {@link QName} namespace
+     * @param revision {@link QName} revision
+     * @param localName {@link QName} localname
+     * @return instance of {@link SchemaNode}
+     */
+    public static SchemaNode getSchemaNode(final SchemaContext schemaContext, final String namespace,
+            final String revision, final String localName) {
+        QName qname = QName.create(namespace, revision, localName);
+        return DataSchemaContextTree.from(schemaContext).getChild(YangInstanceIdentifier.of(qname)).getDataSchemaNode();
+    }
+
+    /**
+     * Appends all nodes given as children into a node given by node name with given namespace.
+     *
+     * @param nodeName the top level node
+     * @param namespace provided namespace for the nodename
+     * @param children child elements to be appended
+     * @return created {@link XmlElement}
+     * @see XmlUtil
+     */
+    private static XmlElement wrapNodes(final String nodeName, final String namespace,
+            final Collection<XmlElement> children) {
+        StringBuilder sb = new StringBuilder("<").append(nodeName).append(" xmlns=\"").append(namespace).append("\"/>");
+        Document document;
+        try {
+            document = XmlUtil.readXmlToDocument(sb.toString());
+        } catch (SAXException | IOException e) {
+            // should never happen
+            throw new IllegalStateException(e);
+        }
+        children.forEach(child -> {
+            Node importedNode = document.importNode(child.getDomElement(), true);
+            document.getChildNodes().item(0).appendChild(importedNode);
+        });
+        return XmlElement.fromDomDocument(document);
+    }
+
+    private static Optional<Module> findModule(final SchemaContext schemaContext, final QName qname) {
+        if (qname.getRevision().isPresent()) {
+            return schemaContext.findModule(qname.getNamespace(), qname.getRevision());
+        }
+
+        Collection<? extends Module> moduleByNamespace = schemaContext.findModules(qname.getNamespace());
+        return Optional.ofNullable(moduleByNamespace.isEmpty() || moduleByNamespace.size() > 1 ? null
+                : moduleByNamespace.iterator().next());
+    }
+
+    private static <T extends SchemaNode> Optional<T> findDefinition(final QName qname, final Collection<T> nodes) {
+        List<T> foundNodes = nodes.stream().filter(node -> node.getQName().getLocalName().equals(qname.getLocalName()))
+                .collect(Collectors.toList());
+        return Optional.ofNullable(foundNodes.isEmpty() || foundNodes.size() > 1 ? null : foundNodes.get(0));
+    }
+}

--- a/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/ConverterUtils.java
+++ b/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/ConverterUtils.java
@@ -176,12 +176,14 @@ public final class ConverterUtils {
      * @return instance of {@link SchemaNode}
      */
     public static SchemaNode getSchemaNode(final SchemaContext schemaContext, final QName qname) {
-        return DataSchemaContextTree.from(schemaContext).getChild(YangInstanceIdentifier.of(qname)).getDataSchemaNode();
+        return DataSchemaContextTree.from(schemaContext)
+                .findChild(YangInstanceIdentifier.of(qname)).orElseThrow().getDataSchemaNode();
     }
 
     public static SchemaNode getSchemaNode(final SchemaContext schemaContext,
             final YangInstanceIdentifier yangInstanceIdentifier) {
-        return DataSchemaContextTree.from(schemaContext).getChild(yangInstanceIdentifier).getDataSchemaNode();
+        return DataSchemaContextTree.from(schemaContext)
+                .findChild(yangInstanceIdentifier).orElseThrow().getDataSchemaNode();
     }
 
     /**
@@ -199,7 +201,8 @@ public final class ConverterUtils {
     public static SchemaNode getSchemaNode(final SchemaContext schemaContext, final String namespace,
             final String revision, final String localName) {
         QName qname = QName.create(namespace, revision, localName);
-        return DataSchemaContextTree.from(schemaContext).getChild(YangInstanceIdentifier.of(qname)).getDataSchemaNode();
+        return DataSchemaContextTree.from(schemaContext)
+                .findChild(YangInstanceIdentifier.of(qname)).orElseThrow().getDataSchemaNode();
     }
 
     /**
@@ -241,6 +244,6 @@ public final class ConverterUtils {
     private static <T extends SchemaNode> Optional<T> findDefinition(final QName qname, final Collection<T> nodes) {
         List<T> foundNodes = nodes.stream().filter(node -> node.getQName().getLocalName().equals(qname.getLocalName()))
                 .collect(Collectors.toList());
-        return Optional.ofNullable(foundNodes.isEmpty() || foundNodes.size() > 1 ? null : foundNodes.get(0));
+        return Optional.ofNullable(foundNodes.size() != 1 ? null : foundNodes.get(0));
     }
 }

--- a/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/JsonNodeConverter.java
+++ b/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/JsonNodeConverter.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2018 Pantheon Technologies s.r.o. All Rights Reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ */
+package io.lighty.codecs.util;
+
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.net.URI;
+import org.opendaylight.yangtools.yang.common.QName;
+import org.opendaylight.yangtools.yang.data.api.schema.ContainerNode;
+import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
+import org.opendaylight.yangtools.yang.data.api.schema.stream.NormalizedNodeStreamWriter;
+import org.opendaylight.yangtools.yang.data.api.schema.stream.NormalizedNodeWriter;
+import org.opendaylight.yangtools.yang.data.codec.gson.JSONCodecFactory;
+import org.opendaylight.yangtools.yang.data.codec.gson.JSONCodecFactorySupplier;
+import org.opendaylight.yangtools.yang.data.codec.gson.JSONNormalizedNodeStreamWriter;
+import org.opendaylight.yangtools.yang.data.codec.gson.JsonParserStream;
+import org.opendaylight.yangtools.yang.data.impl.schema.ImmutableNormalizedNodeStreamWriter;
+import org.opendaylight.yangtools.yang.data.impl.schema.NormalizedNodeResult;
+import org.opendaylight.yangtools.yang.model.api.SchemaContext;
+import org.opendaylight.yangtools.yang.model.api.SchemaNode;
+
+/**
+ * The implementation of {@link NodeConverter} which serializes and deserializes binding independent
+ * representation into/from JSON representation.
+ *
+ * @see XmlNodeConverter
+ */
+public class JsonNodeConverter implements NodeConverter {
+
+    private final SchemaContext schemaContext;
+
+    /**
+     * The only available constructor.
+     *
+     * @param schemaContext to be used
+     */
+    public JsonNodeConverter(final SchemaContext schemaContext) {
+        this.schemaContext = schemaContext;
+    }
+
+    /**
+     * This method serializes the provided {@link NormalizedNode} into its JSON representation.
+     *
+     * @param schemaNode {@link SchemaNode} may be obtained via
+     *        {@link ConverterUtils#getSchemaNode(SchemaContext, QName)} or
+     *        {@link ConverterUtils#getSchemaNode(SchemaContext, String, String, String)}
+     * @param normalizedNode {@link NormalizedNode} to be serialized
+     * @return string representation of JSON serialized data is returned via {@link StringWriter}
+     * @throws SerializationException if there was a problem during writing JSON data
+     */
+    @Override
+    public Writer serializeData(final SchemaNode schemaNode, final NormalizedNode<?, ?> normalizedNode)
+            throws SerializationException {
+        Writer writer = new StringWriter();
+        JsonWriter jsonWriter = new JsonWriter(writer);
+        JSONCodecFactory jsonCodecFactory =
+                JSONCodecFactorySupplier.DRAFT_LHOTKA_NETMOD_YANG_JSON_02.createLazy(this.schemaContext);
+        URI namespace = schemaNode.getQName().getNamespace();
+        NormalizedNodeStreamWriter create = JSONNormalizedNodeStreamWriter.createExclusiveWriter(jsonCodecFactory,
+                schemaNode.getPath(), namespace, jsonWriter);
+        try (NormalizedNodeWriter normalizedNodeWriter = NormalizedNodeWriter.forStreamWriter(create)) {
+            normalizedNodeWriter.write(normalizedNode);
+            jsonWriter.flush();
+        } catch (IOException ioe) {
+            throw new SerializationException(ioe);
+        }
+        return writer;
+    }
+
+    /**
+     * This method serializes the {@link NormalizedNode} which represents the input or output of an RPC.
+     *
+     * @param schemaNode the input or output {@link SchemaNode} of the RPC
+     * @param normalizedNode serialized binding independent data
+     * @return JSON string representation of the given {@link NormalizedNode}
+     * @throws SerializationException if an {@link IOException} occurs during serialization
+     */
+    @Override
+    public Writer serializeRpc(final SchemaNode schemaNode, final NormalizedNode<?, ?> normalizedNode)
+            throws SerializationException {
+        Writer writer = new StringWriter();
+        JsonWriter jsonWriter = new JsonWriter(writer);
+        JSONCodecFactory jsonCodecFactory =
+                JSONCodecFactorySupplier.DRAFT_LHOTKA_NETMOD_YANG_JSON_02.createLazy(this.schemaContext);
+        String localName = schemaNode.getQName().getLocalName();
+        URI namespace = schemaNode.getQName().getNamespace();
+        NormalizedNodeStreamWriter create = JSONNormalizedNodeStreamWriter.createExclusiveWriter(jsonCodecFactory,
+                schemaNode.getPath(), namespace, jsonWriter);
+        try (NormalizedNodeWriter normalizedNodeWriter = NormalizedNodeWriter.forStreamWriter(create)) {
+            jsonWriter.beginObject().name(localName);
+            for (NormalizedNode<?, ?> child : ((ContainerNode) normalizedNode).getValue()) {
+                normalizedNodeWriter.write(child);
+            }
+            // XXX dirty check for end of object. When serializing RPCs with input/output which is not a
+            // container
+            // the object is not closed.
+            if (!writer.toString().endsWith("}")) {
+                jsonWriter.endObject();
+            }
+        } catch (IOException ioe) {
+            throw new SerializationException(ioe);
+        }
+        return writer;
+    }
+
+    /**
+     * Deserializes the given JSON representation into {@link NormalizedNode}s.
+     *
+     * @param schemaNode a correct {@link SchemaNode} may be obtained via
+     *        {@link ConverterUtils#getSchemaNode(SchemaContext, QName)} or
+     *        {@link ConverterUtils#getSchemaNode(SchemaContext, String, String, String)} or
+     *        {@link ConverterUtils#loadRpc(SchemaContext, QName)} depending on the input/output
+     * @param inputData reader containing input data.
+     * @return {@link NormalizedNode} representation of input data
+     * @throws SerializationException if there was a problem during deserialization or reading the input
+     *         data
+     */
+    @Override
+    public NormalizedNode<?, ?> deserialize(final SchemaNode schemaNode, final Reader inputData)
+            throws SerializationException {
+        NormalizedNodeResult result = new NormalizedNodeResult();
+        JSONCodecFactory jsonCodecFactory =
+                JSONCodecFactorySupplier.DRAFT_LHOTKA_NETMOD_YANG_JSON_02.createLazy(schemaContext);
+        try (JsonReader reader = new JsonReader(inputData);
+                NormalizedNodeStreamWriter streamWriter = ImmutableNormalizedNodeStreamWriter.from(result);
+
+                JsonParserStream jsonParser = JsonParserStream.create(streamWriter, jsonCodecFactory, schemaNode)) {
+            jsonParser.parse(reader);
+        } catch (IOException e) {
+            throw new SerializationException(e);
+        }
+        return result.getResult();
+    }
+}

--- a/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/JsonNodeConverter.java
+++ b/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/JsonNodeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Pantheon Technologies s.r.o. All Rights Reserved.
+ * Copyright (c) 2021 Pantheon Technologies s.r.o. All Rights Reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution,
@@ -39,9 +39,10 @@ public class JsonNodeConverter implements NodeConverter {
     private final SchemaContext schemaContext;
 
     /**
-     * The only available constructor.
+     * The only constructor will create an instance of {@link JsonNodeConverter} with the given
+     * {@link SchemaContext}. This schema context will be used for proper RPC and Node resolution
      *
-     * @param schemaContext to be used
+     * @param schemaContext initial schema context
      */
     public JsonNodeConverter(final SchemaContext schemaContext) {
         this.schemaContext = schemaContext;

--- a/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/NodeConverter.java
+++ b/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/NodeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Pantheon Technologies s.r.o. All Rights Reserved.
+ * Copyright (c) 2021 Pantheon Technologies s.r.o. All Rights Reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/NodeConverter.java
+++ b/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/NodeConverter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2018 Pantheon Technologies s.r.o. All Rights Reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ */
+package io.lighty.codecs.util;
+
+import java.io.Reader;
+import java.io.Writer;
+import org.opendaylight.netconf.api.xml.XmlElement;
+import org.opendaylight.yangtools.yang.common.QName;
+import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
+import org.opendaylight.yangtools.yang.model.api.SchemaContext;
+import org.opendaylight.yangtools.yang.model.api.SchemaNode;
+
+/**
+ * This interface may be useful when (de)serializing {@link NormalizedNode}s (from)into its XML or
+ * JSON representation. Currently there are two implementations {@link XmlNodeConverter} and
+ * {@link JsonNodeConverter}.
+ */
+public interface NodeConverter {
+    /**
+     * This method will serialize the given {@link NormalizedNode} into its string representation.
+     *
+     * @see ConverterUtils#getSchemaNode(SchemaContext, QName)
+     * @param schemaNode parent schema node used during serialization
+     * @param normalizedNode normalized nodes to be serialized
+     * @return {@link Writer}
+     * @throws SerializationException may be throws while serializing data
+     */
+    Writer serializeData(SchemaNode schemaNode, NormalizedNode<?, ?> normalizedNode) throws SerializationException;
+
+    /**
+     * This method will serialize the input {@link NormalizedNode} RPC into its string representation. It
+     * is highly recommend to use {@link ConverterUtils#loadRpc(SchemaContext, QName)} and proper
+     * input/output definition as the schemaNode parameter.
+     *
+     * @see ConverterUtils#rpcAsInput(XmlElement)
+     * @see ConverterUtils#rpcAsOutput(XmlElement)
+     * @see ConverterUtils#getRpcQName(XmlElement)
+     * @param schemaNode parent schema node which may be obtained via
+     *        {@link ConverterUtils#loadRpc(SchemaContext, QName)} and input/output definition
+     * @param normalizedNode normalized nodes to be serialized
+     * @return string representation of the given nodes starting with input or output tag
+     * @throws SerializationException thrown in case serialization fails.
+     */
+    Writer serializeRpc(SchemaNode schemaNode, NormalizedNode<?, ?> normalizedNode) throws SerializationException;
+
+    /**
+     * This method will deserialize the given input data into {@link NormalizedNode}s. In case of RPC
+     * input/output use proper parent schema node obtained via
+     * {@link ConverterUtils#loadRpc(SchemaContext, QName)}.
+     *
+     * @see ConverterUtils#loadRpc(SchemaContext, QName)
+     * @see ConverterUtils#rpcAsInput(XmlElement)
+     * @see ConverterUtils#rpcAsOutput(XmlElement)
+     * @param schemaNode parent schema node
+     * @param inputData string representation of input/output RPC or data. In case of RPC the inputData
+     *        <b>MUST</b> start with input tag (in case of XML) and object (in case of JSON). The same
+     *        goes for RPC output
+     * @return deserialized {@link NormalizedNode}s
+     * @throws SerializationException is thrown in case of an error during deserialization
+     */
+    NormalizedNode<?, ?> deserialize(SchemaNode schemaNode, Reader inputData) throws SerializationException;
+}

--- a/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/SerializationException.java
+++ b/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/SerializationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Pantheon Technologies s.r.o. All Rights Reserved.
+ * Copyright (c) 2021 Pantheon Technologies s.r.o. All Rights Reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/SerializationException.java
+++ b/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/SerializationException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018 Pantheon Technologies s.r.o. All Rights Reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ */
+package io.lighty.codecs.util;
+
+/**
+ * This exception should be thrown when serialization problem occurs.
+ */
+public class SerializationException extends Exception {
+    private static final long serialVersionUID = 2053802415449540367L;
+
+    public SerializationException(final Throwable cause) {
+        super(cause);
+    }
+
+    public SerializationException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/XmlNodeConverter.java
+++ b/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/XmlNodeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Pantheon Technologies s.r.o. All Rights Reserved.
+ * Copyright (c) 2021 Pantheon Technologies s.r.o. All Rights Reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/XmlNodeConverter.java
+++ b/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/XmlNodeConverter.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2018 Pantheon Technologies s.r.o. All Rights Reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ */
+package io.lighty.codecs.util;
+
+import com.google.common.io.Closeables;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.FactoryConfigurationError;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.XMLStreamWriter;
+import org.opendaylight.yangtools.yang.common.QName;
+import org.opendaylight.yangtools.yang.data.api.schema.ContainerNode;
+import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
+import org.opendaylight.yangtools.yang.data.api.schema.stream.NormalizedNodeStreamWriter;
+import org.opendaylight.yangtools.yang.data.api.schema.stream.NormalizedNodeWriter;
+import org.opendaylight.yangtools.yang.data.codec.xml.XMLStreamNormalizedNodeStreamWriter;
+import org.opendaylight.yangtools.yang.data.codec.xml.XmlParserStream;
+import org.opendaylight.yangtools.yang.data.impl.schema.ImmutableNormalizedNodeStreamWriter;
+import org.opendaylight.yangtools.yang.data.impl.schema.NormalizedNodeResult;
+import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
+import org.opendaylight.yangtools.yang.model.api.SchemaContext;
+import org.opendaylight.yangtools.yang.model.api.SchemaNode;
+import org.opendaylight.yangtools.yang.model.api.SchemaPath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
+
+/**
+ * The implementation of {@link NodeConverter} which serializes and deserializes binding independent
+ * representation into/from XML representation.
+ *
+ * @see JsonNodeConverter
+ */
+public class XmlNodeConverter implements NodeConverter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(XmlNodeConverter.class);
+
+    private static final XMLInputFactory XML_IN_FACTORY;
+    private static final XMLOutputFactory XML_OUT_FACTORY;
+
+    static {
+        XML_IN_FACTORY = XMLInputFactory.newInstance();
+        XML_OUT_FACTORY = XMLOutputFactory.newFactory();
+        XML_OUT_FACTORY.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, true);
+    }
+
+    private final EffectiveModelContext effectiveModelContext;
+
+    /**
+     * The only constructor will create an instance of {@link XmlNodeConverter} with the given
+     * {@link SchemaContext}. This schema context will be used for proper RPC and Node resolution
+     *
+     * @param effectiveModelContext initial schema context
+     */
+    public XmlNodeConverter(final EffectiveModelContext effectiveModelContext) {
+        this.effectiveModelContext = effectiveModelContext;
+    }
+
+    /**
+     * This method serializes the given {@link NormalizedNode} into its XML string representation.
+     *
+     * @see NodeConverter#serializeData(SchemaNode, NormalizedNode)
+     *
+     * @param schemaNode the parent schema node where the nodes exist
+     * @param normalizedNode {@link NormalizedNode} to be serialized
+     * @return {@link StringWriter} implementation of {@link Writer} is returned
+     * @throws SerializationException if it was not possible to serialize the normalized nodes into XML
+     */
+    @Override
+    public Writer serializeData(final SchemaNode schemaNode, final NormalizedNode<?, ?> normalizedNode)
+            throws SerializationException {
+        Writer writer = new StringWriter();
+        try (NormalizedNodeWriter normalizedNodeWriter =
+                createNormalizedNodeWriter(effectiveModelContext, writer, schemaNode.getPath())) {
+            normalizedNodeWriter.write(normalizedNode);
+            normalizedNodeWriter.flush();
+        } catch (IOException ioe) {
+            throw new SerializationException(ioe);
+        }
+        return writer;
+    }
+
+    /**
+     * This method serializes the input or output of a RPC given as {@link NormalizedNode}
+     * representation into XML string representation.
+     *
+     * <p>
+     * To obtain correct {@link SchemaNode} use {@link ConverterUtils#loadRpc(SchemaContext, QName)} method.
+     *
+     * @param schemaNode input or output {@link SchemaNode}
+     * @param normalizedNode {@link NormalizedNode} representation of input or output
+     * @return XML string representation of provided BI nodes. It utilizes the {@link StringWriter}
+     * @throws SerializationException may be thrown if there was a problem during serialization
+     */
+    @Override
+    public Writer serializeRpc(final SchemaNode schemaNode, final NormalizedNode<?, ?> normalizedNode)
+            throws SerializationException {
+        Writer writer = new StringWriter();
+        XMLStreamWriter xmlStreamWriter = createXmlStreamWriter(writer);
+        URI namespace = schemaNode.getQName().getNamespace();
+        String localName = schemaNode.getQName().getLocalName();
+        try (NormalizedNodeWriter normalizedNodeWriter =
+                createNormalizedNodeWriter(effectiveModelContext, xmlStreamWriter, schemaNode.getPath())) {
+            // the localName may be "input" or "output" - this may be changed
+            xmlStreamWriter.writeStartElement(XMLConstants.DEFAULT_NS_PREFIX, localName, namespace.toString());
+            xmlStreamWriter.writeDefaultNamespace(namespace.toString());
+            for (NormalizedNode<?, ?> child : ((ContainerNode) normalizedNode).getValue()) {
+                normalizedNodeWriter.write(child);
+            }
+            normalizedNodeWriter.flush();
+            xmlStreamWriter.writeEndElement();
+            xmlStreamWriter.flush();
+        } catch (IOException | XMLStreamException ioe) {
+            throw new SerializationException(ioe);
+        }
+        return writer;
+    }
+
+    /**
+     * This method deserializes the provided XML string representation (via {@link Reader}) interface
+     * into {@link NormalizedNode}s. During deserialization of RPC input and output a proper
+     * {@link SchemaNode} (given for input or output) must be passed. This may be obtained via
+     * {@link ConverterUtils#loadRpc(SchemaContext, QName)}.
+     *
+     * @param schemaNode parent schema node which contains information about the input data
+     * @param inputData XML input
+     * @return an {@link Optional} representation of {@link NormalizedNode}. If the deserialization
+     *         process finished incorrectly an empty value will be present
+     * @throws SerializationException if it was not possible to deserialize the input data
+     * @throws IllegalArgumentException if a problem occurs during reading the input
+     */
+    @Override
+    public NormalizedNode<?, ?> deserialize(final SchemaNode schemaNode, final Reader inputData)
+            throws SerializationException {
+        final XMLStreamReader reader;
+        try {
+            reader = XML_IN_FACTORY.createXMLStreamReader(inputData);
+        } catch (XMLStreamException e) {
+            throw new IllegalArgumentException(e);
+        }
+        final NormalizedNodeResult result = new NormalizedNodeResult();
+        try (NormalizedNodeStreamWriter streamWriter = ImmutableNormalizedNodeStreamWriter.from(result);
+                XmlParserStream xmlParser = XmlParserStream.create(streamWriter, this.effectiveModelContext,
+                        schemaNode)) {
+            xmlParser.parse(reader);
+        } catch (XMLStreamException | URISyntaxException | IOException | SAXException e) {
+            throw new SerializationException(e);
+        } finally {
+            closeQuietly(reader);
+        }
+        return result.getResult();
+    }
+
+    /**
+     * Utility method to obtain an instance of {@link NormalizedNodeWriter} by using the {@link Writer}.
+     */
+    private static NormalizedNodeWriter createNormalizedNodeWriter(final SchemaContext schemaContext,
+            final Writer backingWriter, final SchemaPath pathToParent) {
+        XMLStreamWriter createXMLStreamWriter = createXmlStreamWriter(backingWriter);
+        return createNormalizedNodeWriter(schemaContext, createXMLStreamWriter, pathToParent);
+    }
+
+    /**
+     * Create a new {@link NormalizedNodeWriter}.
+     *
+     * @see XMLStreamNormalizedNodeStreamWriter#create(XMLStreamWriter, SchemaContext)
+     * @see XMLStreamNormalizedNodeStreamWriter#create(XMLStreamWriter, SchemaContext, SchemaPath)
+     *
+     * @param schemaContext the root schema context
+     * @param backingWriter used backing writer
+     * @param pathToParent path to parent, may be the same as {@link SchemaContext} param
+     * @return a new instance of {@link NormalizedNodeWriter}
+     */
+    private static NormalizedNodeWriter createNormalizedNodeWriter(final SchemaContext schemaContext,
+            final XMLStreamWriter backingWriter, final SchemaPath pathToParent) {
+        NormalizedNodeStreamWriter streamWriter;
+        if (pathToParent == null) {
+            streamWriter = XMLStreamNormalizedNodeStreamWriter.create(backingWriter, schemaContext);
+        } else {
+            streamWriter = XMLStreamNormalizedNodeStreamWriter.create(backingWriter, schemaContext, pathToParent);
+        }
+        return NormalizedNodeWriter.forStreamWriter(streamWriter);
+    }
+
+    /**
+     * Utility method which returns a new instance of {@link XMLStreamWriter} obtained via
+     * {@link XmlNodeConverter#XML_OUT_FACTORY}. This factory is namespace aware by default.
+     *
+     * @param backingWriter backing {@link Writer}
+     * @return a fresh instance of {@link XMLStreamWriter}
+     * @throws IllegalStateException if it's not possible to obtain the instance
+     */
+    private static XMLStreamWriter createXmlStreamWriter(final Writer backingWriter) {
+        XMLStreamWriter xmlStreamWriter;
+        try {
+            xmlStreamWriter = XML_OUT_FACTORY.createXMLStreamWriter(backingWriter);
+        } catch (XMLStreamException | FactoryConfigurationError e) {
+            throw new IllegalStateException(e);
+        }
+        return xmlStreamWriter;
+    }
+
+    /**
+     * This method is similar to the {@link Closeables#closeQuietly(Reader)} or other 'closeQuietly
+     * methods. It takes the {@link XMLStreamReader} as parameter checks for null and tries to close it
+     * while consuming the {@link IOException}. If the {@link IOException} occurs it will be logged.
+     *
+     * @param xmlStreamReader the given {@link XMLStreamReader} may be null
+     */
+    public static void closeQuietly(final XMLStreamReader xmlStreamReader) {
+        if (xmlStreamReader != null) {
+            try {
+                xmlStreamReader.close();
+            } catch (XMLStreamException e) {
+                LOG.warn("Failed to close stream", e);
+            }
+        }
+    }
+}

--- a/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/AbstractCodecTest.java
+++ b/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/AbstractCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Pantheon Technologies s.r.o. All Rights Reserved.
+ * Copyright (c) 2021 Pantheon Technologies s.r.o. All Rights Reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/AbstractCodecTest.java
+++ b/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/AbstractCodecTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2018 Pantheon Technologies s.r.o. All Rights Reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ */
+package io.lighty.codecs.util;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ServiceLoader;
+import org.opendaylight.binding.runtime.api.BindingRuntimeGenerator;
+import org.opendaylight.binding.runtime.api.DefaultBindingRuntimeContext;
+import org.opendaylight.binding.runtime.spi.ModuleInfoBackedContext;
+import org.opendaylight.mdsal.binding.dom.codec.impl.BindingCodecContext;
+import org.opendaylight.mdsal.binding.generator.impl.DefaultBindingRuntimeGenerator;
+import org.opendaylight.yang.gen.v1.http.netconfcentral.org.ns.toaster.rev091120.DisplayString;
+import org.opendaylight.yang.gen.v1.http.netconfcentral.org.ns.toaster.rev091120.MakeToastInput;
+import org.opendaylight.yang.gen.v1.http.netconfcentral.org.ns.toaster.rev091120.MakeToastInputBuilder;
+import org.opendaylight.yang.gen.v1.http.netconfcentral.org.ns.toaster.rev091120.Toaster;
+import org.opendaylight.yang.gen.v1.http.netconfcentral.org.ns.toaster.rev091120.Toaster.ToasterStatus;
+import org.opendaylight.yang.gen.v1.http.netconfcentral.org.ns.toaster.rev091120.ToasterBuilder;
+import org.opendaylight.yang.gen.v1.http.pantheon.tech.ns.test.models.rev180119.SampleList;
+import org.opendaylight.yangtools.yang.binding.YangModelBindingProvider;
+import org.opendaylight.yangtools.yang.binding.YangModuleInfo;
+import org.opendaylight.yangtools.yang.common.QName;
+import org.opendaylight.yangtools.yang.common.Uint32;
+import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier;
+import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier.NodeIdentifier;
+import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier.NodeIdentifierWithPredicates;
+import org.opendaylight.yangtools.yang.data.api.schema.ContainerNode;
+import org.opendaylight.yangtools.yang.data.api.schema.LeafNode;
+import org.opendaylight.yangtools.yang.data.api.schema.MapEntryNode;
+import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
+import org.opendaylight.yangtools.yang.data.impl.schema.builder.api.DataContainerNodeBuilder;
+import org.opendaylight.yangtools.yang.data.impl.schema.builder.impl.ImmutableContainerNodeBuilder;
+import org.opendaylight.yangtools.yang.data.impl.schema.builder.impl.ImmutableLeafNodeBuilder;
+import org.opendaylight.yangtools.yang.data.impl.schema.builder.impl.ImmutableMapEntryNodeBuilder;
+import org.opendaylight.yangtools.yang.data.impl.schema.builder.impl.ImmutableMapNodeBuilder;
+import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
+import org.opendaylight.yangtools.yang.parser.impl.YangParserFactoryImpl;
+import org.opendaylight.yangtools.yang.xpath.api.YangXPathParserFactory;
+import org.opendaylight.yangtools.yang.xpath.impl.AntlrXPathParserFactory;
+
+public abstract class AbstractCodecTest {
+
+    protected static final Uint32 EXPECTED_ONE = Uint32.ONE;
+    protected static final Uint32 COFFEE_VALUE = Uint32.valueOf(0xC00FFEEL);
+    protected static final String TOASTER_NAMESPACE = "http://netconfcentral.org/ns/toaster";
+    protected static final String TOASTER_REVISION = "2009-11-20";
+
+    protected static final String SAMPLES_NAMESPACE = "http://pantheon.tech/ns/test-models";
+    protected static final String SAMPLES_REVISION = "2018-01-19";
+
+    protected static final YangInstanceIdentifier TOASTER_YANG_INSTANCE_IDENTIFIER =
+            YangInstanceIdentifier.of(Toaster.QNAME);
+
+    protected static final QName SIMPLE_IO_RPC_QNAME =
+            QName.create(SAMPLES_NAMESPACE, SAMPLES_REVISION, "simple-input-output-rpc");
+    protected static final QName MAKE_TOAST_RPC_QNAME = QName.create(TOASTER_NAMESPACE, TOASTER_REVISION, "make-toast");
+    protected static final QName CONTAINER_IO_RPC_QNAME =
+            QName.create(SAMPLES_NAMESPACE, SAMPLES_REVISION, "container-io-rpc");
+
+    // tested DataObject
+    protected final Toaster testedToaster;
+    // tested DataObject for RPC
+    protected final MakeToastInput testedMakeToasterInput;
+    // BI representation of testedToaster
+    protected final NormalizedNode<?, ?> testedToasterNormalizedNodes;
+    // BI representation of testedMakeToasterInput
+
+    protected final NormalizedNode<?, ?> testedSimpleRpcInputNormalizedNodes;
+    protected final NormalizedNode<?, ?> testedSimpleRpcOutputNormalizedNodes;
+    protected final NormalizedNode<?, ?> testedNotificationNormalizedNodes;
+    protected final NormalizedNode<?, ?> testedSampleListNormalizedNodes;
+    protected final NormalizedNode<?, ?> testedSampleMapNodeNormalizedNodes;
+
+    protected final BindingCodecContext bindingCodecContext;
+    protected final EffectiveModelContext effectiveModelContext;
+
+    public AbstractCodecTest() {
+        List<YangModuleInfo> moduleInfos = loadModuleInfos();
+        this.bindingCodecContext = createCodecContext(moduleInfos);
+        this.effectiveModelContext = bindingCodecContext.getRuntimeContext().getEffectiveModelContext();
+
+        this.testedToaster = new ToasterBuilder().setDarknessFactor(COFFEE_VALUE)
+                .setToasterManufacturer(new DisplayString("manufacturer")).setToasterStatus(ToasterStatus.Up).build();
+        this.testedMakeToasterInput = new MakeToastInputBuilder().setToasterDoneness(EXPECTED_ONE).build();
+
+        this.testedToasterNormalizedNodes = createToasterNormalizedNodes();
+
+        this.testedSimpleRpcInputNormalizedNodes = simpleRpcInputNormalizedNodes_in();
+        this.testedSimpleRpcOutputNormalizedNodes = simpleRpcInputNormalizedNodes_out();
+        this.testedNotificationNormalizedNodes = toasterNotificationNormalizedNodes();
+        this.testedSampleListNormalizedNodes = sampleListNormalizedNodes();
+        this.testedSampleMapNodeNormalizedNodes = sampleMapNode();
+    }
+
+    protected BindingCodecContext createCodecContext(List<YangModuleInfo> moduleInfos) {
+        final YangXPathParserFactory xpathFactory = new AntlrXPathParserFactory();
+        final YangParserFactoryImpl yangParserFactory = new YangParserFactoryImpl(xpathFactory);
+        final BindingRuntimeGenerator bindingRuntimeGenerator = new DefaultBindingRuntimeGenerator();
+        final ModuleInfoBackedContext ctx = ModuleInfoBackedContext.create("tests", yangParserFactory);
+        ctx.registerModuleInfos(moduleInfos);
+
+        final DefaultBindingRuntimeContext runtimeContext = DefaultBindingRuntimeContext
+                .create(bindingRuntimeGenerator.generateTypeMapping(ctx.tryToCreateModelContext().orElseThrow()), ctx);
+        return new BindingCodecContext(runtimeContext);
+    }
+
+    /**
+     * Utility method to create the {@link NodeIdentifier} for a node within the toaster module. The
+     * namespace and version are given by this module.
+     *
+     * @param nodeName of the node
+     * @return created {@link NodeIdentifier}
+     */
+    protected static NodeIdentifier getNodeIdentifier(final String namespace, final String revision,
+            final String nodeName) {
+        return new NodeIdentifier(QName.create(namespace, revision, nodeName));
+    }
+
+    protected static NodeIdentifier getToasterNodeIdentifier(final String nodeName) {
+        return getNodeIdentifier(TOASTER_NAMESPACE, TOASTER_REVISION, nodeName);
+    }
+
+    /**
+     * Loads the XML file containing a sample {@link Toaster} object.
+     *
+     * <pre>
+     * {@code
+     * &lt;toaster xmlns="http://netconfcentral.org/ns/toaster"&gt;
+     *   &lt;toasterManufacturer&gtmanufacturer&lt;/toasterManufacturer&gt;
+     *   &lt;toasterStatus&gtup&lt;/toasterStatus&gt;
+     *   &lt;darknessFactor&gt201392110&lt;/darknessFactor&gt;
+     * &lt;/toaster&gt;
+     * }
+     * </pre>
+     *
+     * @return
+     */
+    protected static String loadToasterXml() {
+        return loadResourceAsString("toaster.xml");
+    }
+
+    protected static String loadResourceAsString(final String fileName) {
+        URL resource = Resources.getResource(fileName);
+        try {
+            return Resources.toString(resource, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not load toaster xml file", e);
+        }
+    }
+
+    /**
+     * Helper method for loading {@link YangModuleInfo}s from the classpath.
+     *
+     * @return {@link List} of loaded {@link YangModuleInfo}
+     */
+    private static List<YangModuleInfo> loadModuleInfos() {
+        List<YangModuleInfo> moduleInfos = new LinkedList<>();
+        ServiceLoader<YangModelBindingProvider> yangProviderLoader = ServiceLoader.load(YangModelBindingProvider.class);
+        for (YangModelBindingProvider yangModelBindingProvider : yangProviderLoader) {
+            moduleInfos.add(yangModelBindingProvider.getModuleInfo());
+        }
+        return moduleInfos;
+    }
+
+    private static NormalizedNode<?, ?> createToasterNormalizedNodes() {
+        NodeIdentifier toasterNodeIdentifier = new NodeIdentifier(Toaster.QNAME);
+        LeafNode<String> manufacturer = new ImmutableLeafNodeBuilder<String>().withValue("manufacturer")
+                .withNodeIdentifier(getToasterNodeIdentifier("toasterManufacturer")).build();
+        LeafNode<String> toasterStatus = new ImmutableLeafNodeBuilder<String>().withValue(ToasterStatus.Up.getName())
+                .withNodeIdentifier(getToasterNodeIdentifier("toasterStatus")).build();
+        LeafNode<Uint32> darknessFactor = new ImmutableLeafNodeBuilder<Uint32>().withValue(COFFEE_VALUE)
+                .withNodeIdentifier(getToasterNodeIdentifier("darknessFactor")).build();
+        ContainerNode containerNode = ImmutableContainerNodeBuilder.create().withNodeIdentifier(toasterNodeIdentifier)
+                .withValue(ImmutableList.of(manufacturer, darknessFactor, toasterStatus)).build();
+        return containerNode;
+    }
+
+    private static NormalizedNode<?, ?> simpleRpcInputNormalizedNodes_in() {
+        NodeIdentifier toasterNodeIdentifier =
+                new NodeIdentifier(QName.create(SAMPLES_NAMESPACE, "2018-01-19", "input"));
+        LeafNode<String> input = new ImmutableLeafNodeBuilder<String>()
+                .withNodeIdentifier(new NodeIdentifier(QName.create(SAMPLES_NAMESPACE, "2018-01-19", "input-obj")))
+                .withValue("a").build();
+        ContainerNode containerNode = ImmutableContainerNodeBuilder.create().withNodeIdentifier(toasterNodeIdentifier)
+                .withValue(ImmutableList.of(input)).build();
+        return containerNode;
+    }
+
+    private static NormalizedNode<?, ?> simpleRpcInputNormalizedNodes_out() {
+        NodeIdentifier toasterNodeIdentifier =
+                new NodeIdentifier(QName.create(SAMPLES_NAMESPACE, "2018-01-19", "output"));
+        LeafNode<String> input = new ImmutableLeafNodeBuilder<String>()
+                .withNodeIdentifier(new NodeIdentifier(QName.create(SAMPLES_NAMESPACE, "2018-01-19", "output-obj")))
+                .withValue("a").build();
+        ContainerNode containerNode = ImmutableContainerNodeBuilder.create().withNodeIdentifier(toasterNodeIdentifier)
+                .withValue(ImmutableList.of(input)).build();
+        return containerNode;
+    }
+
+    private static NormalizedNode<?, ?> toasterNotificationNormalizedNodes() {
+        NodeIdentifier toasterNodeIdentifier =
+                new NodeIdentifier(QName.create(TOASTER_NAMESPACE, TOASTER_REVISION, "toasterRestocked"));
+        LeafNode<Long> value = new ImmutableLeafNodeBuilder<Long>()
+                .withNodeIdentifier(
+                        new NodeIdentifier(QName.create(TOASTER_NAMESPACE, TOASTER_REVISION, "amountOfBread")))
+                .withValue(1L).build();
+        ContainerNode containerNode = ImmutableContainerNodeBuilder.create().withNodeIdentifier(toasterNodeIdentifier)
+                .withValue(ImmutableList.of(value)).build();
+        return containerNode;
+    }
+
+    private static NormalizedNode<?, ?> sampleListNormalizedNodes() {
+        DataContainerNodeBuilder<NodeIdentifierWithPredicates, MapEntryNode> create =
+                ImmutableMapEntryNodeBuilder.create();
+        QName keyQname = QName.create(SAMPLES_NAMESPACE, SAMPLES_REVISION, "name");
+        QName valueQname = QName.create(SAMPLES_NAMESPACE, SAMPLES_REVISION, "value");
+        NodeIdentifierWithPredicates nodeIdentifier = NodeIdentifierWithPredicates.of(
+                QName.create(SAMPLES_NAMESPACE, SAMPLES_REVISION, "sample-list"), keyQname, "name");
+        create.withNodeIdentifier(nodeIdentifier);
+        LeafNode<String> name = new ImmutableLeafNodeBuilder<String>().withNodeIdentifier(new NodeIdentifier(keyQname))
+                .withValue("name").build();
+        LeafNode<Short> value = new ImmutableLeafNodeBuilder<Short>().withNodeIdentifier(new NodeIdentifier(valueQname))
+                .withValue((short) 1).build();
+        create.withValue(ImmutableList.of(name, value));
+        return create.build();
+    }
+
+    private static NormalizedNode<?, ?> sampleMapNode() {
+        return ImmutableMapNodeBuilder.create().withNodeIdentifier(new NodeIdentifier(SampleList.QNAME))
+                .withChild((MapEntryNode) sampleListNormalizedNodes()).build();
+    }
+}

--- a/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/AbstractCodecTest.java
+++ b/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/AbstractCodecTest.java
@@ -34,7 +34,6 @@ import org.opendaylight.yangtools.yang.common.Uint32;
 import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier;
 import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier.NodeIdentifier;
 import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier.NodeIdentifierWithPredicates;
-import org.opendaylight.yangtools.yang.data.api.schema.ContainerNode;
 import org.opendaylight.yangtools.yang.data.api.schema.LeafNode;
 import org.opendaylight.yangtools.yang.data.api.schema.MapEntryNode;
 import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
@@ -180,9 +179,8 @@ public abstract class AbstractCodecTest {
                 .withNodeIdentifier(getToasterNodeIdentifier("toasterStatus")).build();
         LeafNode<Uint32> darknessFactor = new ImmutableLeafNodeBuilder<Uint32>().withValue(COFFEE_VALUE)
                 .withNodeIdentifier(getToasterNodeIdentifier("darknessFactor")).build();
-        ContainerNode containerNode = ImmutableContainerNodeBuilder.create().withNodeIdentifier(toasterNodeIdentifier)
+        return ImmutableContainerNodeBuilder.create().withNodeIdentifier(toasterNodeIdentifier)
                 .withValue(ImmutableList.of(manufacturer, darknessFactor, toasterStatus)).build();
-        return containerNode;
     }
 
     private static NormalizedNode<?, ?> simpleRpcInputNormalizedNodes_in() {
@@ -191,9 +189,8 @@ public abstract class AbstractCodecTest {
         LeafNode<String> input = new ImmutableLeafNodeBuilder<String>()
                 .withNodeIdentifier(new NodeIdentifier(QName.create(SAMPLES_NAMESPACE, "2018-01-19", "input-obj")))
                 .withValue("a").build();
-        ContainerNode containerNode = ImmutableContainerNodeBuilder.create().withNodeIdentifier(toasterNodeIdentifier)
+        return ImmutableContainerNodeBuilder.create().withNodeIdentifier(toasterNodeIdentifier)
                 .withValue(ImmutableList.of(input)).build();
-        return containerNode;
     }
 
     private static NormalizedNode<?, ?> simpleRpcInputNormalizedNodes_out() {
@@ -202,9 +199,8 @@ public abstract class AbstractCodecTest {
         LeafNode<String> input = new ImmutableLeafNodeBuilder<String>()
                 .withNodeIdentifier(new NodeIdentifier(QName.create(SAMPLES_NAMESPACE, "2018-01-19", "output-obj")))
                 .withValue("a").build();
-        ContainerNode containerNode = ImmutableContainerNodeBuilder.create().withNodeIdentifier(toasterNodeIdentifier)
+        return ImmutableContainerNodeBuilder.create().withNodeIdentifier(toasterNodeIdentifier)
                 .withValue(ImmutableList.of(input)).build();
-        return containerNode;
     }
 
     private static NormalizedNode<?, ?> toasterNotificationNormalizedNodes() {
@@ -214,9 +210,8 @@ public abstract class AbstractCodecTest {
                 .withNodeIdentifier(
                         new NodeIdentifier(QName.create(TOASTER_NAMESPACE, TOASTER_REVISION, "amountOfBread")))
                 .withValue(1L).build();
-        ContainerNode containerNode = ImmutableContainerNodeBuilder.create().withNodeIdentifier(toasterNodeIdentifier)
+        return ImmutableContainerNodeBuilder.create().withNodeIdentifier(toasterNodeIdentifier)
                 .withValue(ImmutableList.of(value)).build();
-        return containerNode;
     }
 
     private static NormalizedNode<?, ?> sampleListNormalizedNodes() {

--- a/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/ConverterUtilsTest.java
+++ b/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/ConverterUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Pantheon Technologies s.r.o. All Rights Reserved.
+ * Copyright (c) 2021 Pantheon Technologies s.r.o. All Rights Reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/ConverterUtilsTest.java
+++ b/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/ConverterUtilsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2018 Pantheon Technologies s.r.o. All Rights Reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ */
+package io.lighty.codecs.util;
+
+import java.util.Optional;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opendaylight.netconf.api.xml.XmlElement;
+import org.opendaylight.yang.gen.v1.http.netconfcentral.org.ns.toaster.rev091120.Toaster;
+import org.opendaylight.yangtools.yang.common.QName;
+import org.opendaylight.yangtools.yang.model.api.SchemaNode;
+
+public class ConverterUtilsTest extends AbstractCodecTest {
+
+    @Test
+    public void testGetRpcQName_norevision() throws Exception {
+        XmlElement xmlElement = XmlElement.fromString(loadResourceAsString("make-toast-input_norev.xml"));
+        Optional<QName> rpcQName = ConverterUtils.getRpcQName(xmlElement);
+        Assert.assertTrue(rpcQName.isPresent());
+        Assert.assertTrue(MAKE_TOAST_RPC_QNAME.getLocalName().equals(rpcQName.get().getLocalName()));
+        Assert.assertTrue(MAKE_TOAST_RPC_QNAME.getNamespace().equals(rpcQName.get().getNamespace()));
+        Assert.assertFalse(MAKE_TOAST_RPC_QNAME.getRevision().equals(rpcQName.get().getRevision()));
+    }
+
+    @Test
+    public void testGetRpcQNameFromXML_norevision() {
+        Optional<QName> rpcQName = ConverterUtils.getRpcQName(loadResourceAsString("make-toast-input_norev.xml"));
+        Assert.assertTrue(rpcQName.isPresent());
+        Assert.assertTrue(MAKE_TOAST_RPC_QNAME.getLocalName().equals(rpcQName.get().getLocalName()));
+        Assert.assertTrue(MAKE_TOAST_RPC_QNAME.getNamespace().equals(rpcQName.get().getNamespace()));
+        Assert.assertFalse(MAKE_TOAST_RPC_QNAME.getRevision().equals(rpcQName.get().getRevision()));
+    }
+
+    @Test
+    public void testGetRpcQName_revision() throws Exception {
+        XmlElement xmlElement = XmlElement.fromString(loadResourceAsString("make-toast-input_rev.xml"));
+        Optional<QName> rpcQName = ConverterUtils.getRpcQName(xmlElement);
+        Assert.assertTrue(rpcQName.isPresent());
+        Assert.assertTrue(MAKE_TOAST_RPC_QNAME.getLocalName().equals(rpcQName.get().getLocalName()));
+        Assert.assertTrue(MAKE_TOAST_RPC_QNAME.getNamespace().equals(rpcQName.get().getNamespace()));
+        Assert.assertTrue(MAKE_TOAST_RPC_QNAME.getRevision().equals(rpcQName.get().getRevision()));
+    }
+
+    @Test
+    public void testRpcAsInput() throws Exception {
+        XmlElement makeToastRpc = XmlElement.fromString(loadResourceAsString("make-toast-input_rev.xml"));
+        XmlElement rpcAsInput =
+                ConverterUtils.rpcAsInput(makeToastRpc, "http://netconfcentral.org/ns/toaster?revision=2009-11-20");
+        Assert.assertNotNull(rpcAsInput);
+        Assert.assertTrue(rpcAsInput.getName().equals("input"));
+        rpcAsInput = ConverterUtils.rpcAsInput(makeToastRpc);
+        Assert.assertNotNull(rpcAsInput);
+        Assert.assertTrue(rpcAsInput.getName().equals("input"));
+    }
+
+    @Test
+    public void testRpcAsOutput() throws Exception {
+        XmlElement makeToastRpc = XmlElement.fromString(loadResourceAsString("make-toast-input_rev.xml"));
+        XmlElement rpcAsOutput =
+                ConverterUtils.rpcAsOutput(makeToastRpc, "http://netconfcentral.org/ns/toaster?revision=2009-11-20");
+        Assert.assertNotNull(rpcAsOutput);
+        Assert.assertTrue(rpcAsOutput.getName().equals("output"));
+        rpcAsOutput = ConverterUtils.rpcAsOutput(makeToastRpc);
+        Assert.assertNotNull(rpcAsOutput);
+        Assert.assertTrue(rpcAsOutput.getName().equals("output"));
+    }
+
+    @Test
+    public void testGetSchemaNode() {
+        SchemaNode node = ConverterUtils.getSchemaNode(this.effectiveModelContext, Toaster.QNAME);
+        Assert.assertNotNull(node);
+        Assert.assertTrue(node.getQName().equals(Toaster.QNAME));
+        node = ConverterUtils.getSchemaNode(this.effectiveModelContext, TOASTER_YANG_INSTANCE_IDENTIFIER);
+        Assert.assertNotNull(node);
+        Assert.assertTrue(node.getQName().equals(Toaster.QNAME));
+    }
+}

--- a/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/ConverterUtilsTest.java
+++ b/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/ConverterUtilsTest.java
@@ -22,18 +22,18 @@ public class ConverterUtilsTest extends AbstractCodecTest {
         XmlElement xmlElement = XmlElement.fromString(loadResourceAsString("make-toast-input_norev.xml"));
         Optional<QName> rpcQName = ConverterUtils.getRpcQName(xmlElement);
         Assert.assertTrue(rpcQName.isPresent());
-        Assert.assertTrue(MAKE_TOAST_RPC_QNAME.getLocalName().equals(rpcQName.get().getLocalName()));
-        Assert.assertTrue(MAKE_TOAST_RPC_QNAME.getNamespace().equals(rpcQName.get().getNamespace()));
-        Assert.assertFalse(MAKE_TOAST_RPC_QNAME.getRevision().equals(rpcQName.get().getRevision()));
+        Assert.assertEquals(MAKE_TOAST_RPC_QNAME.getLocalName(), rpcQName.get().getLocalName());
+        Assert.assertEquals(MAKE_TOAST_RPC_QNAME.getNamespace(), rpcQName.get().getNamespace());
+        Assert.assertNotEquals(MAKE_TOAST_RPC_QNAME.getRevision(), rpcQName.get().getRevision());
     }
 
     @Test
     public void testGetRpcQNameFromXML_norevision() {
         Optional<QName> rpcQName = ConverterUtils.getRpcQName(loadResourceAsString("make-toast-input_norev.xml"));
         Assert.assertTrue(rpcQName.isPresent());
-        Assert.assertTrue(MAKE_TOAST_RPC_QNAME.getLocalName().equals(rpcQName.get().getLocalName()));
-        Assert.assertTrue(MAKE_TOAST_RPC_QNAME.getNamespace().equals(rpcQName.get().getNamespace()));
-        Assert.assertFalse(MAKE_TOAST_RPC_QNAME.getRevision().equals(rpcQName.get().getRevision()));
+        Assert.assertEquals(MAKE_TOAST_RPC_QNAME.getLocalName(), rpcQName.get().getLocalName());
+        Assert.assertEquals(MAKE_TOAST_RPC_QNAME.getNamespace(), rpcQName.get().getNamespace());
+        Assert.assertNotEquals(MAKE_TOAST_RPC_QNAME.getRevision(), rpcQName.get().getRevision());
     }
 
     @Test
@@ -41,9 +41,9 @@ public class ConverterUtilsTest extends AbstractCodecTest {
         XmlElement xmlElement = XmlElement.fromString(loadResourceAsString("make-toast-input_rev.xml"));
         Optional<QName> rpcQName = ConverterUtils.getRpcQName(xmlElement);
         Assert.assertTrue(rpcQName.isPresent());
-        Assert.assertTrue(MAKE_TOAST_RPC_QNAME.getLocalName().equals(rpcQName.get().getLocalName()));
-        Assert.assertTrue(MAKE_TOAST_RPC_QNAME.getNamespace().equals(rpcQName.get().getNamespace()));
-        Assert.assertTrue(MAKE_TOAST_RPC_QNAME.getRevision().equals(rpcQName.get().getRevision()));
+        Assert.assertEquals(MAKE_TOAST_RPC_QNAME.getLocalName(), rpcQName.get().getLocalName());
+        Assert.assertEquals(MAKE_TOAST_RPC_QNAME.getNamespace(), rpcQName.get().getNamespace());
+        Assert.assertEquals(MAKE_TOAST_RPC_QNAME.getRevision(), rpcQName.get().getRevision());
     }
 
     @Test
@@ -52,10 +52,10 @@ public class ConverterUtilsTest extends AbstractCodecTest {
         XmlElement rpcAsInput =
                 ConverterUtils.rpcAsInput(makeToastRpc, "http://netconfcentral.org/ns/toaster?revision=2009-11-20");
         Assert.assertNotNull(rpcAsInput);
-        Assert.assertTrue(rpcAsInput.getName().equals("input"));
+        Assert.assertEquals("input", rpcAsInput.getName());
         rpcAsInput = ConverterUtils.rpcAsInput(makeToastRpc);
         Assert.assertNotNull(rpcAsInput);
-        Assert.assertTrue(rpcAsInput.getName().equals("input"));
+        Assert.assertEquals("input", rpcAsInput.getName());
     }
 
     @Test
@@ -64,19 +64,19 @@ public class ConverterUtilsTest extends AbstractCodecTest {
         XmlElement rpcAsOutput =
                 ConverterUtils.rpcAsOutput(makeToastRpc, "http://netconfcentral.org/ns/toaster?revision=2009-11-20");
         Assert.assertNotNull(rpcAsOutput);
-        Assert.assertTrue(rpcAsOutput.getName().equals("output"));
+        Assert.assertEquals("output", rpcAsOutput.getName());
         rpcAsOutput = ConverterUtils.rpcAsOutput(makeToastRpc);
         Assert.assertNotNull(rpcAsOutput);
-        Assert.assertTrue(rpcAsOutput.getName().equals("output"));
+        Assert.assertEquals("output", rpcAsOutput.getName());
     }
 
     @Test
     public void testGetSchemaNode() {
         SchemaNode node = ConverterUtils.getSchemaNode(this.effectiveModelContext, Toaster.QNAME);
         Assert.assertNotNull(node);
-        Assert.assertTrue(node.getQName().equals(Toaster.QNAME));
+        Assert.assertEquals(node.getQName(), Toaster.QNAME);
         node = ConverterUtils.getSchemaNode(this.effectiveModelContext, TOASTER_YANG_INSTANCE_IDENTIFIER);
         Assert.assertNotNull(node);
-        Assert.assertTrue(node.getQName().equals(Toaster.QNAME));
+        Assert.assertEquals(node.getQName(), Toaster.QNAME);
     }
 }

--- a/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/JsonNodeConverterTest.java
+++ b/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/JsonNodeConverterTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2018 Pantheon Technologies s.r.o. All Rights Reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ */
+package io.lighty.codecs.util;
+
+import com.google.common.base.Strings;
+import java.io.StringReader;
+import java.io.Writer;
+import java.util.Optional;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
+import org.opendaylight.yangtools.yang.model.api.RpcDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JsonNodeConverterTest extends AbstractCodecTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JsonNodeConverterTest.class);
+
+    private final NodeConverter bindingSerializer;
+
+    public JsonNodeConverterTest() {
+        bindingSerializer = new JsonNodeConverter(this.effectiveModelContext);
+    }
+
+    @Test
+    public void testSerializeRpc_in() throws Exception {
+        Optional<? extends RpcDefinition>
+                loadedRpc = ConverterUtils.loadRpc(this.effectiveModelContext, SIMPLE_IO_RPC_QNAME);
+        Writer serializedRpc =
+                bindingSerializer.serializeRpc(loadedRpc.get().getInput(), testedSimpleRpcInputNormalizedNodes);
+        Assert.assertFalse(Strings.isNullOrEmpty(serializedRpc.toString()));
+        LOG.info(serializedRpc.toString());
+    }
+
+    @Test
+    public void testSerializeRpc_out() throws Exception {
+        Optional<? extends RpcDefinition>
+                loadedRpc = ConverterUtils.loadRpc(this.effectiveModelContext, SIMPLE_IO_RPC_QNAME);
+        Writer serializedRpc =
+                bindingSerializer.serializeRpc(loadedRpc.get().getOutput(), testedSimpleRpcOutputNormalizedNodes);
+        Assert.assertFalse(Strings.isNullOrEmpty(serializedRpc.toString()));
+        LOG.info(serializedRpc.toString());
+    }
+
+    @Test
+    public void testSerializeData() throws Exception {
+        Writer serializeData =
+                bindingSerializer.serializeData(this.effectiveModelContext, testedToasterNormalizedNodes);
+        Assert.assertFalse(Strings.isNullOrEmpty(serializeData.toString()));
+        LOG.info(serializeData.toString());
+    }
+
+    @Test
+    public void testDeserializeData() throws Exception {
+        NormalizedNode<?, ?> deserializeData = bindingSerializer.deserialize(this.effectiveModelContext,
+                new StringReader(loadResourceAsString("toaster.json")));
+        Assert.assertNotNull(deserializeData);
+        LOG.info(deserializeData.toString());
+    }
+
+    @Test
+    public void testDeserialize_in() throws Exception {
+        Optional<? extends RpcDefinition>
+                loadRpc = ConverterUtils.loadRpc(this.effectiveModelContext, SIMPLE_IO_RPC_QNAME);
+        String loadIoRpcIn = loadResourceAsString("input-output-rpc-in.json");
+        NormalizedNode<?, ?> deserializeRpc =
+                bindingSerializer.deserialize(loadRpc.get(), new StringReader(loadIoRpcIn));
+        Assert.assertNotNull(deserializeRpc);
+        LOG.info(deserializeRpc.toString());
+    }
+
+    @Test
+    public void testDeserialize_out() throws Exception {
+        Optional<? extends RpcDefinition>
+                loadRpc = ConverterUtils.loadRpc(this.effectiveModelContext, SIMPLE_IO_RPC_QNAME);
+        String loadIoRpcOut = loadResourceAsString("input-output-rpc-out.json");
+        NormalizedNode<?, ?> deserializeRpc =
+                bindingSerializer.deserialize(loadRpc.get(), new StringReader(loadIoRpcOut));
+        Assert.assertNotNull(deserializeRpc);
+        LOG.info(deserializeRpc.toString());
+    }
+
+    @Test
+    public void testDeserialize_container() throws SerializationException {
+        NormalizedNode<?, ?> deserializeContainer = bindingSerializer.deserialize(this.effectiveModelContext,
+                new StringReader(loadResourceAsString("top-level-container.json")));
+        Assert.assertNotNull(deserializeContainer);
+        LOG.info(deserializeContainer.toString());
+    }
+
+    @Test
+    public void testDeserialize_container_rpc() throws SerializationException {
+        Optional<? extends RpcDefinition>
+                loadRpcContainer = ConverterUtils.loadRpc(this.effectiveModelContext, CONTAINER_IO_RPC_QNAME);
+        NormalizedNode<?, ?> deserializeData = bindingSerializer.deserialize(loadRpcContainer.get(),
+                new StringReader(loadResourceAsString("container-io-rpc.json")));
+        Assert.assertNotNull(deserializeData);
+    }
+}

--- a/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/JsonNodeConverterTest.java
+++ b/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/JsonNodeConverterTest.java
@@ -33,7 +33,7 @@ public class JsonNodeConverterTest extends AbstractCodecTest {
         Optional<? extends RpcDefinition>
                 loadedRpc = ConverterUtils.loadRpc(this.effectiveModelContext, SIMPLE_IO_RPC_QNAME);
         Writer serializedRpc =
-                bindingSerializer.serializeRpc(loadedRpc.get().getInput(), testedSimpleRpcInputNormalizedNodes);
+                bindingSerializer.serializeRpc(loadedRpc.orElseThrow().getInput(), testedSimpleRpcInputNormalizedNodes);
         Assert.assertFalse(Strings.isNullOrEmpty(serializedRpc.toString()));
         LOG.info(serializedRpc.toString());
     }
@@ -42,8 +42,8 @@ public class JsonNodeConverterTest extends AbstractCodecTest {
     public void testSerializeRpc_out() throws Exception {
         Optional<? extends RpcDefinition>
                 loadedRpc = ConverterUtils.loadRpc(this.effectiveModelContext, SIMPLE_IO_RPC_QNAME);
-        Writer serializedRpc =
-                bindingSerializer.serializeRpc(loadedRpc.get().getOutput(), testedSimpleRpcOutputNormalizedNodes);
+        Writer serializedRpc = bindingSerializer
+                .serializeRpc(loadedRpc.orElseThrow().getOutput(), testedSimpleRpcOutputNormalizedNodes);
         Assert.assertFalse(Strings.isNullOrEmpty(serializedRpc.toString()));
         LOG.info(serializedRpc.toString());
     }
@@ -70,7 +70,7 @@ public class JsonNodeConverterTest extends AbstractCodecTest {
                 loadRpc = ConverterUtils.loadRpc(this.effectiveModelContext, SIMPLE_IO_RPC_QNAME);
         String loadIoRpcIn = loadResourceAsString("input-output-rpc-in.json");
         NormalizedNode<?, ?> deserializeRpc =
-                bindingSerializer.deserialize(loadRpc.get(), new StringReader(loadIoRpcIn));
+                bindingSerializer.deserialize(loadRpc.orElseThrow(), new StringReader(loadIoRpcIn));
         Assert.assertNotNull(deserializeRpc);
         LOG.info(deserializeRpc.toString());
     }
@@ -81,7 +81,7 @@ public class JsonNodeConverterTest extends AbstractCodecTest {
                 loadRpc = ConverterUtils.loadRpc(this.effectiveModelContext, SIMPLE_IO_RPC_QNAME);
         String loadIoRpcOut = loadResourceAsString("input-output-rpc-out.json");
         NormalizedNode<?, ?> deserializeRpc =
-                bindingSerializer.deserialize(loadRpc.get(), new StringReader(loadIoRpcOut));
+                bindingSerializer.deserialize(loadRpc.orElseThrow(), new StringReader(loadIoRpcOut));
         Assert.assertNotNull(deserializeRpc);
         LOG.info(deserializeRpc.toString());
     }
@@ -98,7 +98,7 @@ public class JsonNodeConverterTest extends AbstractCodecTest {
     public void testDeserialize_container_rpc() throws SerializationException {
         Optional<? extends RpcDefinition>
                 loadRpcContainer = ConverterUtils.loadRpc(this.effectiveModelContext, CONTAINER_IO_RPC_QNAME);
-        NormalizedNode<?, ?> deserializeData = bindingSerializer.deserialize(loadRpcContainer.get(),
+        NormalizedNode<?, ?> deserializeData = bindingSerializer.deserialize(loadRpcContainer.orElseThrow(),
                 new StringReader(loadResourceAsString("container-io-rpc.json")));
         Assert.assertNotNull(deserializeData);
     }

--- a/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/JsonNodeConverterTest.java
+++ b/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/JsonNodeConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Pantheon Technologies s.r.o. All Rights Reserved.
+ * Copyright (c) 2021 Pantheon Technologies s.r.o. All Rights Reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution,
@@ -15,12 +15,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
 import org.opendaylight.yangtools.yang.model.api.RpcDefinition;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class JsonNodeConverterTest extends AbstractCodecTest {
-
-    private static final Logger LOG = LoggerFactory.getLogger(JsonNodeConverterTest.class);
 
     private final NodeConverter bindingSerializer;
 
@@ -35,7 +31,6 @@ public class JsonNodeConverterTest extends AbstractCodecTest {
         Writer serializedRpc =
                 bindingSerializer.serializeRpc(loadedRpc.orElseThrow().getInput(), testedSimpleRpcInputNormalizedNodes);
         Assert.assertFalse(Strings.isNullOrEmpty(serializedRpc.toString()));
-        LOG.info(serializedRpc.toString());
     }
 
     @Test
@@ -45,7 +40,6 @@ public class JsonNodeConverterTest extends AbstractCodecTest {
         Writer serializedRpc = bindingSerializer
                 .serializeRpc(loadedRpc.orElseThrow().getOutput(), testedSimpleRpcOutputNormalizedNodes);
         Assert.assertFalse(Strings.isNullOrEmpty(serializedRpc.toString()));
-        LOG.info(serializedRpc.toString());
     }
 
     @Test
@@ -53,7 +47,6 @@ public class JsonNodeConverterTest extends AbstractCodecTest {
         Writer serializeData =
                 bindingSerializer.serializeData(this.effectiveModelContext, testedToasterNormalizedNodes);
         Assert.assertFalse(Strings.isNullOrEmpty(serializeData.toString()));
-        LOG.info(serializeData.toString());
     }
 
     @Test
@@ -61,7 +54,6 @@ public class JsonNodeConverterTest extends AbstractCodecTest {
         NormalizedNode<?, ?> deserializeData = bindingSerializer.deserialize(this.effectiveModelContext,
                 new StringReader(loadResourceAsString("toaster.json")));
         Assert.assertNotNull(deserializeData);
-        LOG.info(deserializeData.toString());
     }
 
     @Test
@@ -72,7 +64,6 @@ public class JsonNodeConverterTest extends AbstractCodecTest {
         NormalizedNode<?, ?> deserializeRpc =
                 bindingSerializer.deserialize(loadRpc.orElseThrow(), new StringReader(loadIoRpcIn));
         Assert.assertNotNull(deserializeRpc);
-        LOG.info(deserializeRpc.toString());
     }
 
     @Test
@@ -83,7 +74,6 @@ public class JsonNodeConverterTest extends AbstractCodecTest {
         NormalizedNode<?, ?> deserializeRpc =
                 bindingSerializer.deserialize(loadRpc.orElseThrow(), new StringReader(loadIoRpcOut));
         Assert.assertNotNull(deserializeRpc);
-        LOG.info(deserializeRpc.toString());
     }
 
     @Test
@@ -91,7 +81,6 @@ public class JsonNodeConverterTest extends AbstractCodecTest {
         NormalizedNode<?, ?> deserializeContainer = bindingSerializer.deserialize(this.effectiveModelContext,
                 new StringReader(loadResourceAsString("top-level-container.json")));
         Assert.assertNotNull(deserializeContainer);
-        LOG.info(deserializeContainer.toString());
     }
 
     @Test

--- a/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/XmlNodeConverterTest.java
+++ b/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/XmlNodeConverterTest.java
@@ -10,7 +10,6 @@ package io.lighty.codecs.util;
 import com.google.common.base.Strings;
 import java.io.StringReader;
 import java.io.Writer;
-import java.net.URISyntaxException;
 import java.util.Optional;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -42,7 +41,7 @@ public class XmlNodeConverterTest extends AbstractCodecTest {
         Optional<? extends RpcDefinition>
                 loadRpc = ConverterUtils.loadRpc(this.effectiveModelContext, SIMPLE_IO_RPC_QNAME);
         Writer serializeRpc =
-                bindingSerializer.serializeRpc(loadRpc.get().getInput(), testedSimpleRpcInputNormalizedNodes);
+                bindingSerializer.serializeRpc(loadRpc.orElseThrow().getInput(), testedSimpleRpcInputNormalizedNodes);
         Assert.assertFalse(Strings.isNullOrEmpty(serializeRpc.toString()));
         LOG.info(serializeRpc.toString());
     }
@@ -52,7 +51,7 @@ public class XmlNodeConverterTest extends AbstractCodecTest {
         Optional<? extends RpcDefinition>
                 loadRpc = ConverterUtils.loadRpc(this.effectiveModelContext, SIMPLE_IO_RPC_QNAME);
         Writer serializeRpc =
-                bindingSerializer.serializeRpc(loadRpc.get().getOutput(), testedSimpleRpcOutputNormalizedNodes);
+                bindingSerializer.serializeRpc(loadRpc.orElseThrow().getOutput(), testedSimpleRpcOutputNormalizedNodes);
         Assert.assertFalse(Strings.isNullOrEmpty(serializeRpc.toString()));
         LOG.info(serializeRpc.toString());
     }
@@ -68,7 +67,7 @@ public class XmlNodeConverterTest extends AbstractCodecTest {
     @Test
     public void testDeserializeData() throws Exception {
         final DataSchemaNode schemaNode = DataSchemaContextTree.from(this.effectiveModelContext)
-                .getChild(YangInstanceIdentifier.of(Toaster.QNAME)).getDataSchemaNode();
+                .findChild(YangInstanceIdentifier.of(Toaster.QNAME)).orElseThrow().getDataSchemaNode();
 
         NormalizedNode<?, ?> deserializeData =
                 bindingSerializer.deserialize(schemaNode, new StringReader(loadToasterXml()));
@@ -81,8 +80,8 @@ public class XmlNodeConverterTest extends AbstractCodecTest {
         Optional<? extends RpcDefinition>
                 loadRpc = ConverterUtils.loadRpc(this.effectiveModelContext, SIMPLE_IO_RPC_QNAME);
         String loadMakeToasterInputXml = loadResourceAsString("input-output-rpc-in.xml");
-        NormalizedNode<?, ?> deserializeRpc =
-                bindingSerializer.deserialize(loadRpc.get().getInput(), new StringReader(loadMakeToasterInputXml));
+        NormalizedNode<?, ?> deserializeRpc = bindingSerializer
+                .deserialize(loadRpc.orElseThrow().getInput(), new StringReader(loadMakeToasterInputXml));
         Assert.assertNotNull(deserializeRpc);
         LOG.info(deserializeRpc.toString());
     }
@@ -92,14 +91,14 @@ public class XmlNodeConverterTest extends AbstractCodecTest {
         Optional<? extends RpcDefinition>
                 loadRpc = ConverterUtils.loadRpc(this.effectiveModelContext, SIMPLE_IO_RPC_QNAME);
         String loadMakeToasterInputXml = loadResourceAsString("input-output-rpc-out.xml");
-        NormalizedNode<?, ?> deserializeRpc =
-                bindingSerializer.deserialize(loadRpc.get().getOutput(), new StringReader(loadMakeToasterInputXml));
+        NormalizedNode<?, ?> deserializeRpc = bindingSerializer
+                .deserialize(loadRpc.orElseThrow().getOutput(), new StringReader(loadMakeToasterInputXml));
         Assert.assertNotNull(deserializeRpc);
         LOG.info(deserializeRpc.toString());
     }
 
     @Test
-    public void testLoadNotification() throws Exception {
+    public void testLoadNotification() {
         Optional<? extends NotificationDefinition> loadNotification =
                 ConverterUtils.loadNotification(this.effectiveModelContext,
                         QName.create(TOASTER_NAMESPACE, TOASTER_REVISION, "toasterRestocked"));
@@ -115,14 +114,14 @@ public class XmlNodeConverterTest extends AbstractCodecTest {
                 ConverterUtils.loadNotification(this.effectiveModelContext,
                         QName.create(TOASTER_NAMESPACE, TOASTER_REVISION, "toasterRestocked"));
         NormalizedNode<?, ?> nodes =
-                bindingSerializer.deserialize(loadNotification.get(), new StringReader(notification));
+                bindingSerializer.deserialize(loadNotification.orElseThrow(), new StringReader(notification));
         Assert.assertNotNull(nodes);
     }
 
     @Test
     public void testSerializeData_container() throws SerializationException {
         final DataSchemaNode schemaNode = DataSchemaContextTree.from(this.effectiveModelContext)
-                .getChild(YangInstanceIdentifier.of(TopLevelContainer.QNAME)).getDataSchemaNode();
+                .findChild(YangInstanceIdentifier.of(TopLevelContainer.QNAME)).orElseThrow().getDataSchemaNode();
 
         NormalizedNode<?, ?> deserializeData = bindingSerializer.deserialize(schemaNode,
                 new StringReader(loadResourceAsString("top-level-container.xml")));
@@ -134,7 +133,7 @@ public class XmlNodeConverterTest extends AbstractCodecTest {
     public void testSerializeData_container_rpc() throws SerializationException {
         Optional<? extends RpcDefinition>
                 loadRpc = ConverterUtils.loadRpc(this.effectiveModelContext, CONTAINER_IO_RPC_QNAME);
-        NormalizedNode<?, ?> deserializeData = bindingSerializer.deserialize(loadRpc.get().getInput(),
+        NormalizedNode<?, ?> deserializeData = bindingSerializer.deserialize(loadRpc.orElseThrow().getInput(),
                 new StringReader(loadResourceAsString("container-io-rpc.xml")));
         Assert.assertNotNull(deserializeData);
     }
@@ -151,13 +150,13 @@ public class XmlNodeConverterTest extends AbstractCodecTest {
     public void testDeserializeData_list_single() throws SerializationException {
         SchemaNode schemaNode = ConverterUtils.getSchemaNode(this.effectiveModelContext, SAMPLES_NAMESPACE,
                 SAMPLES_REVISION, "sample-list");
-        NormalizedNode<?, ?> serializedData =
-                bindingSerializer.deserialize(schemaNode, new StringReader(loadResourceAsString("sample-list.xml")));
+        NormalizedNode<?, ?> serializedData = bindingSerializer
+                .deserialize(schemaNode, new StringReader(loadResourceAsString("sample-list.xml")));
         Assert.assertNotNull(serializedData.toString());
     }
 
     @Test
-    public void testDeserializeData_list_multiple() throws SerializationException, URISyntaxException {
+    public void testDeserializeData_list_multiple() throws SerializationException {
         NormalizedNode<?, ?> serializedData = bindingSerializer.deserialize(this.effectiveModelContext,
                 new StringReader(loadResourceAsString("sample-list-multiple.xml")));
         Assert.assertNotNull(serializedData.toString());

--- a/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/XmlNodeConverterTest.java
+++ b/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/XmlNodeConverterTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2018 Pantheon Technologies s.r.o. All Rights Reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ */
+package io.lighty.codecs.util;
+
+import com.google.common.base.Strings;
+import java.io.StringReader;
+import java.io.Writer;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.opendaylight.yang.gen.v1.http.netconfcentral.org.ns.toaster.rev091120.Toaster;
+import org.opendaylight.yang.gen.v1.http.pantheon.tech.ns.test.models.rev180119.TopLevelContainer;
+import org.opendaylight.yangtools.yang.common.QName;
+import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier;
+import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
+import org.opendaylight.yangtools.yang.data.util.DataSchemaContextTree;
+import org.opendaylight.yangtools.yang.model.api.DataSchemaNode;
+import org.opendaylight.yangtools.yang.model.api.NotificationDefinition;
+import org.opendaylight.yangtools.yang.model.api.RpcDefinition;
+import org.opendaylight.yangtools.yang.model.api.SchemaNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class XmlNodeConverterTest extends AbstractCodecTest {
+    private static final Logger LOG = LoggerFactory.getLogger(XmlNodeConverterTest.class);
+
+    private final NodeConverter bindingSerializer;
+
+    public XmlNodeConverterTest() {
+        bindingSerializer = new XmlNodeConverter(this.effectiveModelContext);
+    }
+
+    @Test
+    public void testSerializeRpc_in() throws Exception {
+        Optional<? extends RpcDefinition>
+                loadRpc = ConverterUtils.loadRpc(this.effectiveModelContext, SIMPLE_IO_RPC_QNAME);
+        Writer serializeRpc =
+                bindingSerializer.serializeRpc(loadRpc.get().getInput(), testedSimpleRpcInputNormalizedNodes);
+        Assert.assertFalse(Strings.isNullOrEmpty(serializeRpc.toString()));
+        LOG.info(serializeRpc.toString());
+    }
+
+    @Test
+    public void testSerializeRpc_out() throws Exception {
+        Optional<? extends RpcDefinition>
+                loadRpc = ConverterUtils.loadRpc(this.effectiveModelContext, SIMPLE_IO_RPC_QNAME);
+        Writer serializeRpc =
+                bindingSerializer.serializeRpc(loadRpc.get().getOutput(), testedSimpleRpcOutputNormalizedNodes);
+        Assert.assertFalse(Strings.isNullOrEmpty(serializeRpc.toString()));
+        LOG.info(serializeRpc.toString());
+    }
+
+    @Test
+    public void testSerializeData() throws Exception {
+        Writer serializeData =
+                bindingSerializer.serializeData(this.effectiveModelContext, testedToasterNormalizedNodes);
+        Assert.assertFalse(Strings.isNullOrEmpty(serializeData.toString()));
+        LOG.info(serializeData.toString());
+    }
+
+    @Test
+    public void testDeserializeData() throws Exception {
+        final DataSchemaNode schemaNode = DataSchemaContextTree.from(this.effectiveModelContext)
+                .getChild(YangInstanceIdentifier.of(Toaster.QNAME)).getDataSchemaNode();
+
+        NormalizedNode<?, ?> deserializeData =
+                bindingSerializer.deserialize(schemaNode, new StringReader(loadToasterXml()));
+        Assert.assertNotNull(deserializeData);
+        LOG.info(deserializeData.toString());
+    }
+
+    @Test
+    public void testDeserializeRpc_in() throws Exception {
+        Optional<? extends RpcDefinition>
+                loadRpc = ConverterUtils.loadRpc(this.effectiveModelContext, SIMPLE_IO_RPC_QNAME);
+        String loadMakeToasterInputXml = loadResourceAsString("input-output-rpc-in.xml");
+        NormalizedNode<?, ?> deserializeRpc =
+                bindingSerializer.deserialize(loadRpc.get().getInput(), new StringReader(loadMakeToasterInputXml));
+        Assert.assertNotNull(deserializeRpc);
+        LOG.info(deserializeRpc.toString());
+    }
+
+    @Test
+    public void testDeserializeRpc_out() throws Exception {
+        Optional<? extends RpcDefinition>
+                loadRpc = ConverterUtils.loadRpc(this.effectiveModelContext, SIMPLE_IO_RPC_QNAME);
+        String loadMakeToasterInputXml = loadResourceAsString("input-output-rpc-out.xml");
+        NormalizedNode<?, ?> deserializeRpc =
+                bindingSerializer.deserialize(loadRpc.get().getOutput(), new StringReader(loadMakeToasterInputXml));
+        Assert.assertNotNull(deserializeRpc);
+        LOG.info(deserializeRpc.toString());
+    }
+
+    @Test
+    public void testLoadNotification() throws Exception {
+        Optional<? extends NotificationDefinition> loadNotification =
+                ConverterUtils.loadNotification(this.effectiveModelContext,
+                        QName.create(TOASTER_NAMESPACE, TOASTER_REVISION, "toasterRestocked"));
+        Assert.assertNotNull(loadNotification);
+        Assert.assertTrue(loadNotification.isPresent());
+    }
+
+    @Test
+    @Ignore
+    public void testSerializeNotification() throws Exception {
+        String notification = loadResourceAsString("notification.xml");
+        Optional<? extends NotificationDefinition> loadNotification =
+                ConverterUtils.loadNotification(this.effectiveModelContext,
+                        QName.create(TOASTER_NAMESPACE, TOASTER_REVISION, "toasterRestocked"));
+        NormalizedNode<?, ?> nodes =
+                bindingSerializer.deserialize(loadNotification.get(), new StringReader(notification));
+        Assert.assertNotNull(nodes);
+    }
+
+    @Test
+    public void testSerializeData_container() throws SerializationException {
+        final DataSchemaNode schemaNode = DataSchemaContextTree.from(this.effectiveModelContext)
+                .getChild(YangInstanceIdentifier.of(TopLevelContainer.QNAME)).getDataSchemaNode();
+
+        NormalizedNode<?, ?> deserializeData = bindingSerializer.deserialize(schemaNode,
+                new StringReader(loadResourceAsString("top-level-container.xml")));
+        Assert.assertNotNull(deserializeData);
+        LOG.info(deserializeData.toString());
+    }
+
+    @Test
+    public void testSerializeData_container_rpc() throws SerializationException {
+        Optional<? extends RpcDefinition>
+                loadRpc = ConverterUtils.loadRpc(this.effectiveModelContext, CONTAINER_IO_RPC_QNAME);
+        NormalizedNode<?, ?> deserializeData = bindingSerializer.deserialize(loadRpc.get().getInput(),
+                new StringReader(loadResourceAsString("container-io-rpc.xml")));
+        Assert.assertNotNull(deserializeData);
+    }
+
+    @Test
+    public void testSerializeData_list() throws SerializationException {
+        SchemaNode schemaNode = ConverterUtils.getSchemaNode(this.effectiveModelContext, SAMPLES_NAMESPACE,
+                SAMPLES_REVISION, "sample-list");
+        Writer serializedData = bindingSerializer.serializeData(schemaNode, testedSampleListNormalizedNodes);
+        Assert.assertNotNull(serializedData.toString());
+    }
+
+    @Test
+    public void testDeserializeData_list_single() throws SerializationException {
+        SchemaNode schemaNode = ConverterUtils.getSchemaNode(this.effectiveModelContext, SAMPLES_NAMESPACE,
+                SAMPLES_REVISION, "sample-list");
+        NormalizedNode<?, ?> serializedData =
+                bindingSerializer.deserialize(schemaNode, new StringReader(loadResourceAsString("sample-list.xml")));
+        Assert.assertNotNull(serializedData.toString());
+    }
+
+    @Test
+    public void testDeserializeData_list_multiple() throws SerializationException, URISyntaxException {
+        NormalizedNode<?, ?> serializedData = bindingSerializer.deserialize(this.effectiveModelContext,
+                new StringReader(loadResourceAsString("sample-list-multiple.xml")));
+        Assert.assertNotNull(serializedData.toString());
+    }
+}

--- a/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/XmlNodeConverterTest.java
+++ b/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/XmlNodeConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Pantheon Technologies s.r.o. All Rights Reserved.
+ * Copyright (c) 2021 Pantheon Technologies s.r.o. All Rights Reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution,
@@ -24,11 +24,8 @@ import org.opendaylight.yangtools.yang.model.api.DataSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.NotificationDefinition;
 import org.opendaylight.yangtools.yang.model.api.RpcDefinition;
 import org.opendaylight.yangtools.yang.model.api.SchemaNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class XmlNodeConverterTest extends AbstractCodecTest {
-    private static final Logger LOG = LoggerFactory.getLogger(XmlNodeConverterTest.class);
 
     private final NodeConverter bindingSerializer;
 
@@ -43,7 +40,6 @@ public class XmlNodeConverterTest extends AbstractCodecTest {
         Writer serializeRpc =
                 bindingSerializer.serializeRpc(loadRpc.orElseThrow().getInput(), testedSimpleRpcInputNormalizedNodes);
         Assert.assertFalse(Strings.isNullOrEmpty(serializeRpc.toString()));
-        LOG.info(serializeRpc.toString());
     }
 
     @Test
@@ -53,7 +49,6 @@ public class XmlNodeConverterTest extends AbstractCodecTest {
         Writer serializeRpc =
                 bindingSerializer.serializeRpc(loadRpc.orElseThrow().getOutput(), testedSimpleRpcOutputNormalizedNodes);
         Assert.assertFalse(Strings.isNullOrEmpty(serializeRpc.toString()));
-        LOG.info(serializeRpc.toString());
     }
 
     @Test
@@ -61,7 +56,6 @@ public class XmlNodeConverterTest extends AbstractCodecTest {
         Writer serializeData =
                 bindingSerializer.serializeData(this.effectiveModelContext, testedToasterNormalizedNodes);
         Assert.assertFalse(Strings.isNullOrEmpty(serializeData.toString()));
-        LOG.info(serializeData.toString());
     }
 
     @Test
@@ -72,7 +66,6 @@ public class XmlNodeConverterTest extends AbstractCodecTest {
         NormalizedNode<?, ?> deserializeData =
                 bindingSerializer.deserialize(schemaNode, new StringReader(loadToasterXml()));
         Assert.assertNotNull(deserializeData);
-        LOG.info(deserializeData.toString());
     }
 
     @Test
@@ -83,7 +76,6 @@ public class XmlNodeConverterTest extends AbstractCodecTest {
         NormalizedNode<?, ?> deserializeRpc = bindingSerializer
                 .deserialize(loadRpc.orElseThrow().getInput(), new StringReader(loadMakeToasterInputXml));
         Assert.assertNotNull(deserializeRpc);
-        LOG.info(deserializeRpc.toString());
     }
 
     @Test
@@ -94,7 +86,6 @@ public class XmlNodeConverterTest extends AbstractCodecTest {
         NormalizedNode<?, ?> deserializeRpc = bindingSerializer
                 .deserialize(loadRpc.orElseThrow().getOutput(), new StringReader(loadMakeToasterInputXml));
         Assert.assertNotNull(deserializeRpc);
-        LOG.info(deserializeRpc.toString());
     }
 
     @Test
@@ -126,7 +117,6 @@ public class XmlNodeConverterTest extends AbstractCodecTest {
         NormalizedNode<?, ?> deserializeData = bindingSerializer.deserialize(schemaNode,
                 new StringReader(loadResourceAsString("top-level-container.xml")));
         Assert.assertNotNull(deserializeData);
-        LOG.info(deserializeData.toString());
     }
 
     @Test

--- a/lighty-core/lighty-codecs-util/src/test/resources/container-io-rpc.json
+++ b/lighty-core/lighty-codecs-util/src/test/resources/container-io-rpc.json
@@ -1,0 +1,8 @@
+{
+    "input": {
+        "sample-container": {
+            "name": "name",
+            "value": 1
+        }
+    }
+}

--- a/lighty-core/lighty-codecs-util/src/test/resources/container-io-rpc.xml
+++ b/lighty-core/lighty-codecs-util/src/test/resources/container-io-rpc.xml
@@ -1,0 +1,1 @@
+<input xmlns="http://pantheon.tech/ns/test-models"><sample-container><name>name</name><value>1</value></sample-container></input>

--- a/lighty-core/lighty-codecs-util/src/test/resources/input-output-rpc-in.json
+++ b/lighty-core/lighty-codecs-util/src/test/resources/input-output-rpc-in.json
@@ -1,0 +1,1 @@
+{"input":{"input-obj":"a"}}

--- a/lighty-core/lighty-codecs-util/src/test/resources/input-output-rpc-in.xml
+++ b/lighty-core/lighty-codecs-util/src/test/resources/input-output-rpc-in.xml
@@ -1,0 +1,1 @@
+<input xmlns="http://pantheon.tech/ns/test-models"><input-obj>a</input-obj></input>

--- a/lighty-core/lighty-codecs-util/src/test/resources/input-output-rpc-out.json
+++ b/lighty-core/lighty-codecs-util/src/test/resources/input-output-rpc-out.json
@@ -1,0 +1,1 @@
+{"output":{"output-obj":"a"}}

--- a/lighty-core/lighty-codecs-util/src/test/resources/input-output-rpc-out.xml
+++ b/lighty-core/lighty-codecs-util/src/test/resources/input-output-rpc-out.xml
@@ -1,0 +1,1 @@
+<output xmlns="http://pantheon.tech/ns/test-models"><output-obj>a</output-obj></output>

--- a/lighty-core/lighty-codecs-util/src/test/resources/make-toast-input_norev.xml
+++ b/lighty-core/lighty-codecs-util/src/test/resources/make-toast-input_norev.xml
@@ -1,0 +1,4 @@
+<make-toast xmlns="http://netconfcentral.org/ns/toaster">
+    <toasterDoneness>5</toasterDoneness>
+    <toasterToastType>wheat-bread</toasterToastType>
+</make-toast>

--- a/lighty-core/lighty-codecs-util/src/test/resources/make-toast-input_rev.xml
+++ b/lighty-core/lighty-codecs-util/src/test/resources/make-toast-input_rev.xml
@@ -1,0 +1,4 @@
+<make-toast xmlns="http://netconfcentral.org/ns/toaster?revision=2009-11-20">
+    <toasterDoneness>5</toasterDoneness>
+    <toasterToastType>wheat-bread</toasterToastType>
+</make-toast>

--- a/lighty-core/lighty-codecs-util/src/test/resources/notification.xml
+++ b/lighty-core/lighty-codecs-util/src/test/resources/notification.xml
@@ -1,0 +1,3 @@
+<toasterRestocked xmlns="http://netconfcentral.org/ns/toaster?revision=2009-11-20">
+    <amountOfBread>1</amountOfBread>
+</toasterRestocked>

--- a/lighty-core/lighty-codecs-util/src/test/resources/sample-list-multiple.xml
+++ b/lighty-core/lighty-codecs-util/src/test/resources/sample-list-multiple.xml
@@ -1,0 +1,4 @@
+<data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <sample-list xmlns="http://pantheon.tech/ns/test-models"><name>name1</name><value>1</value></sample-list>
+    <sample-list xmlns="http://pantheon.tech/ns/test-models"><name>name2</name><value>1</value></sample-list>
+</data>

--- a/lighty-core/lighty-codecs-util/src/test/resources/sample-list.xml
+++ b/lighty-core/lighty-codecs-util/src/test/resources/sample-list.xml
@@ -1,0 +1,1 @@
+<sample-list xmlns="http://pantheon.tech/ns/test-models"><name>name1</name><value>1</value></sample-list>

--- a/lighty-core/lighty-codecs-util/src/test/resources/toaster.json
+++ b/lighty-core/lighty-codecs-util/src/test/resources/toaster.json
@@ -1,0 +1,1 @@
+{"toaster:toaster":{"toasterManufacturer":"manufacturer","toasterStatus":"up","darknessFactor":201392110}}

--- a/lighty-core/lighty-codecs-util/src/test/resources/toaster.xml
+++ b/lighty-core/lighty-codecs-util/src/test/resources/toaster.xml
@@ -1,0 +1,1 @@
+<toaster xmlns="http://netconfcentral.org/ns/toaster"><toasterManufacturer>manufacturer</toasterManufacturer><toasterStatus>up</toasterStatus><darknessFactor>201392110</darknessFactor></toaster>

--- a/lighty-core/lighty-codecs-util/src/test/resources/top-level-container.json
+++ b/lighty-core/lighty-codecs-util/src/test/resources/top-level-container.json
@@ -1,0 +1,8 @@
+{
+    "test-models:top-level-container": {
+        "sample-container": {
+            "name": "name",
+            "value": 1
+        }
+    }
+}

--- a/lighty-core/lighty-codecs-util/src/test/resources/top-level-container.xml
+++ b/lighty-core/lighty-codecs-util/src/test/resources/top-level-container.xml
@@ -1,0 +1,6 @@
+<top-level-container xmlns="http://pantheon.tech/ns/test-models">
+    <sample-container>
+        <name>name</name>
+        <value>1</value>
+    </sample-container>
+</top-level-container>

--- a/lighty-core/lighty-codecs/pom.xml
+++ b/lighty-core/lighty-codecs/pom.xml
@@ -52,6 +52,10 @@
             <groupId>org.opendaylight.netconf</groupId>
             <artifactId>restconf-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.opendaylight.netconf</groupId>
+            <artifactId>netconf-api</artifactId>
+        </dependency>
 
         <!-- Test scoped dependencies -->
         <dependency>

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/DataCodec.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/DataCodec.java
@@ -54,6 +54,12 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
+/**
+ * DataCodec.
+ *
+ * @deprecated DataCodec is marked as deprecated because it can be replaced by direct implementation of
+ * {@link BindingNormalizedNodeSerializer} and {@link NodeConverter}.
+ */
 @Deprecated(forRemoval = true)
 public class DataCodec<T extends DataObject> implements Codec<T> {
 

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/DataCodec.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/DataCodec.java
@@ -54,6 +54,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
+@Deprecated(forRemoval = true)
 public class DataCodec<T extends DataObject> implements Codec<T> {
 
     private static final XMLOutputFactory XML_FACTORY;

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/DeserializeIdentifierCodec.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/DeserializeIdentifierCodec.java
@@ -21,6 +21,13 @@ import org.opendaylight.yangtools.yang.model.api.ListSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.Module;
 import org.opendaylight.yangtools.yang.model.api.SchemaContext;
 
+/**
+ * Deserialize YangInstanceIdentifier.
+ *
+ * @deprecated This class can be replaced by the implementation of
+ * {@link org.opendaylight.yangtools.yang.data.util.AbstractStringInstanceIdentifierCodec}.
+ */
+@Deprecated(forRemoval = true)
 public class DeserializeIdentifierCodec {
 
     private final DataSchemaContextTree dataSchemaContextTree;

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/JsonNodeConverter.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/JsonNodeConverter.java
@@ -35,7 +35,7 @@ import org.opendaylight.yangtools.yang.model.api.SchemaNode;
  * The implementation of {@link NodeConverter} which serializes and deserializes binding independent
  * representation into/from JSON representation.
  *
- * @deprecated This class is moved to lighty-codecs-util
+ * @deprecated This class is moved to lighty-codecs-util.
  * @see XmlNodeConverter
  */
 @Deprecated(forRemoval = true)

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/JsonNodeConverter.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/JsonNodeConverter.java
@@ -35,8 +35,10 @@ import org.opendaylight.yangtools.yang.model.api.SchemaNode;
  * The implementation of {@link NodeConverter} which serializes and deserializes binding independent
  * representation into/from JSON representation.
  *
+ * @deprecated This class is moved to lighty-codecs-util
  * @see XmlNodeConverter
  */
+@Deprecated(forRemoval = true)
 public class JsonNodeConverter implements NodeConverter {
 
     private final SchemaContext schemaContext;

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/SerializeIdentifierCodec.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/SerializeIdentifierCodec.java
@@ -29,7 +29,7 @@ import org.opendaylight.yangtools.yang.model.api.SchemaContext;
  * Serialize YangInstanceIdentifier.
  *
  * @deprecated This class can be replaced by the implementation of
- * {@link org.opendaylight.yangtools.yang.data.util.AbstractStringInstanceIdentifierCodec}
+ * {@link org.opendaylight.yangtools.yang.data.util.AbstractStringInstanceIdentifierCodec}.
  */
 @Deprecated(forRemoval = true)
 public class SerializeIdentifierCodec {

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/SerializeIdentifierCodec.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/SerializeIdentifierCodec.java
@@ -25,6 +25,13 @@ import org.opendaylight.yangtools.yang.model.api.ListSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.Module;
 import org.opendaylight.yangtools.yang.model.api.SchemaContext;
 
+/**
+ * Serialize YangInstanceIdentifier.
+ *
+ * @deprecated This class can be replaced by the implementation of
+ * {@link org.opendaylight.yangtools.yang.data.util.AbstractStringInstanceIdentifierCodec}
+ */
+@Deprecated(forRemoval = true)
 public class SerializeIdentifierCodec {
 
     private final SchemaContext schemaContext;

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/XmlNodeConverter.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/XmlNodeConverter.java
@@ -46,7 +46,7 @@ import org.xml.sax.SAXException;
  * The implementation of {@link NodeConverter} which serializes and deserializes binding independent
  * representation into/from XML representation.
  *
- * @deprecated This class is moved to lighty-codecs-util
+ * @deprecated This class is moved to lighty-codecs-util.
  * @see JsonNodeConverter
  */
 @Deprecated(forRemoval = true)

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/XmlNodeConverter.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/XmlNodeConverter.java
@@ -46,8 +46,10 @@ import org.xml.sax.SAXException;
  * The implementation of {@link NodeConverter} which serializes and deserializes binding independent
  * representation into/from XML representation.
  *
+ * @deprecated This class is moved to lighty-codecs-util
  * @see JsonNodeConverter
  */
+@Deprecated(forRemoval = true)
 public class XmlNodeConverter implements NodeConverter {
 
     private static final Logger LOG = LoggerFactory.getLogger(XmlNodeConverter.class);

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Codec.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Codec.java
@@ -12,10 +12,12 @@ import org.opendaylight.yangtools.yang.binding.DataObject;
 import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
 
 /**
- * Codec to serailize/deserialize Binding Independent data, RPC data, Notification data to/from
+ * Codec to serialize/deserialize Binding Independent data, RPC data, Notification data to/from
  * Binding Aware data, RPC data, Notification data.
  *
  * @param <BA> - type of Binding Aware data, RPC data or Notification data
+ * @deprecated Codec is marked as deprecated because it can be replaced by direct implementation
+ * {@link BindingNormalizedNodeSerializer} and {@link NodeConverter}.
  */
 @Deprecated(forRemoval = true)
 public interface Codec<BA extends DataObject> extends Serializer<BA>, Deserializer<BA> {

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Codec.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Codec.java
@@ -17,6 +17,7 @@ import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
  *
  * @param <BA> - type of Binding Aware data, RPC data or Notification data
  */
+@Deprecated(forRemoval = true)
 public interface Codec<BA extends DataObject> extends Serializer<BA>, Deserializer<BA> {
 
     /**

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/ConverterUtils.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/ConverterUtils.java
@@ -31,7 +31,7 @@ import org.xml.sax.SAXException;
 /**
  * A utility class which may be helpful while manipulating with binding independent nodes.
  *
- * @deprecated This class is moved to lighty-codecs-util
+ * @deprecated This class is moved to lighty-codecs-util.
  */
 @Deprecated(forRemoval = true)
 public final class ConverterUtils {

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/ConverterUtils.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/ConverterUtils.java
@@ -30,7 +30,10 @@ import org.xml.sax.SAXException;
 
 /**
  * A utility class which may be helpful while manipulating with binding independent nodes.
+ *
+ * @deprecated This class is moved to lighty-codecs-util
  */
+@Deprecated(forRemoval = true)
 public final class ConverterUtils {
     private ConverterUtils() {
         throw new UnsupportedOperationException("Do not create an instance of utility class");

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Deserializer.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Deserializer.java
@@ -8,6 +8,7 @@
 package io.lighty.codecs.api;
 
 import java.util.Map.Entry;
+import org.opendaylight.mdsal.binding.dom.codec.api.BindingNormalizedNodeSerializer;
 import org.opendaylight.yangtools.yang.binding.DataContainer;
 import org.opendaylight.yangtools.yang.binding.DataObject;
 import org.opendaylight.yangtools.yang.binding.InstanceIdentifier;
@@ -19,7 +20,8 @@ import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
 /**
  * This class deserializes Binding Independent (DOM) objects FROM Binding Aware (BA) objects.
  *
- * @param <BA> Binding Aware object type data, RPC data or Notification data
+ * @param <BA> Binding Aware object type data, RPC data or Notification data.
+ * @deprecated The interface is no longer needed. Used methods are covered by {@link BindingNormalizedNodeSerializer}.
  */
 @Deprecated(forRemoval = true)
 public interface Deserializer<BA extends DataObject> {

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Deserializer.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Deserializer.java
@@ -21,6 +21,7 @@ import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
  *
  * @param <BA> Binding Aware object type data, RPC data or Notification data
  */
+@Deprecated(forRemoval = true)
 public interface Deserializer<BA extends DataObject> {
 
     /**

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/NodeConverter.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/NodeConverter.java
@@ -22,7 +22,7 @@ import org.opendaylight.yangtools.yang.model.api.SchemaNode;
  * JSON representation. Currently there are two implementations {@link XmlNodeConverter} and
  * {@link JsonNodeConverter}.
  *
- * @deprecated This interface is moved to lighty-codecs-util
+ * @deprecated This interface is moved to lighty-codecs-util.
  */
 @Deprecated(forRemoval = true)
 public interface NodeConverter {

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/NodeConverter.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/NodeConverter.java
@@ -21,7 +21,10 @@ import org.opendaylight.yangtools.yang.model.api.SchemaNode;
  * This interface may be useful when (de)serializing {@link NormalizedNode}s (from)into its XML or
  * JSON representation. Currently there are two implementations {@link XmlNodeConverter} and
  * {@link JsonNodeConverter}.
+ *
+ * @deprecated This interface is moved to lighty-codecs-util
  */
+@Deprecated(forRemoval = true)
 public interface NodeConverter {
     /**
      * This method will serialize the given {@link NormalizedNode} into its string representation.

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/SerializationException.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/SerializationException.java
@@ -10,7 +10,7 @@ package io.lighty.codecs.api;
 /**
  * This exception should be thrown when serialization problem occurs.
  *
- * @deprecated This class is moved to lighty-codecs-util
+ * @deprecated This class is moved to lighty-codecs-util.
  */
 @Deprecated(forRemoval = true)
 public class SerializationException extends Exception {

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/SerializationException.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/SerializationException.java
@@ -9,7 +9,10 @@ package io.lighty.codecs.api;
 
 /**
  * This exception should be thrown when serialization problem occurs.
+ *
+ * @deprecated This class is moved to lighty-codecs-util
  */
+@Deprecated(forRemoval = true)
 public class SerializationException extends Exception {
     private static final long serialVersionUID = 2053802415449540367L;
 

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Serializer.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Serializer.java
@@ -8,6 +8,7 @@
 package io.lighty.codecs.api;
 
 import java.util.Collection;
+import org.opendaylight.mdsal.binding.dom.codec.api.BindingNormalizedNodeSerializer;
 import org.opendaylight.yangtools.yang.binding.DataObject;
 import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier;
 import org.opendaylight.yangtools.yang.data.api.schema.ContainerNode;
@@ -19,6 +20,8 @@ import org.opendaylight.yangtools.yang.model.api.SchemaPath;
  * This class serializes Binding Independent (DOM) objects TO Binding Aware (BA) objects.
  *
  * @param <BA>  Binding Aware object type of data, RPC data or Notification data
+ * @deprecated The interface is no longer needed. The most used methods are covered by
+ * {@link BindingNormalizedNodeSerializer}.
  */
 @Deprecated(forRemoval = true)
 public interface Serializer<BA extends DataObject> {

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Serializer.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Serializer.java
@@ -20,6 +20,7 @@ import org.opendaylight.yangtools.yang.model.api.SchemaPath;
  *
  * @param <BA>  Binding Aware object type of data, RPC data or Notification data
  */
+@Deprecated(forRemoval = true)
 public interface Serializer<BA extends DataObject> {
 
     YangInstanceIdentifier convertIdentifier(String identifier);

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/ConflictingVersionException.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/ConflictingVersionException.java
@@ -12,6 +12,8 @@ package io.lighty.codecs.xml;
  * that the transaction cannot be committed due to the fact that another
  * transaction was committed after creating this transaction. Clients can create
  * new transaction and merge the changes.
+ *
+ * @deprecated No longer needed. Used in deprecated {@link DocumentedException}.
  */
 @Deprecated(forRemoval = true)
 public class ConflictingVersionException extends Exception {

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/ConflictingVersionException.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/ConflictingVersionException.java
@@ -13,6 +13,7 @@ package io.lighty.codecs.xml;
  * transaction was committed after creating this transaction. Clients can create
  * new transaction and merge the changes.
  */
+@Deprecated(forRemoval = true)
 public class ConflictingVersionException extends Exception {
     private static final long serialVersionUID = 1L;
 

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/DocumentedException.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/DocumentedException.java
@@ -26,6 +26,8 @@ import org.w3c.dom.NodeList;
 
 /**
  * Checked exception to communicate an error that needs to be sent to the netconf client.
+ *
+ * @deprecated Replaced by OpenDayLight implementation {@link org.opendaylight.netconf.api.DocumentedException}.
  */
 @Deprecated(forRemoval = true)
 public class DocumentedException extends Exception {

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/DocumentedException.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/DocumentedException.java
@@ -27,6 +27,7 @@ import org.w3c.dom.NodeList;
 /**
  * Checked exception to communicate an error that needs to be sent to the netconf client.
  */
+@Deprecated(forRemoval = true)
 public class DocumentedException extends Exception {
 
     public static final String RPC_ERROR = "rpc-error";

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/MissingNameSpaceException.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/MissingNameSpaceException.java
@@ -10,6 +10,11 @@ package io.lighty.codecs.xml;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * MissingNameSpaceException.
+ *
+ * @deprecated No longer needed. Used in deprecated {@link XmlElement}.
+ */
 @Deprecated(forRemoval = true)
 public class MissingNameSpaceException extends DocumentedException {
     private static final long serialVersionUID = 1L;

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/MissingNameSpaceException.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/MissingNameSpaceException.java
@@ -10,6 +10,7 @@ package io.lighty.codecs.xml;
 import java.util.Collections;
 import java.util.Map;
 
+@Deprecated(forRemoval = true)
 public class MissingNameSpaceException extends DocumentedException {
     private static final long serialVersionUID = 1L;
 

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/ModuleIdentifier.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/ModuleIdentifier.java
@@ -9,6 +9,11 @@ package io.lighty.codecs.xml;
 
 import org.opendaylight.yangtools.concepts.Identifier;
 
+/**
+ * ModuleIdentifier.
+ *
+ * @deprecated No longer needed. Used in deprecated {@link ValidationException}.
+ */
 @Deprecated(forRemoval = true)
 public class ModuleIdentifier implements Identifier {
     private static final long serialVersionUID = 1L;

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/ModuleIdentifier.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/ModuleIdentifier.java
@@ -9,6 +9,7 @@ package io.lighty.codecs.xml;
 
 import org.opendaylight.yangtools.concepts.Identifier;
 
+@Deprecated(forRemoval = true)
 public class ModuleIdentifier implements Identifier {
     private static final long serialVersionUID = 1L;
     private final String factoryName;

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/UnexpectedElementException.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/UnexpectedElementException.java
@@ -10,6 +10,11 @@ package io.lighty.codecs.xml;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * UnexpectedElementException.
+ *
+ * @deprecated No longer needed. Used in deprecated {@link XmlElement}.
+ */
 @Deprecated(forRemoval = true)
 public class UnexpectedElementException extends DocumentedException {
     private static final long serialVersionUID = 1L;

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/UnexpectedElementException.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/UnexpectedElementException.java
@@ -10,6 +10,7 @@ package io.lighty.codecs.xml;
 import java.util.Collections;
 import java.util.Map;
 
+@Deprecated(forRemoval = true)
 public class UnexpectedElementException extends DocumentedException {
     private static final long serialVersionUID = 1L;
 

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/UnexpectedNamespaceException.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/UnexpectedNamespaceException.java
@@ -10,6 +10,11 @@ package io.lighty.codecs.xml;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * ValidationException.
+ *
+ * @deprecated No longer needed. Used in deprecated {@link XmlElement}.
+ */
 @Deprecated(forRemoval = true)
 public class UnexpectedNamespaceException extends DocumentedException {
     private static final long serialVersionUID = 1L;

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/UnexpectedNamespaceException.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/UnexpectedNamespaceException.java
@@ -10,6 +10,7 @@ package io.lighty.codecs.xml;
 import java.util.Collections;
 import java.util.Map;
 
+@Deprecated(forRemoval = true)
 public class UnexpectedNamespaceException extends DocumentedException {
     private static final long serialVersionUID = 1L;
 

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/ValidationException.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/ValidationException.java
@@ -15,6 +15,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+/**
+ * ValidationException.
+ *
+ * @deprecated No longer needed. Used in deprecated {@link DocumentedException}.
+ */
 @Deprecated(forRemoval = true)
 public class ValidationException extends Exception {
     private static final long serialVersionUID = -6072893219820274247L;

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/ValidationException.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/ValidationException.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+@Deprecated(forRemoval = true)
 public class ValidationException extends Exception {
     private static final long serialVersionUID = -6072893219820274247L;
 

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlElement.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlElement.java
@@ -29,6 +29,11 @@ import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
 import org.xml.sax.SAXException;
 
+/**
+ * XmlElement.
+ *
+ * @deprecated Replaced by OpenDayLight implementation {@link org.opendaylight.netconf.api.xml.XmlElement}.
+ */
 @Deprecated(forRemoval = true)
 public final class XmlElement {
     public static final String DEFAULT_NAMESPACE_PREFIX = "";

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlElement.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlElement.java
@@ -29,6 +29,7 @@ import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
 import org.xml.sax.SAXException;
 
+@Deprecated(forRemoval = true)
 public final class XmlElement {
     public static final String DEFAULT_NAMESPACE_PREFIX = "";
 

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlMappingConstants.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlMappingConstants.java
@@ -7,6 +7,11 @@
  */
 package io.lighty.codecs.xml;
 
+/**
+ * XmlMappingConstants.
+ *
+ * @deprecated No longer needed. Used in deprecated {@link DocumentedException} and {@link XmlUtil} .
+ */
 @Deprecated(forRemoval = true)
 public final class XmlMappingConstants {
     public static final String RPC_REPLY_KEY = "rpc-reply";

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlMappingConstants.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlMappingConstants.java
@@ -7,6 +7,7 @@
  */
 package io.lighty.codecs.xml;
 
+@Deprecated(forRemoval = true)
 public final class XmlMappingConstants {
     public static final String RPC_REPLY_KEY = "rpc-reply";
     public static final String TYPE_KEY = "type";

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlUtil.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlUtil.java
@@ -37,6 +37,11 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
 
+/**
+ * XmlUtil.
+ *
+ * @deprecated Replaced by OpenDayLight implementation {@link org.opendaylight.netconf.api.xml.XmlUtil}.
+ */
 @Deprecated(forRemoval = true)
 public final class XmlUtil {
 

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlUtil.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlUtil.java
@@ -37,6 +37,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
 
+@Deprecated(forRemoval = true)
 public final class XmlUtil {
 
     public static final String XMLNS_ATTRIBUTE_KEY = "xmlns";

--- a/lighty-core/pom.xml
+++ b/lighty-core/pom.xml
@@ -29,6 +29,7 @@
 
         <module>lighty-clustering</module>
         <module>lighty-codecs</module>
+        <module>lighty-codecs-util</module>
         <module>lighty-common</module>
         <module>lighty-controller</module>
         <module>lighty-controller-spring-di</module>


### PR DESCRIPTION
lighty-codecs-util is a replacement for deprecated lighty-codecs as it duplicates some classes from ODL base.

Utility classes from lighty-codecs have been copied into new lighty-codecs-util package.
Outdated & deprecated methods used in lighty-codecs-util was replaced by new methods from upstream.