### PR TITLE
lighty-gnmi fold wrong gnmi path from GET request - master

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-commons/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-commons/pom.xml
@@ -37,6 +37,16 @@
             <artifactId>yang-data-codec-gson</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.opendaylight.mdsal</groupId>
+            <artifactId>mdsal-binding-runtime-spi</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-commons/src/main/java/io/lighty/modules/gnmi/commons/util/ElementNameWithModuleName.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-commons/src/main/java/io/lighty/modules/gnmi/commons/util/ElementNameWithModuleName.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021 PANTHEON.tech s.r.o. All Rights Reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ */
+
+package io.lighty.modules.gnmi.commons.util;
+
+import org.opendaylight.yangtools.yang.common.QName;
+import org.opendaylight.yangtools.yang.model.api.Module;
+
+/**
+ * Immutable representation of Element-name together with optional Module-name.
+ * <p>This class may be helpful when preparing string values representing YANG elements, where representation of
+ * `openconfig-interfaces:interfaces` can be parsed and manipulate withing objects of this class.</p>
+ */
+public class ElementNameWithModuleName {
+
+    private final String elementName;
+    private final String moduleName;
+
+    public ElementNameWithModuleName(final String elementName, final String moduleName) {
+        this.elementName = elementName;
+        this.moduleName = moduleName;
+    }
+
+    public ElementNameWithModuleName(final String elementName) {
+        this.elementName = elementName;
+        this.moduleName = null;
+    }
+
+    public static ElementNameWithModuleName parseFromString(final String element) {
+        final String[] elementWithModule = element.split(":", 2);
+        if (elementWithModule.length > 1) {
+            return new ElementNameWithModuleName(elementWithModule[1], elementWithModule[0]);
+        } else {
+            return new ElementNameWithModuleName(elementWithModule[0]);
+        }
+    }
+
+    public String getElementName() {
+        return elementName;
+    }
+
+    public String getModuleName() {
+        return moduleName;
+    }
+
+    public boolean hasModuleName() {
+        return moduleName != null && !moduleName.isEmpty();
+    }
+
+    /**
+     * Compare this element name with provided QName name and Module name (if this element has some module).
+     *
+     * @param quName QName to compare with this element name
+     * @param module Module to compare with this element module-name
+     * @return true only if the element has same name as provided QName and same module-name as provided Module name
+     *     (if any module-name is present), otherwise false.
+     */
+    public boolean equals(final QName quName, final Module module) {
+        if (quName.getLocalName().equals(this.elementName)) {
+            // check module name also
+            if (this.hasModuleName() && !module.getName().equals(this.moduleName)) {
+                return false;
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-commons/src/test/java/io/lighty/modules/gnmi/commons/util/GnmiDataConverterTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-commons/src/test/java/io/lighty/modules/gnmi/commons/util/GnmiDataConverterTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 PANTHEON.tech s.r.o. All Rights Reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ */
+
+package io.lighty.modules.gnmi.commons.util;
+
+import com.google.common.io.ByteSource;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.opendaylight.yangtools.yang.model.api.Module;
+import org.opendaylight.yangtools.yang.model.parser.api.YangSyntaxErrorException;
+import org.opendaylight.yangtools.yang.model.repo.api.YangTextSchemaSource;
+import org.opendaylight.yangtools.yang.parser.rfc7950.reactor.RFC7950Reactors;
+import org.opendaylight.yangtools.yang.parser.rfc7950.repo.YangStatementStreamSource;
+import org.opendaylight.yangtools.yang.parser.spi.meta.ReactorException;
+import org.opendaylight.yangtools.yang.parser.stmt.reactor.CrossSourceStatementReactor;
+import org.opendaylight.yangtools.yang.parser.stmt.reactor.EffectiveSchemaContext;
+
+class GnmiDataConverterTest {
+    private static final String YANG_MODEL_1_FILE_NAME = "rootModel1.yang";
+    private static final String YANG_MODEL_2_FILE_NAME = "rootModel2.yang";
+
+    @Test
+    public void findCorrectRootYangModel() throws ReactorException, YangSyntaxErrorException, IOException {
+        EffectiveSchemaContext schemaContext = prepareSchemaWithMultipleRootContainersWithSameName();
+        final Optional<? extends Module> rootModel1
+                = DataConverter.findModuleByElement("root-model-1:root-container", schemaContext);
+        Assertions.assertTrue(rootModel1.isPresent());
+        final Optional<? extends Module> rootModel2
+                = DataConverter.findModuleByElement("root-model-2:root-container", schemaContext);
+        Assertions.assertTrue(rootModel2.isPresent());
+        Assertions.assertNotEquals(rootModel1, rootModel2);
+
+        final Optional<? extends Module> unspecifiedRootModule
+                = DataConverter.findModuleByElement("root-container", schemaContext);
+        Assertions.assertTrue(unspecifiedRootModule.isEmpty());
+    }
+
+    private static EffectiveSchemaContext prepareSchemaWithMultipleRootContainersWithSameName()
+            throws ReactorException, IOException, YangSyntaxErrorException {
+
+        final CrossSourceStatementReactor.BuildAction buildAction = RFC7950Reactors.defaultReactorBuilder()
+                .build().newBuild();
+
+        for (String modelName : Arrays.asList(YANG_MODEL_1_FILE_NAME, YANG_MODEL_2_FILE_NAME)) {
+            final YangStatementStreamSource yangModelRootSource = YangStatementStreamSource.create(
+                    YangTextSchemaSource.delegateForByteSource(
+                            YangTextSchemaSource.identifierFromFilename(modelName),
+                            ByteSource.wrap(Thread.currentThread().getContextClassLoader()
+                                    .getResourceAsStream("test/schema/" + modelName).readAllBytes())));
+
+            buildAction.addSource(yangModelRootSource);
+        }
+
+        return buildAction.buildEffective();
+    }
+}

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-commons/src/test/resources/test/schema/rootModel1.yang
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-commons/src/test/resources/test/schema/rootModel1.yang
@@ -1,0 +1,23 @@
+module root-model-1 {
+
+  yang-version "1";
+
+  namespace "tag:lighty.io,2021:yang:test:v1:gnmi:converter:root1";
+
+  prefix "rm1";
+
+  organization "PANTHEONtech s.r.o";
+
+  description
+    "Test model for simple YANG structure";
+
+  container root-container {
+    description "Root testingcontainer";
+
+    leaf-list elements {
+      type string;
+    }
+
+  }
+
+}

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-commons/src/test/resources/test/schema/rootModel2.yang
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-commons/src/test/resources/test/schema/rootModel2.yang
@@ -1,0 +1,23 @@
+module root-model-2 {
+
+  yang-version "1";
+
+  namespace "tag:lighty.io,2021:yang:test:v1:gnmi:converter:root2";
+
+  prefix "rm2";
+
+  organization "PANTHEONtech s.r.o";
+
+  description
+    "Test model for simple YANG structure";
+
+  container root-container {
+    description "Root testingcontainer";
+
+    leaf element {
+      type string;
+    }
+
+  }
+
+}

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/java/io/lighty/gnmi/southbound/mountpoint/codecs/YangInstanceIdentifierToGnmiPathCodecTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/java/io/lighty/gnmi/southbound/mountpoint/codecs/YangInstanceIdentifierToGnmiPathCodecTest.java
@@ -12,28 +12,32 @@ import gnmi.Gnmi;
 import io.lighty.gnmi.southbound.mountpoint.codecs.testcases.YangInstanceIdentifiertoPathTestCases;
 import io.lighty.gnmi.southbound.schema.impl.SchemaException;
 import io.lighty.gnmi.southbound.schema.loader.api.YangLoadException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.opendaylight.yangtools.yang.common.QName;
 import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier;
 
 public class YangInstanceIdentifierToGnmiPathCodecTest {
 
-    private static YangInstanceIdentifiertoPathTestCases testCases;
-
-    @BeforeAll
-    public static void init() throws YangLoadException, SchemaException {
-        testCases = new YangInstanceIdentifiertoPathTestCases();
-    }
+    private static final Path TEST_PATH = Paths.get("src/test/resources/not/unique/model/elements");
+    private static final String NAMESPACE_ROOT1 = "tag:lighty.io.2021:yang:test:v1:gnmi:converter:root1";
+    private static final String NAMESPACE_ROOT2 = "tag:lighty.io,2021:yang:test:v1:gnmi:converter:root2";
+    private static final String ROOT_MODULE_NAME_1 = "root-model-1";
+    private static final String ROOT_MODULE_NAME_2 = "root-model-2";
+    private static final String ROOT_CONTAINER = "root-container";
 
     @Test
-    public void yangInstanceIdentifierToPathCodecTest() {
-        testCodec(true);
-        testCodec(false);
+    public void yangInstanceIdentifierToPathCodecTest() throws SchemaException, YangLoadException {
+        YangInstanceIdentifiertoPathTestCases testCases = new YangInstanceIdentifiertoPathTestCases();
+        testCodec(true, testCases);
+        testCodec(false, testCases);
     }
 
-    private void testCodec(final boolean shouldApplyModulePrefixToTopElement) {
+    private void testCodec(final boolean shouldApplyModulePrefixToTopElement,
+                           final YangInstanceIdentifiertoPathTestCases testCases) {
         final YangInstanceIdentifierToPathCodec codec = new YangInstanceIdentifierToPathCodec(
                 testCases.getSchemaContextProvider(), shouldApplyModulePrefixToTopElement);
         //Test root element
@@ -59,4 +63,36 @@ public class YangInstanceIdentifierToGnmiPathCodecTest {
         Assertions.assertEquals(identifierToPathExpected.getValue(), result);
     }
 
+    @Test
+    public void yangInstanceIdentifierToPathCodecWithNotUniqueNameForRootElement()
+            throws SchemaException, YangLoadException {
+        //Init YangInstanceIdentifierToPathCodec with test schema context
+        final TestSchemaContextProvider contextProvider = TestSchemaContextProvider.createFromPath(TEST_PATH);
+        final YangInstanceIdentifierToPathCodec pathCodec
+                = new YangInstanceIdentifierToPathCodec(contextProvider, true);
+        // Test parse YIID path and choosing correct module for not unique name for root element
+        final YangInstanceIdentifier root1YIID = YangInstanceIdentifier.builder()
+                .node(QName.create(NAMESPACE_ROOT1, ROOT_CONTAINER))
+                .node(QName.create(NAMESPACE_ROOT1, "data"))
+                .build();
+        final Gnmi.Path pathRoot1 = pathCodec.apply(root1YIID);
+        final Gnmi.PathElem root1Elem = pathRoot1.getElem(0);
+        final String[] splitRoot1Elem = root1Elem.getName().split(":");
+        Assertions.assertEquals(2, splitRoot1Elem.length);
+        Assertions.assertEquals(ROOT_MODULE_NAME_1, splitRoot1Elem[0]);
+        Assertions.assertEquals(ROOT_CONTAINER, splitRoot1Elem[1]);
+
+        // Parse YIID path and verify choosing correct module for not unique name in root element with
+        // unique last element
+        final YangInstanceIdentifier root2YIID = YangInstanceIdentifier.builder()
+                .node(QName.create(NAMESPACE_ROOT2, ROOT_CONTAINER))
+                .node(QName.create(NAMESPACE_ROOT2, "element"))
+                .build();
+        final Gnmi.Path pathRoot2 = pathCodec.apply(root2YIID);
+        final Gnmi.PathElem root2Elem = pathRoot2.getElem(0);
+        final String[] splitRoot2Elem = root2Elem.getName().split(":");
+        Assertions.assertEquals(2, splitRoot2Elem.length);
+        Assertions.assertEquals(ROOT_MODULE_NAME_2, splitRoot2Elem[0]);
+        Assertions.assertEquals(ROOT_CONTAINER, splitRoot2Elem[1]);
+    }
 }

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/resources/not/unique/model/elements/rootModel1.yang
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/resources/not/unique/model/elements/rootModel1.yang
@@ -1,0 +1,24 @@
+module root-model-1 {
+
+  yang-version "1";
+
+  namespace "tag:lighty.io.2021:yang:test:v1:gnmi:converter:root1";
+  prefix "rm1";
+
+  organization "PANTHEONtech s.r.o";
+
+  description
+    "Test model for simple YANG structure";
+
+  container root-container {
+    description "Root testingcontainer";
+
+    leaf-list elements {
+      type string;
+    }
+
+    leaf data  {
+        type string;
+    }
+  }
+}

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/resources/not/unique/model/elements/rootModel2.yang
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/resources/not/unique/model/elements/rootModel2.yang
@@ -1,0 +1,25 @@
+module root-model-2 {
+
+  yang-version "1";
+
+  namespace "tag:lighty.io,2021:yang:test:v1:gnmi:converter:root2";
+
+  prefix "rm2";
+
+  organization "PANTHEONtech s.r.o";
+
+  description
+    "Test model for simple YANG structure";
+
+  container root-container {
+    description "Root testingcontainer";
+
+    leaf element {
+      type string;
+    }
+
+    leaf data  {
+        type string;
+    }
+  }
+}

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/SimulatorCrudTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/SimulatorCrudTest.java
@@ -109,7 +109,7 @@ public class SimulatorCrudTest {
     public void crudSimpleValueTest() throws ExecutionException, InterruptedException, IOException {
         final Gnmi.Path path = Gnmi.Path.newBuilder()
                 .addElem(Gnmi.PathElem.newBuilder()
-                        .setName("interfaces")
+                        .setName("openconfig-interfaces:interfaces")
                         .build())
                 .addElem(Gnmi.PathElem.newBuilder()
                         .setName("interface")

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/utils/TestUtils.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/utils/TestUtils.java
@@ -38,6 +38,8 @@ public final class TestUtils {
     private static final SessionManagerFactory SESSION_MANAGER_FACTORY
             = new SessionManagerFactoryImpl(new GnmiSessionFactoryImpl());
 
+    private static final JsonParser JSON_PARSER = new JsonParser();
+
     public static SessionManager createSessionManagerWithCerts()
             throws URISyntaxException, InvalidKeySpecException, CertificateException, NoSuchAlgorithmException,
             IOException {
@@ -51,9 +53,8 @@ public final class TestUtils {
     }
 
     public static boolean jsonMatch(final String first, final String second) {
-        final JsonParser parser = new JsonParser();
-        final JsonElement jsonA = parser.parse(first);
-        final JsonElement jsonB = parser.parse(second);
+        final JsonElement jsonA = JSON_PARSER.parse(first);
+        final JsonElement jsonB = JSON_PARSER.parse(second);
         return jsonA.equals(jsonB);
     }
 


### PR DESCRIPTION
If is sent request to "openconfig-interfaces:interface" light-gnmi-sb will send request to gnmi target with path "ietf-interfaces:interfaces". So lighty-gnmi-sb will choose wrong module and instead of using openconfig-interfaces it will use ietf-interfaces. Both of them contain interface container.

This issue is present only if ietf-interfaces model is present in schema-context. Or any two models with same not unique path of elements. This issue is present with connection SONiC device.