### PR TITLE
Fix address allocation in tests for GitHub

### DIFF
--- a/lighty-modules/lighty-aaa/src/test/java/io/lighty/aaa/LocalHttpServerTest.java
+++ b/lighty-modules/lighty-aaa/src/test/java/io/lighty/aaa/LocalHttpServerTest.java
@@ -32,7 +32,7 @@ public class LocalHttpServerTest {
 
     @Test
     public void initLocalHttpServerTest() throws Exception {
-        InetSocketAddress socketAddress = new InetSocketAddress(InetAddress.getLocalHost(), 8888);
+        InetSocketAddress socketAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 8888);
         LightyServerBuilder serverBuilder = new LightyServerBuilder(socketAddress);
         Server server = serverBuilder.build();
         LocalHttpServer localHttpServer = new LocalHttpServer(serverBuilder);


### PR DESCRIPTION
This patch fixes failing tests for `lighty-aaa` when trying to bind server on local machine address, which github obviously is using for some other service (or is prohibited) on running workflow environment.

bellow the log from workflow build
https://github.com/PANTHEONtech/lighty/runs/2331603518?check_suite_focus=true#step:8:701
```
[INFO] --- maven-surefire-plugin:3.0.0-M5:test (default-test) @ lighty-aaa ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running TestSuite
Error:  Tests run: 4, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.372 s <<< FAILURE! - in TestSuite
Error:  io.lighty.aaa.LocalHttpServerTest.initLocalHttpServerTest  Time elapsed: 0.366 s  <<< FAILURE!
java.io.IOException: Failed to bind to fv-az139-256/10.1.0.163:8888
	at io.lighty.aaa.LocalHttpServerTest.initLocalHttpServerTest(LocalHttpServerTest.java:42)
Caused by: java.net.BindException: Cannot assign requested address
	at io.lighty.aaa.LocalHttpServerTest.initLocalHttpServerTest(LocalHttpServerTest.java:42)
```