### PR TITLE
Bump to new upstream ODL release

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -20,21 +20,6 @@
         versions.
     </description>
 
-    <repositories>
-        <!-- FIXME: Remove when the release of OFP and Serviceutils will be available -->
-        <repository>
-            <id>opendaylight-snapshot</id>
-            <name>opendaylight-snapshot</name>
-            <url>https://nexus.opendaylight.org/content/repositories/opendaylight.snapshot/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -93,7 +78,7 @@
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>netconf-artifacts</artifactId>
-                <version>1.13.0</version>
+                <version>1.13.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -108,16 +93,14 @@
             <dependency>
                 <groupId>org.opendaylight.openflowplugin</groupId>
                 <artifactId>openflowplugin-artifacts</artifactId>
-                <!--FIXME: change to release version when will be available -->
-                <version>0.12.0-SNAPSHOT</version>
+                <version>0.12.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.serviceutils</groupId>
                 <artifactId>serviceutils-artifacts</artifactId>
-                <!--FIXME: change to release version when will be available -->
-                <version>0.7.0-SNAPSHOT</version>
+                <version>0.7.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -174,7 +174,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.1.0</version>
+                            <version>8.1.1</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -191,7 +191,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>spotbugs</artifactId>
-                            <version>8.1.0</version>
+                            <version>8.1.1</version>
                         </dependency>
                         <dependency>
                             <!-- The SpotBugs Maven plugin uses SLF4J 1.8 beta 2 -->

--- a/lighty-modules/lighty-openflow-sb/pom.xml
+++ b/lighty-modules/lighty-openflow-sb/pom.xml
@@ -11,21 +11,6 @@
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-openflow-sb</artifactId>
 
-    <repositories>
-        <!-- FIXME: Remove when the release of OFP and Serviceutils will be available  -->
-        <repository>
-            <id>opendaylight-snapshot</id>
-            <name>opendaylight-snapshot</name>
-            <url>https://nexus.opendaylight.org/content/repositories/opendaylight.snapshot/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>io.lighty.core</groupId>


### PR DESCRIPTION
bump org.opendaylight.odlparent (checkstyle, spotbugs) to newest version
bump version for openflowplugin-artifacts and serviceutils-artifacts
remove snapshot repository from build

Signed-off-by: Ivan Caladi <ivan.caladi@pantheon.tech>