### PR TITLE
Add additional-capability parameter to gnmi yang models

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/README.md
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/README.md
@@ -51,6 +51,48 @@ curl --request POST 'http://127.0.0.1:8888/restconf/operations/gnmi-yang-storage
 }'
 ```
 
+The obtained list of capabilities is not always complete, which means that schema context isn't created correctly. Some 
+devices send a list of capabilities without yang models which `augment` other models. For this reason, it's possible 
+to add missing capabilities to the device capability list using the optional `additional-capabilitity` parameter.
+
+```
+curl -X PUT \
+  http://127.0.0.1:8888/restconf/data/network-topology:network-topology/topology=gnmi-topology/node=node-id-1 \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "node": [
+        {
+            "node-id": "node-id-1",
+            "connection-parameters": {
+                "host": "172.0.0.1",
+                "port": 9090,
+                "connection-type": "INSECURE"
+            },
+            "extensions-parameters": {
+                "additional-capability": [
+                    {
+                        "name": "openconfig-if-ethernet",
+                        "version": "2.6.2"
+                    },
+                    {
+                        "name": "openconfig-if-ip",
+                        "version": "2.3.1"
+                    }
+                ]
+            }
+        }
+    ]
+}'
+```
+In case the obtained list of capabilities is not complete, the missing capabilities will be shown in the error response.
+```
+{
+    "gnmi-topology:failure-details": "Errors: Missing models: \topenconfig-if-ethernet semver: 2.6.2\n"
+}
+```
+If an error is present, the node must be removed and the node must be added with the `additional capability` 
+parameter. The node must be removed because the schema context is already created and cannot be updated.
+
 ##How to start rcgnmi example app
 * build the project using ```mvn clean install```
 * go to target directory ```cd lighty-rcgnmi-app/target```

--- a/lighty-models/lighty-gnmi-models/lighty-gnmi-yang-storage-model/pom.xml
+++ b/lighty-models/lighty-gnmi-models/lighty-gnmi-yang-storage-model/pom.xml
@@ -23,4 +23,22 @@
     <artifactId>lighty-gnmi-yang-storage-model</artifactId>
     <version>15.0.0-SNAPSHOT</version>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.opendaylight.mdsal.model</groupId>
+            <artifactId>ietf-topology</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opendaylight.mdsal.binding.model.ietf</groupId>
+            <artifactId>rfc6991-ietf-inet-types</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opendaylight.mdsal.model</groupId>
+            <artifactId>yang-ext</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.lighty.models.gnmi</groupId>
+            <artifactId>lighty-gnmi-topology-model</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/lighty-models/lighty-gnmi-models/lighty-gnmi-yang-storage-model/src/main/yang/gnmi-yang-storage.yang
+++ b/lighty-models/lighty-gnmi-models/lighty-gnmi-yang-storage-model/src/main/yang/gnmi-yang-storage.yang
@@ -16,6 +16,10 @@ module gnmi-yang-storage {
         description "Initial revision of gNMI yang storage model";
     }
 
+    import network-topology { prefix nt; revision-date 2013-10-21; }
+    import yang-ext { prefix ext; revision-date "2013-07-09";}
+    import gnmi-topology { prefix gnmi; revision-date "2021-03-16";}
+
     typedef module-version-type {
         type string;
         description
@@ -31,18 +35,41 @@ module gnmi-yang-storage {
             "gNMI Specification Section 2.6.1 The ModelData message";
     }
 
+    grouping yang-model-name-version {
+            leaf name {
+                description "Name of the yang model";
+                type string;
+            }
+            leaf version {
+                description "Version of the yang model";
+                type module-version-type;
+            }
+    }
+
     grouping yang-model {
-        leaf name {
-            description "Name of the yang model";
-            type string;
-        }
-        leaf version {
-            description "Version of the yang model";
-            type module-version-type;
-        }
+        uses yang-model-name-version;
         leaf body {
             description "Body of the yang model";
             type string;
+        }
+    }
+
+    grouping additional-yang-models {
+        list additional-capability {
+            description "List of additional capabilities not provided
+                         in the device list of capabilities. Some devices
+                         don't provide a complete list of supported
+                         yang models. If yang models are not provided
+                         from the device, they must be added to
+                         SchemaContext using this additional-capability
+                         list. For example: Some device augmented
+                         openconfig-interfaces by openconfig-if-ethernet.
+                         The openconfig-if-ethernet yang model is not sent
+                         in the list of capabilities and the schemaContext
+                         is incorrect, which means that data obtained
+                         from the device cannot be manipulated.";
+            key "name version";
+            uses yang-model-name-version;
         }
     }
 
@@ -60,4 +87,9 @@ module gnmi-yang-storage {
         }
     }
 
+    augment "/nt:network-topology/nt:topology/nt:node/gnmi:extensions-parameters" {
+        ext:augment-identifier "additional-capabilities";
+
+        uses additional-yang-models;
+    }
 }

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/device/connection/ConfigurableParameters.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/device/connection/ConfigurableParameters.java
@@ -8,16 +8,23 @@
 
 package io.lighty.gnmi.southbound.device.connection;
 
+import java.util.Map;
 import java.util.Optional;
 import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.topology.rev210316.gnmi.connection.parameters.ExtensionsParameters;
 import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.topology.rev210316.gnmi.connection.parameters.extensions.parameters.GnmiParameters;
+import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.yang.storage.rev210331.AdditionalCapabilities;
+import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.yang.storage.rev210331.additional.yang.models.AdditionalCapability;
+import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.yang.storage.rev210331.additional.yang.models.AdditionalCapabilityKey;
 
 public class ConfigurableParameters {
 
     private final GnmiParameters gnmiParameters;
+    private final AdditionalCapabilities additionalCapabilities;
 
     public ConfigurableParameters(final ExtensionsParameters extensionsParameters) {
         gnmiParameters = extensionsParameters == null ? null : extensionsParameters.getGnmiParameters();
+        additionalCapabilities = extensionsParameters == null ? null :
+            extensionsParameters.augmentation(AdditionalCapabilities.class);
     }
 
     public Optional<Boolean> getUseModelNamePrefix() {
@@ -37,6 +44,13 @@ public class ConfigurableParameters {
     public Optional<String> getPathTarget() {
         if (gnmiParameters != null) {
             return Optional.ofNullable(gnmiParameters.getPathTarget());
+        }
+        return Optional.empty();
+    }
+
+    public Optional<Map<AdditionalCapabilityKey, AdditionalCapability>> getAdditionalCapabilities() {
+        if (additionalCapabilities != null) {
+            return Optional.ofNullable(additionalCapabilities.getAdditionalCapability());
         }
         return Optional.empty();
     }

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/device/connection/DeviceConnectionManager.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/device/connection/DeviceConnectionManager.java
@@ -138,6 +138,9 @@ public class DeviceConnectionManager implements AutoCloseable {
             models.get().entrySet()
                 .stream()
                 .map(model -> model.getValue())
+                .peek(additionalCapability ->
+                    LOG.debug("Adding additional gNMI capability: name {} version {}",
+                        additionalCapability.getName(), additionalCapability.getVersion().getValue()))
                 .forEach(model -> capabilitiesResponseBuilder
                     .addSupportedModels(Gnmi.ModelData.newBuilder()
                         .setName(model.getName())

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiConnectionITTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiConnectionITTest.java
@@ -158,7 +158,16 @@ public class GnmiConnectionITTest extends GnmiITBase {
     @Test
     public void connectDeviceCorrectlyTest()
         throws InterruptedException, IOException, ExecutionException, TimeoutException {
-        assertExistingAndEmptyGnmiTopology();
+        //assert existing and empty gnmi topology
+        final HttpResponse<String> getGnmiTopologyResponse = sendGetRequestJSON(GNMI_TOPOLOGY_PATH);
+        assertEquals(HttpURLConnection.HTTP_OK, getGnmiTopologyResponse.statusCode());
+        final JSONArray topologies =
+            new JSONObject(getGnmiTopologyResponse.body()).getJSONArray("network-topology:topology");
+        assertEquals(1, topologies.length());
+        final JSONObject gnmiTopologyJSON = topologies.getJSONObject(0);
+        LOG.info("Empty gnmi-topology check response: {}", gnmiTopologyJSON);
+        assertEquals("gnmi-topology", gnmiTopologyJSON.getString("topology-id"));
+        assertThrows(JSONException.class, () -> gnmiTopologyJSON.getJSONArray("node"));
 
         // add gNMI node to topology
         final String newDevicePayload = createDevicePayload(GNMI_NODE_ID, DEVICE_IP, DEVICE_PORT);
@@ -203,7 +212,15 @@ public class GnmiConnectionITTest extends GnmiITBase {
     @Test
     public void connectDeviceWithAdditionalCapabilityAndModelTest()
         throws InterruptedException, IOException, ExecutionException, TimeoutException {
-        assertExistingAndEmptyGnmiTopology();
+        final HttpResponse<String> getGnmiTopologyResponse = sendGetRequestJSON(GNMI_TOPOLOGY_PATH);
+        assertEquals(HttpURLConnection.HTTP_OK, getGnmiTopologyResponse.statusCode());
+        final JSONArray topologies =
+            new JSONObject(getGnmiTopologyResponse.body()).getJSONArray("network-topology:topology");
+        assertEquals(1, topologies.length());
+        final JSONObject gnmiTopologyJSON = topologies.getJSONObject(0);
+        LOG.info("Empty gnmi-topology check response: {}", gnmiTopologyJSON);
+        assertEquals("gnmi-topology", gnmiTopologyJSON.getString("topology-id"));
+        assertThrows(JSONException.class, () -> gnmiTopologyJSON.getJSONArray("node"));
 
         // add gNMI node to topology
         final String newDevicePayload =
@@ -232,7 +249,15 @@ public class GnmiConnectionITTest extends GnmiITBase {
     @Test
     public void connectDeviceWithAdditionalCapabilitityWithNotImportedYangModelTest()
         throws InterruptedException, IOException, ExecutionException, TimeoutException {
-        assertExistingAndEmptyGnmiTopology();
+        final HttpResponse<String> getGnmiTopologyResponse = sendGetRequestJSON(GNMI_TOPOLOGY_PATH);
+        assertEquals(HttpURLConnection.HTTP_OK, getGnmiTopologyResponse.statusCode());
+        final JSONArray topologies =
+            new JSONObject(getGnmiTopologyResponse.body()).getJSONArray("network-topology:topology");
+        assertEquals(1, topologies.length());
+        final JSONObject gnmiTopologyJSON = topologies.getJSONObject(0);
+        LOG.info("Empty gnmi-topology check response: {}", gnmiTopologyJSON);
+        assertEquals("gnmi-topology", gnmiTopologyJSON.getString("topology-id"));
+        assertThrows(JSONException.class, () -> gnmiTopologyJSON.getJSONArray("node"));
 
         final String modelName = "not-imported-model-name";
         final String nodeState = "gnmi-topology:node-state";
@@ -268,7 +293,16 @@ public class GnmiConnectionITTest extends GnmiITBase {
     @Test
     public void connectDeviceIncorrectlyTest()
         throws InterruptedException, IOException, ExecutionException, TimeoutException {
-        assertExistingAndEmptyGnmiTopology();
+        //assert existing and empty gnmi topology
+        final HttpResponse<String> getGnmiTopologyResponse = sendGetRequestJSON(GNMI_TOPOLOGY_PATH);
+        assertEquals(HttpURLConnection.HTTP_OK, getGnmiTopologyResponse.statusCode());
+        final JSONArray topologies =
+            new JSONObject(getGnmiTopologyResponse.body()).getJSONArray("network-topology:topology");
+        assertEquals(1, topologies.length());
+        final JSONObject gnmiTopologyJSON = topologies.getJSONObject(0);
+        LOG.info("Response: {}", gnmiTopologyJSON);
+        assertEquals("gnmi-topology", gnmiTopologyJSON.getString("topology-id"));
+        assertThrows(JSONException.class, () -> gnmiTopologyJSON.getJSONArray("node"));
 
         //add gnmi node to gnmi topology
         final String newDeviceIncorrectPayload = createDevicePayload(GNMI_NODE_ID, DEVICE_IP, DEVICE_PORT - 1);
@@ -329,7 +363,16 @@ public class GnmiConnectionITTest extends GnmiITBase {
     @Test
     public void connectMultipleDevicesTest()
         throws IOException, InterruptedException, ExecutionException, TimeoutException {
-        assertExistingAndEmptyGnmiTopology();
+        //assert existing and empty gnmi topology
+        final HttpResponse<String> getGnmiTopologyResponse = sendGetRequestJSON(GNMI_TOPOLOGY_PATH);
+        final JSONArray topologies =
+            new JSONObject(getGnmiTopologyResponse.body()).getJSONArray("network-topology:topology");
+        assertEquals(1, topologies.length());
+        final JSONObject gnmiTopologyJSON = topologies.getJSONObject(0);
+        LOG.info("Empty gnmi-topology check response: {}", gnmiTopologyJSON);
+        assertEquals(HttpURLConnection.HTTP_OK, getGnmiTopologyResponse.statusCode());
+        assertEquals("gnmi-topology", gnmiTopologyJSON.getString("topology-id"));
+        assertThrows(JSONException.class, () -> gnmiTopologyJSON.getJSONArray("node"));
 
         final HttpResponse<String> addGnmiDeviceResponse =
                 sendPutRequestJSON(GNMI_TOPOLOGY_PATH, MULTIPLE_DEVICES_PAYLOAD);
@@ -426,7 +469,16 @@ public class GnmiConnectionITTest extends GnmiITBase {
     @Test
     public void reconnectIncorrectlyConnectedDeviceTest()
         throws IOException, InterruptedException, ExecutionException, TimeoutException {
-        assertExistingAndEmptyGnmiTopology();
+        //assert existing and empty gnmi topology
+        final HttpResponse<String> getGnmiTopologyResponse = sendGetRequestJSON(GNMI_TOPOLOGY_PATH);
+        final JSONArray topologies =
+            new JSONObject(getGnmiTopologyResponse.body()).getJSONArray("network-topology:topology");
+        assertEquals(1, topologies.length());
+        final JSONObject gnmiTopologyJSON = topologies.getJSONObject(0);
+        LOG.info("Response: {}", gnmiTopologyJSON);
+        assertEquals(HttpURLConnection.HTTP_OK, getGnmiTopologyResponse.statusCode());
+        assertEquals("gnmi-topology", gnmiTopologyJSON.getString("topology-id"));
+        assertThrows(JSONException.class, () -> gnmiTopologyJSON.getJSONArray("node"));
 
         //add gnmi node to gnmi topology
         final String newDeviceIncorrectPayload = createDevicePayload(GNMI_NODE_ID, DEVICE_IP, DEVICE_PORT - 1);
@@ -495,7 +547,16 @@ public class GnmiConnectionITTest extends GnmiITBase {
     @Test
     public void connectDeviceWithIncorrectCredentialsTest()
         throws IOException, InterruptedException, ExecutionException, TimeoutException {
-        assertExistingAndEmptyGnmiTopology();
+        //assert existing and empty gnmi topology
+        final HttpResponse<String> getGnmiTopologyResponse = sendGetRequestJSON(GNMI_TOPOLOGY_PATH);
+        assertEquals(HttpURLConnection.HTTP_OK, getGnmiTopologyResponse.statusCode());
+        final JSONArray topologies =
+            new JSONObject(getGnmiTopologyResponse.body()).getJSONArray("network-topology:topology");
+        assertEquals(1, topologies.length());
+        final JSONObject gnmiTopologyJSON = topologies.getJSONObject(0);
+        LOG.info("Empty gnmi-topology check response: {}", gnmiTopologyJSON);
+        assertEquals("gnmi-topology", gnmiTopologyJSON.getString("topology-id"));
+        assertThrows(JSONException.class, () -> gnmiTopologyJSON.getJSONArray("node"));
 
         // add gNMI node with wrong password to topology
         LOG.info("Adding gnmi device with ID {}", GNMI_NODE_WITH_WRONG_PASSWD_ID);
@@ -537,18 +598,6 @@ public class GnmiConnectionITTest extends GnmiITBase {
                         + "/gnmi-topology:node-state");
                 assertEquals(HttpURLConnection.HTTP_CONFLICT, getConnectionStatusResponse.statusCode());
             });
-    }
-
-    private void assertExistingAndEmptyGnmiTopology() throws IOException, InterruptedException {
-        final HttpResponse<String> getGnmiTopologyResponse = sendGetRequestJSON(GNMI_TOPOLOGY_PATH);
-        assertEquals(HttpURLConnection.HTTP_OK, getGnmiTopologyResponse.statusCode());
-        final JSONArray topologies =
-            new JSONObject(getGnmiTopologyResponse.body()).getJSONArray("network-topology:topology");
-        assertEquals(1, topologies.length());
-        final JSONObject gnmiTopologyJSON = topologies.getJSONObject(0);
-        LOG.info("Empty gnmi-topology check response: {}", gnmiTopologyJSON);
-        assertEquals("gnmi-topology", gnmiTopologyJSON.getString("topology-id"));
-        assertThrows(JSONException.class, () -> gnmiTopologyJSON.getJSONArray("node"));
     }
 
 }

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiITBase.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiITBase.java
@@ -226,6 +226,36 @@ public abstract class GnmiITBase {
             + "}";
     }
 
+    protected String createDevicePayloadWithAdditionalCapabilities(final String nodeId, final String ipAddr,
+                                                                   final int port, final String modelName,
+                                                                   final String modelVersion) {
+        return "{\n"
+            + "    \"node\": [\n"
+            + "        {\n"
+            + "            \"node-id\": \"" + nodeId + "\",\n"
+            + "            \"connection-parameters\": {\n"
+            + "                \"host\": \"" + ipAddr + "\",\n"
+            + "                \"port\": " + port + ",\n"
+            + "                \"connection-type\": \"INSECURE\"\n"
+            + "            },\n"
+            + "            \"extensions-parameters\": {\n"
+            + "                \"gnmi-parameters\": {\n"
+            + "                    \"overwrite-data-type\": \"NONE\",\n"
+            + "                    \"use-model-name-prefix\": true,\n"
+            + "                    \"path-target\": \"OC_YANG\"\n"
+            + "                },\n"
+            + "                \"additional-capability\": [\n"
+            + "                    {\n"
+            + "                        \"name\": \"" + modelName + "\",\n"
+            + "                        \"version\": \"" + modelVersion + "\"\n"
+            + "                    }\n"
+            + "                ]\n"
+            + "            }\n"
+            + "        }\n"
+            + "    ]\n"
+            + "}";
+    }
+
     protected HttpResponse<String> sendDeleteRequestJSON(final String path) throws InterruptedException, IOException {
         LOG.info("Sending DELETE request to path: {}", path);
         final HttpRequest deleteRequest = HttpRequest.newBuilder()


### PR DESCRIPTION
 Introduce the ability to add additional capability to node
 schema context. Some devices not provide complete
 capability list, so missing capabilities must
 be added by this addtional-capability list parameter.
Add tests for cover this functionality.
Add readme for describing this functionality.

Signed-off-by: Ivan Caladi <ivan.caladi@pantheon.tech>