### PR TITLE
Verify startup of example application's modules - cherry-pick to 14.0.x

### DIFF
--- a/lighty-core/lighty-common/src/main/java/io/lighty/core/common/exceptions/ModuleStartupException.java
+++ b/lighty-core/lighty-common/src/main/java/io/lighty/core/common/exceptions/ModuleStartupException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021 Pantheon Technologies s.r.o. All Rights Reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ */
+package io.lighty.core.common.exceptions;
+
+/**
+ * Exception to be thrown for module startup failures - when they return false from start() method.
+ */
+public class ModuleStartupException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    public ModuleStartupException() {
+        super();
+    }
+
+    public ModuleStartupException(final String message) {
+        super(message);
+    }
+
+    public ModuleStartupException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public ModuleStartupException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/lighty-examples/lighty-community-aaa-restconf-app/src/main/java/io/lighty/kit/examples/community/aaa/restconf/Main.java
+++ b/lighty-examples/lighty-community-aaa-restconf-app/src/main/java/io/lighty/kit/examples/community/aaa/restconf/Main.java
@@ -8,14 +8,13 @@
 package io.lighty.kit.examples.community.aaa.restconf;
 
 import com.google.common.base.Stopwatch;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import io.lighty.aaa.AAALighty;
 import io.lighty.aaa.config.CertificateManagerConfig;
 import io.lighty.aaa.config.DatastoreConfigurationConfig;
 import io.lighty.aaa.config.ShiroConfigurationConfig;
+import io.lighty.core.common.exceptions.ModuleStartupException;
 import io.lighty.core.controller.api.LightyController;
+import io.lighty.core.controller.api.LightyModule;
 import io.lighty.core.controller.impl.LightyControllerBuilder;
 import io.lighty.core.controller.impl.config.ConfigurationException;
 import io.lighty.core.controller.impl.config.ControllerConfiguration;
@@ -31,9 +30,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.Security;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -47,7 +46,11 @@ public final class Main {
     private static final Logger LOG = LoggerFactory.getLogger(Main.class);
     private static final String PASS = "bar";
     private static final String USER = "foo";
-    private ShutdownHook shutdownHook;
+    private static final long DEFAULT_TIMEOUT_SECONDS = 30;
+
+    private LightyController lightyController;
+    private AAALighty aaaLighty;
+    private CommunityRestConf restconf;
 
     public static void main(String[] args) {
         Main app = new Main();
@@ -58,131 +61,90 @@ public final class Main {
     public void start(final String[] args, final boolean registerShutdownHook) {
         final Stopwatch stopwatch = Stopwatch.createStarted();
         try {
+            final ControllerConfiguration singleNodeConfiguration;
+            final RestConfConfiguration restconfConfiguration;
             if (args.length > 0) {
                 final Path configPath = Paths.get(args[0]);
                 LOG.info("Lighty and Restconf starting, using configuration from file {} ...", configPath);
-                final ControllerConfiguration singleNodeConfiguration =
-                        ControllerConfigUtils.getConfiguration(Files.newInputStream(configPath));
-                final RestConfConfiguration restConfConfiguration = RestConfConfigUtils
-                        .getRestConfConfiguration(Files.newInputStream(configPath));
-                startLighty(singleNodeConfiguration, restConfConfiguration, registerShutdownHook);
+                singleNodeConfiguration = ControllerConfigUtils.getConfiguration(Files.newInputStream(configPath));
+                restconfConfiguration = RestConfConfigUtils.getRestConfConfiguration(Files.newInputStream(configPath));
             } else {
                 LOG.info("Lighty and Restconf starting, using default configuration ...");
                 final Set<YangModuleInfo> modelPaths = Stream.concat(RestConfConfigUtils.YANG_MODELS.stream(),
                         AAALighty.YANG_MODELS.stream()).collect(Collectors.toSet());
-
-                final ControllerConfiguration defaultSingleNodeConfiguration =
-                        ControllerConfigUtils.getDefaultSingleNodeConfiguration(modelPaths);
-                final RestConfConfiguration restConfConfig =
-                        RestConfConfigUtils.getDefaultRestConfConfiguration();
-                startLighty(defaultSingleNodeConfiguration, restConfConfig, registerShutdownHook);
+                singleNodeConfiguration = ControllerConfigUtils.getDefaultSingleNodeConfiguration(modelPaths);
+                restconfConfiguration = RestConfConfigUtils.getDefaultRestConfConfiguration();
             }
-            LOG.info("Lighty and Restconf started in {}", stopwatch.stop());
-        } catch (final Throwable e) {
-            LOG.error("Main Restconf application exception: ", e);
+            //Register shutdown hook for graceful shutdown.
+            if (registerShutdownHook) {
+                Runtime.getRuntime().addShutdownHook(new Thread(this::shutdown));
+            }
+            startLighty(singleNodeConfiguration, restconfConfiguration);
+            LOG.info("Lighty.io, Restconf and AAA module started in {}", stopwatch.stop());
+        } catch (final Throwable cause) {
+            LOG.error("Lighty.io, Restconf and AAA module main application exception: ", cause);
+            shutdown();
         }
     }
 
     private void startLighty(final ControllerConfiguration controllerConfiguration,
-            final RestConfConfiguration restconfConfiguration, final boolean registerShutdownHook)
-                    throws ConfigurationException, ExecutionException, InterruptedException {
+                             final RestConfConfiguration restconfConfiguration)
+        throws ConfigurationException, ExecutionException, InterruptedException, TimeoutException,
+               ModuleStartupException {
+
         //1. initialize and start Lighty controller (MD-SAL, Controller, YangTools, Akka)
         final LightyControllerBuilder lightyControllerBuilder = new LightyControllerBuilder();
-        final LightyController lightyController = lightyControllerBuilder.from(controllerConfiguration).build();
-        lightyController.start().get();
+        this.lightyController = lightyControllerBuilder.from(controllerConfiguration).build();
+        final boolean controllerStartOk = this.lightyController.start().get(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        if (!controllerStartOk) {
+            throw new ModuleStartupException("Lighty.io Controller startup failed!");
+        }
 
         // 2. start Restconf server
         final LightyServerBuilder jettyServerBuilder = new LightyServerBuilder(new InetSocketAddress(
                 restconfConfiguration.getInetAddress(), restconfConfiguration.getHttpPort()));
-        final CommunityRestConf communityRestConf = CommunityRestConfBuilder.from(RestConfConfigUtils
-                .getRestConfConfiguration(restconfConfiguration, lightyController.getServices())).withLightyServer(
-                        jettyServerBuilder)
+        this.restconf = CommunityRestConfBuilder
+                .from(RestConfConfigUtils.getRestConfConfiguration(restconfConfiguration,
+                    this.lightyController.getServices()))
+                .withLightyServer(jettyServerBuilder)
                 .build();
-        final ListenableFuture<Boolean> startRestconf = communityRestConf.start();
-        addCallback(startRestconf);
+        final boolean restconfStartOk = this.restconf.start().get(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        if (!restconfStartOk) {
+            throw new ModuleStartupException("Community Restconf startup failed!");
+        }
         Security.addProvider(new BouncyCastleProvider());
 
-        final DataBroker bindingDataBroker = lightyController.getServices().getBindingDataBroker();
+        final DataBroker bindingDataBroker = this.lightyController.getServices().getBindingDataBroker();
         final String moonEndpointPath = "/moon";
         // this is example only real application should not use hardcoded credentials.
-        final AAALighty aaaLighty = new AAALighty(bindingDataBroker, CertificateManagerConfig.getDefault(
-                bindingDataBroker), null, ShiroConfigurationConfig.getDefault(), moonEndpointPath,
+        this.aaaLighty = new AAALighty(bindingDataBroker, CertificateManagerConfig.getDefault(bindingDataBroker),
+                null, ShiroConfigurationConfig.getDefault(), moonEndpointPath,
                 DatastoreConfigurationConfig.getDefault(), USER, PASS, jettyServerBuilder);
-        final ListenableFuture<Boolean> start = aaaLighty.start();
+        final boolean aaaLightyStartOk = this.aaaLighty.start().get(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        if (!aaaLightyStartOk) {
+            throw new ModuleStartupException("AAA module startup failed!");
+        }
 
-        addCallback(start);
+        this.restconf.startServer();
+    }
 
-        communityRestConf.startServer();
-
-        //3. Register shutdown hook for graceful shutdown.
-        this.shutdownHook = new ShutdownHook(lightyController, communityRestConf, aaaLighty);
-        if (registerShutdownHook) {
-            Runtime.getRuntime().addShutdownHook(this.shutdownHook);
+    @SuppressWarnings("IllegalCatch")
+    private void closeLightyModule(LightyModule module) {
+        if (module != null) {
+            try {
+                module.shutdown().get(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            } catch (final Exception e) {
+                LOG.error("Exception while shutting down {} module: ", module.getClass().getSimpleName(), e);
+            }
         }
     }
 
     public void shutdown() {
-        this.shutdownHook.execute();
-    }
-
-    @SuppressWarnings("checkstyle:illegalCatch")
-    private static void addCallback(final ListenableFuture<Boolean> start)
-            throws InterruptedException {
-        final CountDownLatch cdl = new CountDownLatch(1);
-        Futures.addCallback(start, new FutureCallback<Boolean>() {
-
-            @Override
-            public void onSuccess(final Boolean result) {
-                cdl.countDown();
-            }
-
-            @Override
-            public void onFailure(final Throwable cause) {
-                throw new RuntimeException(cause);
-            }
-        }, Executors.newSingleThreadExecutor());
-        cdl.await();
-    }
-
-    @SuppressWarnings("checkstyle:illegalCatch")
-    private static class ShutdownHook extends Thread {
-
-        private static final Logger LOG = LoggerFactory.getLogger(ShutdownHook.class);
-        private final LightyController lightyController;
-        private final CommunityRestConf communityRestConf;
-        private final AAALighty aaaLighty;
-
-        ShutdownHook(final LightyController lightyController, final CommunityRestConf communityRestConf,
-                final AAALighty aaaLighty) {
-            this.lightyController = lightyController;
-            this.communityRestConf = communityRestConf;
-            this.aaaLighty = aaaLighty;
-        }
-
-        @Override
-        public void run() {
-            this.execute();
-        }
-
-        public void execute() {
-            LOG.info("Lighty and Restconf shutting down ...");
-            final Stopwatch stopwatch = Stopwatch.createStarted();
-            try {
-                this.communityRestConf.shutdown();
-            } catch (final Exception e) {
-                LOG.error("Exception:", e);
-            }
-            try {
-                this.aaaLighty.shutdown();
-            } catch (final Exception e) {
-                LOG.error("Exception while shutting down Lighty controller:", e);
-            }
-            try {
-                this.lightyController.shutdown();
-            } catch (final Exception e) {
-                LOG.error("Exception while shutting down Lighty controller:", e);
-            }
-            LOG.info("Lighty and Restconf stopped in {}", stopwatch.stop());
-        }
+        LOG.info("Lighty.io, Restconf and AAA module shutting down ...");
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        closeLightyModule(this.aaaLighty);
+        closeLightyModule(this.restconf);
+        closeLightyModule(this.lightyController);
+        LOG.info("Lighty.io, Restconf and AAA module stopped in {}", stopwatch.stop());
     }
 }

--- a/lighty-examples/lighty-community-restconf-ofp-app/src/main/java/io/lighty/examples/controllers/restconf/ofp/Main.java
+++ b/lighty-examples/lighty-community-restconf-ofp-app/src/main/java/io/lighty/examples/controllers/restconf/ofp/Main.java
@@ -1,10 +1,8 @@
 package io.lighty.examples.controllers.restconf.ofp;
 
 import com.google.common.base.Stopwatch;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.lighty.core.common.exceptions.ModuleStartupException;
 import io.lighty.core.controller.api.LightyController;
 import io.lighty.core.controller.api.LightyModule;
 import io.lighty.core.controller.impl.LightyControllerBuilder;
@@ -25,7 +23,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.opendaylight.yangtools.yang.binding.YangModuleInfo;
@@ -35,10 +34,20 @@ import org.slf4j.LoggerFactory;
 public final class Main {
 
     private static final Logger LOG = LoggerFactory.getLogger(Main.class);
-    private static ShutdownHook shutdownHook;
+    private static final long DEFAULT_TIMEOUT_SECONDS = 30;
 
+    private LightyController lightyController;
+    private OpenflowSouthboundPlugin openflowSBPlugin;
+    private CommunityRestConf restconf;
+
+    public static void main(String[] args) {
+        Main main = new Main();
+        main.start(args, true);
+    }
+
+    @SuppressWarnings("IllegalCatch")
     @SuppressFBWarnings("SLF4J_SIGN_ONLY_FORMAT")
-    public static void main(final String[] args) throws Exception {
+    public void start(final String[] args, boolean registerShutdownHook) {
         final Stopwatch stopwatch = Stopwatch.createStarted();
         LOG.info(".__  .__       .__     __              .__         ________  ___________");
         LOG.info("|  | |__| ____ |  |___/  |_ ___.__.    |__| ____   \\_____  \\ \\_   _____/");
@@ -49,139 +58,98 @@ public final class Main {
         LOG.info("Starting lighty.io RESTCONF-OPENFLOW example application ...");
         LOG.info("https://lighty.io/");
         LOG.info("https://github.com/PANTHEONtech/lighty");
+
         try {
             final ControllerConfiguration controllerConfiguration;
-            final RestConfConfiguration restConfConfiguration;
-            final OpenflowpluginConfiguration openflowpluginConfiguration;
+            final RestConfConfiguration restconfConfiguration;
+            final OpenflowpluginConfiguration openflowConfiguration;
 
             if (args.length > 0) {
                 final Path configPath = Paths.get(args[0]);
                 LOG.info("Lighty and OFP starting, using configuration from file {} ...", configPath);
                 controllerConfiguration = ControllerConfigUtils.getConfiguration(Files.newInputStream(configPath));
-                restConfConfiguration = RestConfConfigUtils
-                        .getRestConfConfiguration(Files.newInputStream(configPath));
-                openflowpluginConfiguration = OpenflowConfigUtils.getOfpConfiguration(Files.newInputStream(configPath));
+                restconfConfiguration = RestConfConfigUtils.getRestConfConfiguration(Files.newInputStream(configPath));
+                openflowConfiguration = OpenflowConfigUtils.getOfpConfiguration(Files.newInputStream(configPath));
             } else {
                 LOG.info("Lighty and OFP starting, using default configuration ...");
                 final Set<YangModuleInfo> modelPaths = Stream.concat(RestConfConfigUtils.YANG_MODELS.stream(),
                         OpenflowConfigUtils.OFP_MODELS.stream())
                         .collect(Collectors.toSet());
                 controllerConfiguration = ControllerConfigUtils.getDefaultSingleNodeConfiguration(modelPaths);
-                restConfConfiguration =  RestConfConfigUtils.getDefaultRestConfConfiguration();
-                openflowpluginConfiguration = OpenflowConfigUtils.getDefaultOfpConfiguration();
+                restconfConfiguration =  RestConfConfigUtils.getDefaultRestConfConfiguration();
+                openflowConfiguration = OpenflowConfigUtils.getDefaultOfpConfiguration();
             }
-
+            //Register shutdown hook for graceful shutdown.
+            if (registerShutdownHook) {
+                Runtime.getRuntime().addShutdownHook(new Thread(this::shutdown));
+            }
             // start controller at last
-            startLighty(
-                    controllerConfiguration,
-                    restConfConfiguration,
-                    openflowpluginConfiguration
-            );
-            LOG.info("Lighty and OFP started in {}", stopwatch.stop());
-        } catch (IOException cause) {
-            LOG.error("Main OFP application - could not read configuration: ", cause);
-        } catch (ConfigurationException | ExecutionException | InterruptedException cause) {
-            LOG.error("Main OFP application exception: ", cause);
+            startLighty(controllerConfiguration, restconfConfiguration, openflowConfiguration);
+            LOG.info("Lighty.io and OFP started in {}", stopwatch.stop());
+        } catch (IOException e) {
+            LOG.error("Main OFP application - could not read configuration: ", e);
+            shutdown();
+        } catch (Exception e) {
+            LOG.error("Main OFP application exception: ", e);
+            shutdown();
         }
     }
 
-    public static void start() throws Exception {
-        main(new String[]{});
-    }
-
-    public static void shutdown() {
-        if (shutdownHook != null) {
-            shutdownHook.execute();
-        }
-    }
-
-    private static void startLighty(final ControllerConfiguration controllerConfiguration,
-                                    final RestConfConfiguration restConfConfiguration,
-                                    OpenflowpluginConfiguration configuration)
-            throws ConfigurationException, ExecutionException, InterruptedException {
+    private void startLighty(final ControllerConfiguration controllerConfiguration,
+                                final RestConfConfiguration restconfConfiguration,
+                                final OpenflowpluginConfiguration ofpConfiguration)
+        throws ConfigurationException, ExecutionException, InterruptedException, TimeoutException,
+               ModuleStartupException {
 
         //1. initialize and start Lighty controller (MD-SAL, Controller, YangTools, Akka)
         final LightyControllerBuilder lightyControllerBuilder = new LightyControllerBuilder();
-        final LightyController lightyController = lightyControllerBuilder.from(controllerConfiguration).build();
-        lightyController.start().get();
+        this.lightyController = lightyControllerBuilder.from(controllerConfiguration).build();
+        final boolean controllerStartOk = this.lightyController.start().get(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        if (!controllerStartOk) {
+            throw new ModuleStartupException("Lighty.io Controller startup failed!");
+        }
 
         //2. start RESTCONF server
-        final CommunityRestConf communityRestConf = CommunityRestConfBuilder
-                .from(RestConfConfigUtils.getRestConfConfiguration(restConfConfiguration,
-                        lightyController.getServices()))
+        this.restconf = CommunityRestConfBuilder
+                .from(RestConfConfigUtils.getRestConfConfiguration(restconfConfiguration,
+                    this.lightyController.getServices()))
                 .build();
-        communityRestConf.start();
+        final boolean restconfStartOk = this.restconf.start().get(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        if (!restconfStartOk) {
+            throw new ModuleStartupException("Community Restconf startup failed!");
+        }
 
-        //3. start OpenFlow SBP
-        final OpenflowSouthboundPlugin plugin;
-        plugin = OpenflowSouthboundPluginBuilder
-                .from(configuration, lightyController.getServices())
+        //3. start OpenFlow SBP and set SystemReadyMonitor listeners to active state
+        this.openflowSBPlugin = OpenflowSouthboundPluginBuilder
+                .from(ofpConfiguration, this.lightyController.getServices())
                 .withPacketListener(new PacketInListener())
                 .build();
-        ListenableFuture<Boolean> start = plugin.start();
-
-        //Set SystemReadyMonitor listeners to active state
-        Futures.addCallback(start, new FutureCallback<>() {
-            @Override
-            public void onSuccess(Boolean result) {
-                if (result != null && result) {
-                    lightyController.getServices().getLightySystemReadyService().onSystemBootReady();
-                } else {
-                    LOG.error("OFP wasn unable to start correctly");
-                    throw new RuntimeException("Unexcepted result of OFP initialization");
-                }
-            }
-
-            @Override
-            public void onFailure(Throwable cause) {
-                LOG.error("Exception while initializing OFP", cause);
-            }
-        }, Executors.newSingleThreadExecutor());
-
-        shutdownHook = new ShutdownHook(lightyController, communityRestConf, plugin);
-        Runtime.getRuntime().addShutdownHook(shutdownHook);
+        final boolean ofpStartOk = this.openflowSBPlugin.start().get(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        if (!ofpStartOk) {
+            throw new ModuleStartupException("OpenflowSB Plugin startup failed - shutting down ...");
+        } else {
+            this.lightyController.getServices().getLightySystemReadyService().onSystemBootReady();
+        }
     }
 
-    private static class ShutdownHook extends Thread {
-
-        private static final Logger LOG = LoggerFactory.getLogger(ShutdownHook.class);
-        private final LightyController lightyController;
-        private final LightyModule restconf;
-        private final LightyModule opennflowPlugin;
-
-        ShutdownHook(final LightyController lightyController, final LightyModule restconf,
-                     final LightyModule ofPlugin) {
-            this.lightyController = lightyController;
-            this.restconf = restconf;
-            this.opennflowPlugin = ofPlugin;
-        }
-
-        @Override
-        public void run() {
-            this.execute();
-        }
-
-        @SuppressWarnings("checkstyle:illegalCatch")
-        public void execute() {
-            LOG.info("Lighty and OFP shutting down ...");
-            final Stopwatch stopwatch = Stopwatch.createStarted();
+    @SuppressWarnings("IllegalCatch")
+    private void closeLightyModule(LightyModule module) {
+        if (module != null) {
             try {
-                this.opennflowPlugin.shutdown();
+                module.shutdown().get(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             } catch (final Exception e) {
-                LOG.error("OFP Application shutdown failed: ", e);
+                LOG.error("Exception while shutting down {} module: ", module.getClass().getSimpleName(), e);
             }
-            try {
-                this.restconf.shutdown();
-            } catch (final Exception e) {
-                LOG.error("RESTCONF NBP shutdown failed:", e);
-            }
-            try {
-                this.lightyController.shutdown();
-            } catch (final Exception e) {
-                LOG.error("Exception while shutting down Lighty controller:", e);
-            }
-            LOG.info("Lighty and OFP stopped in {}", stopwatch.stop());
         }
+    }
+
+    public void shutdown() {
+        LOG.info("Lighty and OFP shutting down ...");
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        closeLightyModule(this.openflowSBPlugin);
+        closeLightyModule(this.restconf);
+        closeLightyModule(this.lightyController);
+        LOG.info("Lighty and OFP stopped in {}", stopwatch.stop());
     }
 
     private Main() {


### PR DESCRIPTION
Add verification to lighty-examples, whether
modules in each example are started correctly.
If not, log error message and shutdown all
currently started components.

Signed-off-by: Martin Bugan martin.bugan@pantheon.tech