### PR TITLE
Prepare release 12.2.3 before archive

### DIFF
--- a/lighty-core/lighty-controller/README.md
+++ b/lighty-core/lighty-controller/README.md
@@ -17,7 +17,7 @@ To use Lighty controller in your project:
   <dependency>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-controller</artifactId>
-    <version>12.2.2-SNAPSHOT</version>
+    <version>12.2.3</version>
   </dependency>
 ```
 

--- a/lighty-examples/README.md
+++ b/lighty-examples/README.md
@@ -17,7 +17,7 @@ ODL core services represent MD-SAL layer, controller, DataStore, global schema c
    <dependency>
       <groupId>io.lighty.core.parents</groupId>
       <artifactId>lighty-dependency-artifacts</artifactId>
-      <version>12.2.2-SNAPSHOT</version>
+      <version>12.2.3</version>
       <type>pom</type>
       <scope>import</scope>
    </dependency>

--- a/lighty-examples/lighty-cluster-app/Dockerfile.k8s
+++ b/lighty-examples/lighty-cluster-app/Dockerfile.k8s
@@ -1,9 +1,9 @@
 FROM openjdk:11-jre-slim
 
-COPY target/lighty-cluster-app-12.2.2-SNAPSHOT-bin.zip /
+COPY target/lighty-cluster-app-12.2.3-bin.zip /
 
 RUN apt-get update && apt-get install unzip \
-    && unzip /lighty-cluster-app-12.2.2-SNAPSHOT-bin.zip \
-    && rm /lighty-cluster-app-12.2.2-SNAPSHOT-bin.zip
+    && unzip /lighty-cluster-app-12.2.3-bin.zip \
+    && rm /lighty-cluster-app-12.2.3-bin.zip
 
-ENTRYPOINT ["/lighty-cluster-app-12.2.2-SNAPSHOT/start-controller-node-k8s.sh"]
+ENTRYPOINT ["/lighty-cluster-app-12.2.3/start-controller-node-k8s.sh"]

--- a/lighty-examples/lighty-cluster-app/src/main/assembly/resources/start-controller-node-k8s.sh
+++ b/lighty-examples/lighty-cluster-app/src/main/assembly/resources/start-controller-node-k8s.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 #start controller
-cd /lighty-cluster-app-12.2.2-SNAPSHOT
-java -ms128m -mx128m -XX:MaxMetaspaceSize=128m -jar lighty-cluster-app-12.2.2-SNAPSHOT.jar -n 0 -k
+cd /lighty-cluster-app-12.2.3
+java -ms128m -mx128m -XX:MaxMetaspaceSize=128m -jar lighty-cluster-app-12.2.3.jar -n 0 -k

--- a/lighty-examples/lighty-community-netconf-quarkus-app/README.md
+++ b/lighty-examples/lighty-community-netconf-quarkus-app/README.md
@@ -30,7 +30,7 @@ mvn clean compile quarkus:dev
 ## Build package & Run
 ```
 mvn clean package
-java -Xms128m -Xmx128m -XX:MaxMetaspaceSize=128m -jar target/lighty-quarkus-netconf-app-12.2.2-SNAPSHOT-runner.jar
+java -Xms128m -Xmx128m -XX:MaxMetaspaceSize=128m -jar target/lighty-quarkus-netconf-app-12.2.3-runner.jar
 ```
 
 ## Build native image

--- a/lighty-examples/lighty-community-netconf-quarkus-app/pom.xml
+++ b/lighty-examples/lighty-community-netconf-quarkus-app/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.lighty.quarkus</groupId>
   <artifactId>lighty-quarkus-netconf-app</artifactId>
-  <version>12.2.2-SNAPSHOT</version>
+  <version>12.2.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -15,7 +15,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
     <application.attach.zip>true</application.attach.zip>
-    <lighty.version>12.2.2-SNAPSHOT</lighty.version>
+    <lighty.version>12.2.3-SNAPSHOT</lighty.version>
   </properties>
 
   <dependencyManagement>

--- a/lighty-examples/lighty-community-restconf-netconf-app/README.md
+++ b/lighty-examples/lighty-community-restconf-netconf-app/README.md
@@ -21,12 +21,12 @@ build the project: ```mvn clean install```
 ### Start this demo example
 * build the project using ```mvn clean install```
 * go to target directory ```cd lighty-examples/lighty-community-restconf-netconf-app/target``` 
-* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-12.2.2-SNAPSHOT-bin.zip```
-* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-12.2.2-SNAPSHOT```
-* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-12.2.2-SNAPSHOT.jar``` 
+* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-12.2.3-bin.zip```
+* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-12.2.3```
+* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-12.2.3.jar``` 
 
 ### Test example application
-Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-12.2.2-SNAPSHOT.jar``` 
+Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-12.2.3.jar``` 
 RESTCONF web interface is available at URL ```http://localhost:8888/restconf/*```
 
 ##### URLs to start with
@@ -47,7 +47,7 @@ URLs for Swagger RESTCONF [draft02](https://tools.ietf.org/html/draft-bierman-ne
 
 ### Use custom config files
 There are two separated config files: for NETCONF SBP single node and for cluster.
-`java -jar lighty-community-restconf-netconf-app-12.2.2-SNAPSHOT.jar /path/to/singleNodeConfig.json`
+`java -jar lighty-community-restconf-netconf-app-12.2.3.jar /path/to/singleNodeConfig.json`
 
 Example configuration for single node is [here](src/main/assembly/resources/sampleConfigSingleNode.json)
 

--- a/lighty-examples/lighty-community-restconf-ofp-app/Dockerfile
+++ b/lighty-examples/lighty-community-restconf-ofp-app/Dockerfile
@@ -1,15 +1,15 @@
 FROM openjdk:8u191-jre-alpine3.9
 
-COPY ./target/lighty-community-restconf-ofp-app-12.2.2-SNAPSHOT-bin.zip /
+COPY ./target/lighty-community-restconf-ofp-app-12.2.3-bin.zip /
 
-RUN unzip /lighty-community-restconf-ofp-app-12.2.2-SNAPSHOT-bin.zip && rm /lighty-community-restconf-ofp-app-12.2.2-SNAPSHOT-bin.zip
+RUN unzip /lighty-community-restconf-ofp-app-12.2.3-bin.zip && rm /lighty-community-restconf-ofp-app-12.2.3-bin.zip
 
 ##libstdc++ is required by leveldbjni-1.8 (Akka dispatcher)
 #Uncaught error from thread [opendaylight-cluster-data-akka.persistence.dispatchers.default-plugin-dispatcher-22]: Could not load library. Reasons: [no leveldbjni64-1.8 in java.library.path, no leveldbjni-1.8 in java.library.path, no leveldbjni in java.library.path, /tmp/libleveldbjni-64-1-3166161234556196376.8: Error loading shared library libstdc++.so.6: No such file or directory (needed by /tmp/libleveldbjni-64-1-3166161234556196376.8)], shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled for ActorSystem[opendaylight-cluster-data]
 RUN apk add --update libstdc++ curl && \
     rm -rf /var/cache/apk/*
 
-WORKDIR /lighty-community-restconf-ofp-app-12.2.2-SNAPSHOT
+WORKDIR /lighty-community-restconf-ofp-app-12.2.3
 
 EXPOSE 8888
 EXPOSE 8185
@@ -18,4 +18,4 @@ EXPOSE 6653
 EXPOSE 2550
 EXPOSE 80
 
-CMD java -jar lighty-community-restconf-ofp-app-12.2.2-SNAPSHOT.jar sampleConfigSingleNode.json
+CMD java -jar lighty-community-restconf-ofp-app-12.2.3.jar sampleConfigSingleNode.json

--- a/lighty-examples/lighty-community-restconf-ofp-app/README.md
+++ b/lighty-examples/lighty-community-restconf-ofp-app/README.md
@@ -12,7 +12,7 @@ Build the project using maven command: ```mvn clean install```.
 This will create *.zip* archive in target directory. Extract this archive
 and run *.jar* file using java with command:
 ```
-java -jar lighty-community-restconf-ofp-app-12.2.2-SNAPSHOT.jar
+java -jar lighty-community-restconf-ofp-app-12.2.3.jar
 ```
 
 ### Use custom config files
@@ -24,7 +24,7 @@ after build.
 
 When running application pass path to configuration file as argument:
 ```
-java -jar lighty-community-restconf-ofp-app-12.2.2-SNAPSHOT.jar sampleConfigSingleNode.json
+java -jar lighty-community-restconf-ofp-app-12.2.3.jar sampleConfigSingleNode.json
 ```
 
 ### Building and running Docker Image

--- a/lighty-examples/lighty-controller-springboot-netconf/README.md
+++ b/lighty-examples/lighty-controller-springboot-netconf/README.md
@@ -46,7 +46,7 @@ mvn spring-boot:run
 or
 
 ```
-java -jar target/lighty-controller-springboot-12.2.2-SNAPSHOT.jar
+java -jar target/lighty-controller-springboot-12.2.3.jar
 ```
 
 or in any IDE, run main in 

--- a/lighty-models/README.md
+++ b/lighty-models/README.md
@@ -56,7 +56,7 @@ my-model/pom.xml
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>12.2.2-SNAPSHOT</version>
+        <version>12.2.3</version>
         <relativePath/>
     </parent>
 

--- a/lighty-modules/lighty-netconf-sb/README.md
+++ b/lighty-modules/lighty-netconf-sb/README.md
@@ -42,7 +42,7 @@ To use NETCONF in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-netconf-sb</artifactId>
-    <version>12.2.2-SNAPSHOT</version>
+    <version>12.2.3</version>
   </dependency>  
 ```
 2. Initialize and start an instance of NETCONF SBP in your code:

--- a/lighty-modules/lighty-openflow-sb/README.md
+++ b/lighty-modules/lighty-openflow-sb/README.md
@@ -10,7 +10,7 @@ is Lighty's version of openflow plugin.
 <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-openflow-sb</artifactId>
-    <version>12.2.2-SNAPSHOT</version>
+    <version>12.2.3</version>
 </dependency>
 ```
 

--- a/lighty-modules/lighty-restconf-nb-community/README.md
+++ b/lighty-modules/lighty-restconf-nb-community/README.md
@@ -12,7 +12,7 @@ To use RESTCONF in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-restconf-nb-community</artifactId>
-    <version>12.2.2-SNAPSHOT</version>
+    <version>12.2.3</version>
   </dependency>
 ```
 


### PR DESCRIPTION
Prepare files skipped by maven-release-plugin for release 13.1.1 before archiving branch 13.1.x

Release notes:
```
Migrate from travis to GH actions
- uploading & storing built artifacts in GH
- easier integration for forked repositories with GH actions & SonarCloud
```