### PR TITLE
Add additional-capability parameter to gnmi yang models - 14.0.x

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/README.md
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/README.md
@@ -51,6 +51,48 @@ curl --request POST 'http://127.0.0.1:8888/restconf/operations/gnmi-yang-storage
 }'
 ```
 
+The obtained list of capabilities is not always complete, which means that schema context isn't created correctly. Some 
+devices send a list of capabilities without yang models which `augment` other models. For this reason, it's possible 
+to add missing capabilities to the device capability list using the optional `additional-capabilitity` parameter.
+
+```
+curl -X PUT \
+  http://127.0.0.1:8888/restconf/data/network-topology:network-topology/topology=gnmi-topology/node=node-id-1 \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "node": [
+        {
+            "node-id": "node-id-1",
+            "connection-parameters": {
+                "host": "172.0.0.1",
+                "port": 9090,
+                "connection-type": "INSECURE"
+            },
+            "extensions-parameters": {
+                "additional-capability": [
+                    {
+                        "name": "openconfig-if-ethernet",
+                        "version": "2.6.2"
+                    },
+                    {
+                        "name": "openconfig-if-ip",
+                        "version": "2.3.1"
+                    }
+                ]
+            }
+        }
+    ]
+}'
+```
+In case the obtained list of capabilities is not complete, the missing capabilities will be shown in the error response.
+```
+{
+    "gnmi-topology:failure-details": "Errors: Missing models: \topenconfig-if-ethernet semver: 2.6.2\n"
+}
+```
+If an error is present, the node must be removed and the node must be added with the `additional capability` 
+parameter. The node must be removed because the schema context is already created and cannot be updated.
+
 ##How to start rcgnmi example app
 * build the project using ```mvn clean install```
 * go to target directory ```cd lighty-rcgnmi-app/target```

--- a/lighty-models/lighty-gnmi-models/lighty-gnmi-yang-storage-model/pom.xml
+++ b/lighty-models/lighty-gnmi-models/lighty-gnmi-yang-storage-model/pom.xml
@@ -23,4 +23,22 @@
     <artifactId>lighty-gnmi-yang-storage-model</artifactId>
     <version>14.0.1-SNAPSHOT</version>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.opendaylight.mdsal.model</groupId>
+            <artifactId>ietf-topology</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opendaylight.mdsal.binding.model.ietf</groupId>
+            <artifactId>rfc6991-ietf-inet-types</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opendaylight.mdsal.model</groupId>
+            <artifactId>yang-ext</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.lighty.models.gnmi</groupId>
+            <artifactId>lighty-gnmi-topology-model</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/lighty-models/lighty-gnmi-models/lighty-gnmi-yang-storage-model/src/main/yang/gnmi-yang-storage.yang
+++ b/lighty-models/lighty-gnmi-models/lighty-gnmi-yang-storage-model/src/main/yang/gnmi-yang-storage.yang
@@ -16,6 +16,10 @@ module gnmi-yang-storage {
         description "Initial revision of gNMI yang storage model";
     }
 
+    import network-topology { prefix nt; revision-date 2013-10-21; }
+    import yang-ext { prefix ext; revision-date "2013-07-09";}
+    import gnmi-topology { prefix gnmi; revision-date "2021-03-16";}
+
     typedef module-version-type {
         type string;
         description
@@ -31,18 +35,41 @@ module gnmi-yang-storage {
             "gNMI Specification Section 2.6.1 The ModelData message";
     }
 
+    grouping yang-model-name-version {
+            leaf name {
+                description "Name of the yang model";
+                type string;
+            }
+            leaf version {
+                description "Version of the yang model";
+                type module-version-type;
+            }
+    }
+
     grouping yang-model {
-        leaf name {
-            description "Name of the yang model";
-            type string;
-        }
-        leaf version {
-            description "Version of the yang model";
-            type module-version-type;
-        }
+        uses yang-model-name-version;
         leaf body {
             description "Body of the yang model";
             type string;
+        }
+    }
+
+    grouping additional-yang-models {
+        list additional-capability {
+            description "List of additional capabilities not provided
+                         in the device list of capabilities. Some devices
+                         don't provide a complete list of supported
+                         yang models. If yang models are not provided
+                         from the device, they must be added to
+                         SchemaContext using this additional-capability
+                         list. For example: Some device augmented
+                         openconfig-interfaces by openconfig-if-ethernet.
+                         The openconfig-if-ethernet yang model is not sent
+                         in the list of capabilities and the schemaContext
+                         is incorrect, which means that data obtained
+                         from the device cannot be manipulated.";
+            key "name version";
+            uses yang-model-name-version;
         }
     }
 
@@ -60,4 +87,9 @@ module gnmi-yang-storage {
         }
     }
 
+    augment "/nt:network-topology/nt:topology/nt:node/gnmi:extensions-parameters" {
+        ext:augment-identifier "additional-capabilities";
+
+        uses additional-yang-models;
+    }
 }

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/device/connection/ConfigurableParameters.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/device/connection/ConfigurableParameters.java
@@ -8,16 +8,23 @@
 
 package io.lighty.gnmi.southbound.device.connection;
 
+import java.util.Map;
 import java.util.Optional;
 import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.topology.rev210316.gnmi.connection.parameters.ExtensionsParameters;
 import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.topology.rev210316.gnmi.connection.parameters.extensions.parameters.GnmiParameters;
+import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.yang.storage.rev210331.AdditionalCapabilities;
+import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.yang.storage.rev210331.additional.yang.models.AdditionalCapability;
+import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.yang.storage.rev210331.additional.yang.models.AdditionalCapabilityKey;
 
 public class ConfigurableParameters {
 
     private final GnmiParameters gnmiParameters;
+    private final AdditionalCapabilities additionalCapabilities;
 
     public ConfigurableParameters(final ExtensionsParameters extensionsParameters) {
         gnmiParameters = extensionsParameters == null ? null : extensionsParameters.getGnmiParameters();
+        additionalCapabilities = extensionsParameters == null ? null :
+            extensionsParameters.augmentation(AdditionalCapabilities.class);
     }
 
     public Optional<Boolean> getUseModelNamePrefix() {
@@ -37,6 +44,13 @@ public class ConfigurableParameters {
     public Optional<String> getPathTarget() {
         if (gnmiParameters != null) {
             return Optional.ofNullable(gnmiParameters.getPathTarget());
+        }
+        return Optional.empty();
+    }
+
+    public Optional<Map<AdditionalCapabilityKey, AdditionalCapability>> getAdditionalCapabilities() {
+        if (additionalCapabilities != null) {
+            return Optional.ofNullable(additionalCapabilities.getAdditionalCapability());
         }
         return Optional.empty();
     }

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/device/connection/DeviceConnectionManager.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/device/connection/DeviceConnectionManager.java
@@ -24,6 +24,7 @@ import io.lighty.gnmi.southbound.schema.impl.SchemaException;
 import io.lighty.gnmi.southbound.timeout.TimeoutUtils;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -38,6 +39,8 @@ import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.topology.rev210316.gnmi.node
 import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.topology.rev210316.gnmi.node.state.node.state.AvailableCapabilitiesBuilder;
 import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.topology.rev210316.gnmi.node.state.node.state.available.capabilities.AvailableCapability;
 import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.topology.rev210316.gnmi.node.state.node.state.available.capabilities.AvailableCapabilityBuilder;
+import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.yang.storage.rev210331.additional.yang.models.AdditionalCapability;
+import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.yang.storage.rev210331.additional.yang.models.AdditionalCapabilityKey;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.NodeId;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.topology.Node;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.topology.NodeBuilder;
@@ -108,6 +111,8 @@ public class DeviceConnectionManager implements AutoCloseable {
                 LOG.debug("Received gNMI Capabiltiies response from {} : {}",node.getNodeId(), capabilityResponse);
                 final List<GnmiDeviceCapability> capabilitiesList =
                     GnmiRequestUtils.fromCapabilitiesResponse(capabilityResponse);
+                capabilitiesList
+                    .addAll(GnmiRequestUtils.fromCapabilitiesResponse(getExtensionYangModelsList(deviceConnection)));
                 try {
                     final EffectiveSchemaContext schemaContext = schemaContextHolder.getSchemaContext(capabilitiesList);
                     deviceConnection.setSchemaContext(schemaContext);
@@ -123,6 +128,25 @@ public class DeviceConnectionManager implements AutoCloseable {
                 }
             },
             executorService);
+    }
+
+    private Gnmi.CapabilityResponse getExtensionYangModelsList(final DeviceConnection deviceConnection) {
+        Optional<Map<AdditionalCapabilityKey, AdditionalCapability>> models =
+            deviceConnection.getConfigurableParameters().getAdditionalCapabilities();
+        Gnmi.CapabilityResponse.Builder capabilitiesResponseBuilder = Gnmi.CapabilityResponse.newBuilder();
+        if (models.isPresent()) {
+            models.get().entrySet()
+                .stream()
+                .map(model -> model.getValue())
+                .peek(additionalCapability ->
+                    LOG.debug("Adding additional gNMI capability: name {} version {}",
+                        additionalCapability.getName(), additionalCapability.getVersion().getValue()))
+                .forEach(model -> capabilitiesResponseBuilder
+                    .addSupportedModels(Gnmi.ModelData.newBuilder()
+                        .setName(model.getName())
+                        .setVersion(model.getVersion().getValue())));
+        }
+        return capabilitiesResponseBuilder.build();
     }
 
     private void saveCapabilitiesList(final NodeId nodeId, final List<GnmiDeviceCapability> gnmiDeviceCapabilities)

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiConnectionITTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiConnectionITTest.java
@@ -43,6 +43,12 @@ public class GnmiConnectionITTest extends GnmiITBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(GnmiConnectionITTest.class);
 
+    private static final String GET_CAPABILITIES_PATH
+        = GNMI_TOPOLOGY_PATH + "/node=" + GNMI_NODE_ID + "/gnmi-topology:node-state/available-capabilities";
+    private static final String MODEL_OPENCONFIG_AAA_NAME = "openconfig-aaa";
+    private static final String MODEL_OPENCONFIG_AAA_VERSION = "0.5.0";
+    private static final String EXPECTED_CAPABILITY
+        = MODEL_OPENCONFIG_AAA_NAME + " semver: " + MODEL_OPENCONFIG_AAA_VERSION;
     private static final Duration CONNECT_ATTEMPT_WAIT_DURATION = Duration.ofMillis(5_000L);
     private static final String GNMI_NODE_STATUS_TRANSIENT_FAIL = "TRANSIENT_FAILURE";
     private static final String GNMI_NODE_STATUS_CONNECTING = "CONNECTING";
@@ -198,6 +204,87 @@ public class GnmiConnectionITTest extends GnmiITBase {
             .getJSONArray("network-topology:topology").getJSONObject(0)
             .getJSONArray("node").getJSONObject(0).getString("node-id");
         assertEquals(nodeIdFromTopology, GNMI_NODE_ID);
+
+        //assert disconnected device
+        assertTrue(disconnectDevice(GNMI_NODE_ID));
+    }
+
+    @Test
+    public void connectDeviceWithAdditionalCapabilityAndModelTest()
+        throws InterruptedException, IOException, ExecutionException, TimeoutException {
+        final HttpResponse<String> getGnmiTopologyResponse = sendGetRequestJSON(GNMI_TOPOLOGY_PATH);
+        assertEquals(HttpURLConnection.HTTP_OK, getGnmiTopologyResponse.statusCode());
+        final JSONArray topologies =
+            new JSONObject(getGnmiTopologyResponse.body()).getJSONArray("network-topology:topology");
+        assertEquals(1, topologies.length());
+        final JSONObject gnmiTopologyJSON = topologies.getJSONObject(0);
+        LOG.info("Empty gnmi-topology check response: {}", gnmiTopologyJSON);
+        assertEquals("gnmi-topology", gnmiTopologyJSON.getString("topology-id"));
+        assertThrows(JSONException.class, () -> gnmiTopologyJSON.getJSONArray("node"));
+
+        // add gNMI node to topology
+        final String newDevicePayload =
+            createDevicePayloadWithAdditionalCapabilities(GNMI_NODE_ID, DEVICE_IP, DEVICE_PORT,
+                MODEL_OPENCONFIG_AAA_NAME, MODEL_OPENCONFIG_AAA_VERSION);
+        LOG.info("Adding gnmi device with ID {}", GNMI_NODE_ID);
+        final HttpResponse<String> addGnmiDeviceResponse = sendPutRequestJSON(GNMI_NODE_PATH, newDevicePayload);
+        assertEquals(HttpURLConnection.HTTP_CREATED, addGnmiDeviceResponse.statusCode());
+
+        // assert gNMI node is connected
+        Awaitility.waitAtMost(WAIT_TIME_DURATION)
+            .pollInterval(POLL_INTERVAL_DURATION)
+            .untilAsserted(() -> {
+                final HttpResponse<String> capabilitiesResponse =
+                    sendGetRequestJSON(GET_CAPABILITIES_PATH);
+                assertEquals(HttpURLConnection.HTTP_OK, capabilitiesResponse.statusCode());
+                final JSONArray gnmiDeviceCapabilities = new JSONObject(capabilitiesResponse.body())
+                    .getJSONObject("gnmi-topology:available-capabilities").getJSONArray("available-capability");
+                assertTrue(gnmiDeviceCapabilities.toString().contains(EXPECTED_CAPABILITY));
+            });
+
+        //assert disconnected device
+        assertTrue(disconnectDevice(GNMI_NODE_ID));
+    }
+
+    @Test
+    public void connectDeviceWithAdditionalCapabilityWithNotImportedYangModelTest()
+        throws InterruptedException, IOException, ExecutionException, TimeoutException {
+        final HttpResponse<String> getGnmiTopologyResponse = sendGetRequestJSON(GNMI_TOPOLOGY_PATH);
+        assertEquals(HttpURLConnection.HTTP_OK, getGnmiTopologyResponse.statusCode());
+        final JSONArray topologies =
+            new JSONObject(getGnmiTopologyResponse.body()).getJSONArray("network-topology:topology");
+        assertEquals(1, topologies.length());
+        final JSONObject gnmiTopologyJSON = topologies.getJSONObject(0);
+        LOG.info("Empty gnmi-topology check response: {}", gnmiTopologyJSON);
+        assertEquals("gnmi-topology", gnmiTopologyJSON.getString("topology-id"));
+        assertThrows(JSONException.class, () -> gnmiTopologyJSON.getJSONArray("node"));
+
+        final String modelName = "not-imported-model-name";
+        final String nodeState = "gnmi-topology:node-state";
+        // add gNMI node to topology
+        final String newDevicePayload =
+            createDevicePayloadWithAdditionalCapabilities(GNMI_NODE_ID, DEVICE_IP, DEVICE_PORT,
+                modelName, MODEL_OPENCONFIG_AAA_VERSION);
+        LOG.info("Adding gnmi device with ID {}", GNMI_NODE_ID);
+        final HttpResponse<String> addGnmiDeviceResponse = sendPutRequestJSON(GNMI_NODE_PATH, newDevicePayload);
+        assertEquals(HttpURLConnection.HTTP_CREATED, addGnmiDeviceResponse.statusCode());
+
+        // assert gNMI node is connected
+        Awaitility.waitAtMost(WAIT_TIME_DURATION)
+            .pollInterval(POLL_INTERVAL_DURATION)
+            .untilAsserted(() -> {
+                final HttpResponse<String> capabilitiesResponse =
+                    sendGetRequestJSON(GNMI_NODE_PATH  + "/" + nodeState);
+                assertEquals(HttpURLConnection.HTTP_OK, capabilitiesResponse.statusCode());
+                final String gnmiDeviceConnectStatus =
+                    new JSONObject(capabilitiesResponse.body()).getJSONObject(nodeState).getString(
+                        "node-status");
+                final String gnmiDeviceFailureDetails =
+                    new JSONObject(capabilitiesResponse.body()).getJSONObject(nodeState).getString(
+                        "failure-details");
+                assertTrue(gnmiDeviceConnectStatus.equals("FAILURE"));
+                assertTrue(gnmiDeviceFailureDetails.contains(modelName));
+            });
 
         //assert disconnected device
         assertTrue(disconnectDevice(GNMI_NODE_ID));

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiITBase.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiITBase.java
@@ -226,6 +226,36 @@ public abstract class GnmiITBase {
             + "}";
     }
 
+    protected String createDevicePayloadWithAdditionalCapabilities(final String nodeId, final String ipAddr,
+                                                                   final int port, final String modelName,
+                                                                   final String modelVersion) {
+        return "{\n"
+            + "    \"node\": [\n"
+            + "        {\n"
+            + "            \"node-id\": \"" + nodeId + "\",\n"
+            + "            \"connection-parameters\": {\n"
+            + "                \"host\": \"" + ipAddr + "\",\n"
+            + "                \"port\": " + port + ",\n"
+            + "                \"connection-type\": \"INSECURE\"\n"
+            + "            },\n"
+            + "            \"extensions-parameters\": {\n"
+            + "                \"gnmi-parameters\": {\n"
+            + "                    \"overwrite-data-type\": \"NONE\",\n"
+            + "                    \"use-model-name-prefix\": true,\n"
+            + "                    \"path-target\": \"OC_YANG\"\n"
+            + "                },\n"
+            + "                \"additional-capability\": [\n"
+            + "                    {\n"
+            + "                        \"name\": \"" + modelName + "\",\n"
+            + "                        \"version\": \"" + modelVersion + "\"\n"
+            + "                    }\n"
+            + "                ]\n"
+            + "            }\n"
+            + "        }\n"
+            + "    ]\n"
+            + "}";
+    }
+
     protected HttpResponse<String> sendDeleteRequestJSON(final String path) throws InterruptedException, IOException {
         LOG.info("Sending DELETE request to path: {}", path);
         final HttpRequest deleteRequest = HttpRequest.newBuilder()


### PR DESCRIPTION
Introduce the ability to add additional capability to node
schema context. Some devices not provide complete
capability list, so missing capabilities must
be added by this addtional-capability list parameter.
Add tests for cover this functionality.
Add readme for describing this functionality.

Signed-off-by: Ivan Caladi <ivan.caladi@pantheon.tech>