### PR TITLE
Fix lighty-gnmi-connector tests package naming

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-connector/src/test/java/io/lighty/modules/gnmi/connector/tests/commons/TestUtils.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-connector/src/test/java/io/lighty/modules/gnmi/connector/tests/commons/TestUtils.java
@@ -6,7 +6,7 @@
  * and is available at https://www.eclipse.org/legal/epl-v10.html
  */
 
-package io.lighty.modules.gnmi.connector.commons;
+package io.lighty.modules.gnmi.connector.tests.commons;
 
 import io.lighty.modules.gnmi.connector.configuration.SecurityFactory;
 import io.lighty.modules.gnmi.connector.gnmi.session.impl.GnmiSessionFactoryImpl;

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-connector/src/test/java/io/lighty/modules/gnmi/connector/tests/commons/TimeoutUtil.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-connector/src/test/java/io/lighty/modules/gnmi/connector/tests/commons/TimeoutUtil.java
@@ -6,7 +6,7 @@
  * and is available at https://www.eclipse.org/legal/epl-v10.html
  */
 
-package io.lighty.modules.gnmi.connector.commons;
+package io.lighty.modules.gnmi.connector.tests.commons;
 
 public abstract class TimeoutUtil {
 

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-connector/src/test/java/io/lighty/modules/gnmi/connector/tests/gnmi/GnmiTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-connector/src/test/java/io/lighty/modules/gnmi/connector/tests/gnmi/GnmiTest.java
@@ -6,7 +6,7 @@
  * and is available at https://www.eclipse.org/legal/epl-v10.html
  */
 
-package io.lighty.modules.gnmi.connector.tests;
+package io.lighty.modules.gnmi.connector.tests.gnmi;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import gnmi.Gnmi;
@@ -16,13 +16,13 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
-import io.lighty.modules.gnmi.connector.commons.TestUtils;
-import io.lighty.modules.gnmi.connector.commons.TimeoutUtil;
 import io.lighty.modules.gnmi.connector.configuration.SessionConfiguration;
 import io.lighty.modules.gnmi.connector.gnmi.session.api.GnmiSession;
 import io.lighty.modules.gnmi.connector.gnmi.util.AddressUtil;
 import io.lighty.modules.gnmi.connector.session.api.SessionManager;
 import io.lighty.modules.gnmi.connector.session.api.SessionProvider;
+import io.lighty.modules.gnmi.connector.tests.commons.TestUtils;
+import io.lighty.modules.gnmi.connector.tests.commons.TimeoutUtil;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URISyntaxException;

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-connector/src/test/java/io/lighty/modules/gnmi/connector/tests/gnoi/GnoiTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-connector/src/test/java/io/lighty/modules/gnmi/connector/tests/gnoi/GnoiTest.java
@@ -6,7 +6,7 @@
  * and is available at https://www.eclipse.org/legal/epl-v10.html
  */
 
-package io.lighty.modules.gnmi.connector.gnoi;
+package io.lighty.modules.gnmi.connector.tests.gnoi;
 
 import com.google.protobuf.ByteString;
 import gnoi.file.FileGrpc;
@@ -14,15 +14,15 @@ import gnoi.file.FileOuterClass;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
-import io.lighty.modules.gnmi.connector.commons.TestUtils;
-import io.lighty.modules.gnmi.connector.commons.TimeoutUtil;
 import io.lighty.modules.gnmi.connector.configuration.SessionConfiguration;
 import io.lighty.modules.gnmi.connector.gnmi.util.AddressUtil;
 import io.lighty.modules.gnmi.connector.gnoi.invokers.api.GnoiFileInvoker;
 import io.lighty.modules.gnmi.connector.gnoi.session.api.GnoiSession;
 import io.lighty.modules.gnmi.connector.session.api.SessionManager;
 import io.lighty.modules.gnmi.connector.session.api.SessionProvider;
-import io.lighty.modules.gnmi.connector.tests.GnmiTest;
+import io.lighty.modules.gnmi.connector.tests.commons.TestUtils;
+import io.lighty.modules.gnmi.connector.tests.commons.TimeoutUtil;
+import io.lighty.modules.gnmi.connector.tests.gnmi.GnmiTest;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URISyntaxException;


### PR DESCRIPTION
- rename io.lighty.modules.gnmi.connector to io.lighty.modules.gnmi.connector.tests and rename tests subpackage with GnmiTest in it, to gnmi