### PR TITLE
Remove DataConverter's comment for using lighty-codecs-14.0.x

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-commons/src/main/java/io/lighty/modules/gnmi/commons/util/DataConverter.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-commons/src/main/java/io/lighty/modules/gnmi/commons/util/DataConverter.java
@@ -43,10 +43,6 @@ import org.opendaylight.yangtools.yang.model.util.SchemaContextUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/*
-    TODO: Examine if this class can be removed and we can use lighty-codecs instead
-           or move these methods to lighty-codecs and use that.
- */
 public final class DataConverter {
 
     private static final Logger LOG = LoggerFactory.getLogger(DataConverter.class);


### PR DESCRIPTION
 DataConverter cannot be replaced by lighty-codecs-utils
 because DataConverter has a special cases for serialization
 and deserialization JSONs data.

Signed-off-by: Ivan Caladi <ivan.caladi@pantheon.tech>