### PR TITLE
Update workflow to publish docker & helm [13.3.x]

### DIFF
--- a/.github/workflows/publish-docker-helm.yml
+++ b/.github/workflows/publish-docker-helm.yml
@@ -57,7 +57,7 @@ jobs:
           DOCKER_IMAGE_NAME_TAG=$(echo $DOCKER_IMAGE_NAME:${{ github.event.inputs.image-tag }})
           echo "DOCKER_IMAGE_NAME_TAG=$(echo $DOCKER_IMAGE_NAME_TAG)" >> $GITHUB_ENV
       - name: Build docker image
-        run: mvn install -B -pl :${{ github.event.inputs.app-name }},:${{ github.event.inputs.app-name }}-docker -am -P docker
+        run: mvn install -B -pl :${{ github.event.inputs.app-name }},:${{ github.event.inputs.app-name }}-docker -P docker
       - name: Rename image to desired
         run: |
           image_name=$(mvn help:evaluate -f ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-docker/pom.xml -Dexpression=image.name -q -DforceStdout)

--- a/.github/workflows/publish-docker-helm.yml
+++ b/.github/workflows/publish-docker-helm.yml
@@ -11,8 +11,12 @@ on:
         default: lighty-rnc
         required: true
       image-tag:
-        description: Desired TAG of docker image
+        description: Desired TAG of docker image. Please provide specific tag and also use `image-tag-latest` parameter if you want to also use `latest` tag.
         default: latest
+        required: true
+      image-tag-latest:
+        description: Should be this docker labeled with tag latest? Enter `true` if the tag `latest` should be added for image.
+        default: "false"
         required: true
       helm-chart-version:
         description: Desired version of released helm chart, (if "default" the version from Chart.yaml will be used)
@@ -55,14 +59,18 @@ jobs:
         run: |
           DOCKER_IMAGE_NAME=$(echo ghcr.io/pantheontech/${{ github.event.inputs.image-name }})
           DOCKER_IMAGE_NAME_TAG=$(echo $DOCKER_IMAGE_NAME:${{ github.event.inputs.image-tag }})
+          echo "DOCKER_IMAGE_NAME=$(echo $DOCKER_IMAGE_NAME)" >> $GITHUB_ENV
           echo "DOCKER_IMAGE_NAME_TAG=$(echo $DOCKER_IMAGE_NAME_TAG)" >> $GITHUB_ENV
       - name: Build docker image
         run: mvn install -B -pl :${{ github.event.inputs.app-name }},:${{ github.event.inputs.app-name }}-docker -P docker
-      - name: Rename image to desired
+      - name: Tag image
         run: |
           image_name=$(mvn help:evaluate -f ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-docker/pom.xml -Dexpression=image.name -q -DforceStdout)
           docker tag $image_name $DOCKER_IMAGE_NAME_TAG
-          docker images
+          if [ "${{ github.event.inputs.image-tag-latest }}" = 'true' ]; then
+            docker tag $image_name $DOCKER_IMAGE_NAME:latest
+          fi
+          docker images | grep $image_name
       - name: List docker images
         run: |
           docker images
@@ -72,6 +80,9 @@ jobs:
       - name: Publish docker image (ghcr.io)
         run: |
           docker push $DOCKER_IMAGE_NAME_TAG
+          if [ "${{ github.event.inputs.image-tag-latest }}" = 'true' ]; then
+            docker push $DOCKER_IMAGE_NAME:latest
+          fi
       - name: Check if docker image is pullable  (ghcr.io)
         run: |
           docker rmi $DOCKER_IMAGE_NAME_TAG

--- a/.github/workflows/publish-docker-helm.yml
+++ b/.github/workflows/publish-docker-helm.yml
@@ -10,18 +10,13 @@ on:
         description: Desired NAME of docker image
         default: lighty-rnc
         required: true
-      image-tag:
-        description: Desired TAG of docker image. Please provide specific tag and also use `image-tag-latest` parameter if you want to also use `latest` tag.
-        default: latest
+      version:
+        description: Desired version of published docker image & helm charts
         required: true
       image-tag-latest:
         description: Should be this docker labeled with tag latest? Enter `true` if the tag `latest` should be added for image.
         default: "false"
         required: true
-      helm-chart-version:
-        description: Desired version of released helm chart, (if "default" the version from Chart.yaml will be used)
-        default: default
-        required: false
       checkout-ref:
         description: The branch, tag or SHA to checkout. (if "default" the selected branch will be used)
         default: default
@@ -58,7 +53,7 @@ jobs:
       - name: Env docker image name
         run: |
           DOCKER_IMAGE_NAME=$(echo ghcr.io/pantheontech/${{ github.event.inputs.image-name }})
-          DOCKER_IMAGE_NAME_TAG=$(echo $DOCKER_IMAGE_NAME:${{ github.event.inputs.image-tag }})
+          DOCKER_IMAGE_NAME_TAG=$(echo $DOCKER_IMAGE_NAME:${{ github.event.inputs.version }})
           echo "DOCKER_IMAGE_NAME=$(echo $DOCKER_IMAGE_NAME)" >> $GITHUB_ENV
           echo "DOCKER_IMAGE_NAME_TAG=$(echo $DOCKER_IMAGE_NAME_TAG)" >> $GITHUB_ENV
       - name: Build docker image
@@ -92,12 +87,12 @@ jobs:
           sudo snap install yq
       - name: Set image.name, image.version in values.yaml of helm chart
         run: |
-          yq eval '.image.name="ghcr.io/pantheontech/${{ github.event.inputs.image-name }}" | .image.version="${{ github.event.inputs.image-tag }}"' ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-app-helm/helm/${{ github.event.inputs.app-name }}-app-helm/values.yaml -i
+          yq eval '.image.name="ghcr.io/pantheontech/${{ github.event.inputs.image-name }}" | .image.version="${{ github.event.inputs.version }}"' ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-app-helm/helm/${{ github.event.inputs.app-name }}-app-helm/values.yaml -i
       - name: Print values.yaml
         run: |
           cat -A ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-app-helm/helm/${{ github.event.inputs.app-name }}-app-helm/values.yaml
-      - name: "Publish Helm chart to Helm repository (Version: ${{ github.event.inputs.helm-chart-version }} )"
-        if: ${{ github.event.inputs.helm-chart-version != 'default' }}
+      - name: "Publish Helm chart to Helm repository (Version: ${{ github.event.inputs.version }} )"
+        if: ${{ github.event.inputs.version != '' }}
         uses: stefanprodan/helm-gh-pages@master
         with:
           token: ${{ env.PUBLISH_ACCESS_KEY }}
@@ -105,13 +100,4 @@ jobs:
           charts_url: https://pantheontech.github.io/helm-charts/
           repository: helm-charts
           branch: main
-          chart_version: ${{ github.event.inputs.helm-chart-version }}
-      - name: "Publish Helm chart to Helm repository (Version: from Chart.yaml)"
-        if: ${{ github.event.inputs.helm-chart-version == 'default' }}
-        uses: stefanprodan/helm-gh-pages@master
-        with:
-          token: ${{ env.PUBLISH_ACCESS_KEY }}
-          charts_dir: ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-app-helm/helm/
-          charts_url: https://pantheontech.github.io/helm-charts/
-          repository: helm-charts
-          branch: main
+          chart_version: ${{ github.event.inputs.version }}

--- a/.github/workflows/publish-docker-helm.yml
+++ b/.github/workflows/publish-docker-helm.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       app-name:
         description: Name of the application in /lighty-applications
-        default: lighty-rnc-app
+        default: lighty-rnc
         required: true
       image-name:
         description: Desired NAME of docker image
@@ -33,8 +33,8 @@ jobs:
       run:
         shell: bash
     env:
-      app-aggregator-dir: lighty-applications/${{ github.event.inputs.app-name }}-aggregator
-      PUBLISH_ACCESS_KEY: ${{ secrets.MM_PKG_WRITE}}
+      app-aggregator-dir: lighty-applications/${{ github.event.inputs.app-name }}-app-aggregator
+      PUBLISH_ACCESS_KEY: ${{ secrets.MM_PKG_WRITE }}
     name: "Publish docker image and helm chart. App: ${{ github.event.inputs.app-name }}, Checkout-ref: ${{ github.event.inputs.checkout-ref }}"
     steps:
       - name: Clone Repository
@@ -62,10 +62,10 @@ jobs:
           echo "DOCKER_IMAGE_NAME=$(echo $DOCKER_IMAGE_NAME)" >> $GITHUB_ENV
           echo "DOCKER_IMAGE_NAME_TAG=$(echo $DOCKER_IMAGE_NAME_TAG)" >> $GITHUB_ENV
       - name: Build docker image
-        run: mvn install -B -pl :${{ github.event.inputs.app-name }},:${{ github.event.inputs.app-name }}-docker -P docker
+        run: mvn install -B -pl :${{ github.event.inputs.app-name }}-module,:${{ github.event.inputs.app-name }}-app,:${{ github.event.inputs.app-name }}-app-docker -P docker
       - name: Tag image
         run: |
-          image_name=$(mvn help:evaluate -f ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-docker/pom.xml -Dexpression=image.name -q -DforceStdout)
+          image_name=$(mvn help:evaluate -f ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-app-docker/pom.xml -Dexpression=image.name -q -DforceStdout)
           docker tag $image_name $DOCKER_IMAGE_NAME_TAG
           if [ "${{ github.event.inputs.image-tag-latest }}" = 'true' ]; then
             docker tag $image_name $DOCKER_IMAGE_NAME:latest
@@ -92,16 +92,16 @@ jobs:
           sudo snap install yq
       - name: Set image.name, image.version in values.yaml of helm chart
         run: |
-          yq eval '.image.name="ghcr.io/pantheontech/${{ github.event.inputs.image-name }}" | .image.version="${{ github.event.inputs.image-tag }}"' ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-helm/helm/${{ github.event.inputs.app-name }}-helm/values.yaml -i
+          yq eval '.image.name="ghcr.io/pantheontech/${{ github.event.inputs.image-name }}" | .image.version="${{ github.event.inputs.image-tag }}"' ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-app-helm/helm/${{ github.event.inputs.app-name }}-app-helm/values.yaml -i
       - name: Print values.yaml
         run: |
-          cat -A ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-helm/helm/${{ github.event.inputs.app-name }}-helm/values.yaml
+          cat -A ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-app-helm/helm/${{ github.event.inputs.app-name }}-app-helm/values.yaml
       - name: "Publish Helm chart to Helm repository (Version: ${{ github.event.inputs.helm-chart-version }} )"
         if: ${{ github.event.inputs.helm-chart-version != 'default' }}
         uses: stefanprodan/helm-gh-pages@master
         with:
           token: ${{ env.PUBLISH_ACCESS_KEY }}
-          charts_dir: ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-helm/helm/
+          charts_dir: ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-app-helm/helm/
           charts_url: https://pantheontech.github.io/helm-charts/
           repository: helm-charts
           branch: main
@@ -111,7 +111,7 @@ jobs:
         uses: stefanprodan/helm-gh-pages@master
         with:
           token: ${{ env.PUBLISH_ACCESS_KEY }}
-          charts_dir: ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-helm/helm/
+          charts_dir: ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-app-helm/helm/
           charts_url: https://pantheontech.github.io/helm-charts/
           repository: helm-charts
           branch: main

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/Chart.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 appVersion: "1.0"
-description: A Helm chart for Kubernetes
+description: RNC lighty application helm chart for Kubernetes
 name: lighty-rnc-app-helm
 version: 0.1.0


### PR DESCRIPTION
Update workflow to publish docker & helm charts

- workflow should expect & use already released & published lighty-core artifacts in maven-central. These release artifacts is used & included during building docker image.
- also the workflow is updated with another parameter to specify if the image to publish is also latest docker image, so `latest` tag will be applied for the image and pushed to docker hub.
- merged multiple version parameters into single value, minimizing cases when the user forget to input helm-charts version. The version used for docker tag and helm charts is same for most use-cases, if not for every use-case.