### PR TITLE
Fix Akka connection issue in example apps

### DIFF
--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
@@ -422,7 +422,7 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
             final CompletableFuture<Terminated> actorSystemTerminatedFuture = this.actorSystemProvider
                     .getActorSystem()
                     .getWhenTerminated().toCompletableFuture();
-            final int actorSystemPort = this.actorSystemConfig.getInt("akka.remote.netty.tcp.port");
+            final int actorSystemPort = this.actorSystemConfig.getInt("akka.remote.classic.netty.tcp.port");
 
             try {
                 this.actorSystemProvider.close();

--- a/lighty-resources/singlenode-configuration/src/main/resources/singlenode/akka-default.conf
+++ b/lighty-resources/singlenode-configuration/src/main/resources/singlenode/akka-default.conf
@@ -5,7 +5,7 @@ akka {
       canonical.hostname = "127.0.0.1"
       canonical.port = 2550
     }
-    netty.tcp {
+    classic.netty.tcp {
       hostname = "127.0.0.1"
       port = 2550
     }

--- a/lighty-resources/singlenode-configuration/src/main/resources/singlenode/factory-akka-default.conf
+++ b/lighty-resources/singlenode-configuration/src/main/resources/singlenode/factory-akka-default.conf
@@ -62,11 +62,13 @@ akka {
       java = "akka.serialization.JavaSerializer"
       proto = "akka.remote.serialization.ProtobufSerializer"
       readylocal = "org.opendaylight.controller.cluster.datastore.messages.ReadyLocalTransactionSerializer"
+      simpleReplicatedLogEntry = "org.opendaylight.controller.cluster.raft.persisted.SimpleReplicatedLogEntrySerializer"
     }
 
     serialization-bindings {
       "com.google.protobuf.Message" = proto
       "org.opendaylight.controller.cluster.datastore.messages.ReadyLocalTransaction" = readylocal
+      "org.opendaylight.controller.cluster.raft.persisted.SimpleReplicatedLogEntry" = simpleReplicatedLogEntry
     }
 
     default-dispatcher {
@@ -87,7 +89,7 @@ akka {
     # with read-only associations
     use-passive-connections = off
 
-    netty.tcp {
+    classic.netty.tcp {
       maximum-frame-size = 419430400
       send-buffer-size = 52428800
       receive-buffer-size = 52428800


### PR DESCRIPTION
 - Association with remote system [akka.tcp://opendaylight-cluster-data@127.0.0.1:2550]
   has failed, address is now gated for [5000] ms Caused by:
   [java.net.ConnectException: Connection refused: /127.0.0.1:2550]

Signed-off-by: Peter Suna <peter.suna@pantheon.tech>