### PR TITLE
Enforce JSON_IETF [RFC7951] encoding support

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-commons/src/main/java/io/lighty/modules/gnmi/commons/util/DataConverter.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-commons/src/main/java/io/lighty/modules/gnmi/commons/util/DataConverter.java
@@ -78,7 +78,7 @@ public final class DataConverter {
     private static String toJson(final SchemaPath schemaPath, final NormalizedNode<?, ?> data,
                                  final EffectiveModelContext context) {
         final JSONCodecFactory jsonCodecFactory
-                = JSONCodecFactorySupplier.DRAFT_LHOTKA_NETMOD_YANG_JSON_02.createSimple(context);
+                = JSONCodecFactorySupplier.RFC7951.createSimple(context);
         if (isListEntry(data)) {
             return createJsonWithNestedWriter(schemaPath, data, jsonCodecFactory);
         } else {
@@ -150,7 +150,7 @@ public final class DataConverter {
 
         final NormalizedNodeStreamWriter streamWriter = ImmutableNormalizedNodeStreamWriter.from(resultBuilder);
         final JSONCodecFactory jsonCodecFactory =
-                JSONCodecFactorySupplier.DRAFT_LHOTKA_NETMOD_YANG_JSON_02.createLazy(context);
+                JSONCodecFactorySupplier.RFC7951.createLazy(context);
 
         final JsonParserStream jsonParser =
                 (parentNode != null) ? JsonParserStream.create(streamWriter, jsonCodecFactory, parentNode)

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/README.md
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/README.md
@@ -62,6 +62,9 @@ SimulatedGnmiDeviceBuilder.
 
 11. **usePlaintext()** - (default: turned off) This will Disable TLS validation. If this is enabled, then there is no need
    to specify TLS related options.
+   
+12. **setSupportedEncodings(EnumSet<Gnmi.Encoding>)** - overwrites default encoding set {JSON_IETF, JSON} 
+    returned in CapabilityResponse.
 
 12. **setGsonInstance(Gson)** - (default: default instance of Gson)  Provides an option to customize Gson parser instance
    used in device.

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/gnmi/GnmiCapabilitiesService.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/gnmi/GnmiCapabilitiesService.java
@@ -12,6 +12,8 @@ import gnmi.Gnmi;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Objects;
+import org.eclipse.jdt.annotation.Nullable;
 import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
 import org.opendaylight.yangtools.yang.model.api.Module;
 import org.slf4j.Logger;
@@ -21,13 +23,15 @@ public class GnmiCapabilitiesService {
 
     private static final Logger LOG = LoggerFactory.getLogger(GnmiCapabilitiesService.class);
     private static final String GNMI_VERSION = "0.7.0";
-    private static final EnumSet<Gnmi.Encoding> GNMI_ENCODINGS = EnumSet.of(Gnmi.Encoding.JSON,
-        Gnmi.Encoding.JSON_IETF);
 
     private final EffectiveModelContext schemaContext;
+    private final EnumSet<Gnmi.Encoding> supportedEncodings;
 
-    public GnmiCapabilitiesService(final EffectiveModelContext schemaContext) {
+    public GnmiCapabilitiesService(final EffectiveModelContext schemaContext,
+                                   @Nullable final EnumSet<Gnmi.Encoding> supportedEncodings) {
         this.schemaContext = schemaContext;
+        this.supportedEncodings = Objects.requireNonNullElse(supportedEncodings,EnumSet.of(Gnmi.Encoding.JSON,
+                Gnmi.Encoding.JSON_IETF));
     }
 
     @SuppressWarnings("UnstableApiUsage")
@@ -49,7 +53,7 @@ public class GnmiCapabilitiesService {
 
         return Gnmi.CapabilityResponse.newBuilder()
             .addAllSupportedModels(modelDataList)
-            .addAllSupportedEncodings(GNMI_ENCODINGS)
+            .addAllSupportedEncodings(supportedEncodings)
             .setGNMIVersion(GNMI_VERSION)
             .build();
     }

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/gnmi/GnmiCapabilitiesService.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/gnmi/GnmiCapabilitiesService.java
@@ -30,8 +30,8 @@ public class GnmiCapabilitiesService {
     public GnmiCapabilitiesService(final EffectiveModelContext schemaContext,
                                    @Nullable final EnumSet<Gnmi.Encoding> supportedEncodings) {
         this.schemaContext = schemaContext;
-        this.supportedEncodings = Objects.requireNonNullElse(supportedEncodings,EnumSet.of(Gnmi.Encoding.JSON,
-                Gnmi.Encoding.JSON_IETF));
+        this.supportedEncodings = Objects.requireNonNullElse(supportedEncodings,
+                EnumSet.of(Gnmi.Encoding.JSON, Gnmi.Encoding.JSON_IETF));
     }
 
     @SuppressWarnings("UnstableApiUsage")

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/gnmi/GnmiService.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/gnmi/GnmiService.java
@@ -17,6 +17,7 @@ import gnmi.Gnmi;
 import gnmi.gNMIGrpc;
 import io.grpc.stub.StreamObserver;
 import io.lighty.modules.gnmi.simulatordevice.yang.YangDataService;
+import java.util.EnumSet;
 import java.util.Objects;
 import org.eclipse.jdt.annotation.Nullable;
 import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
@@ -33,8 +34,8 @@ public class GnmiService extends gNMIGrpc.gNMIImplBase {
     private final GnmiCrudService gnmiCrudService;
 
     public GnmiService(final EffectiveModelContext schemaContext, final YangDataService dataService,
-                       @Nullable final Gson gson) {
-        this.gnmiCapabilitiesService = new GnmiCapabilitiesService(schemaContext);
+                       @Nullable final Gson gson, @Nullable final EnumSet<Gnmi.Encoding> supportedEncodings) {
+        this.gnmiCapabilitiesService = new GnmiCapabilitiesService(schemaContext, supportedEncodings);
         final Gson nonNullGson = Objects.requireNonNullElse(gson, new Gson());
         this.gnmiCrudService = new GnmiCrudService(dataService, schemaContext,  nonNullGson);
     }

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/impl/SimulatedGnmiDeviceBuilder.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/impl/SimulatedGnmiDeviceBuilder.java
@@ -10,8 +10,10 @@ package io.lighty.modules.gnmi.simulatordevice.impl;
 
 
 import com.google.gson.Gson;
+import gnmi.Gnmi;
 import io.lighty.modules.gnmi.simulatordevice.utils.UsernamePasswordAuth;
 import io.netty.channel.EventLoopGroup;
+import java.util.EnumSet;
 
 public class SimulatedGnmiDeviceBuilder {
     private EventLoopGroup bossGroup;
@@ -27,6 +29,7 @@ public class SimulatedGnmiDeviceBuilder {
     private UsernamePasswordAuth usernamePasswordAuth;
     private boolean plaintext = false;
     private Gson gson;
+    private EnumSet<Gnmi.Encoding> supportedEncodings;
 
     public SimulatedGnmiDeviceBuilder setInitialConfigDataPath(final String initialConfigDataPath) {
         this.initialConfigDataPath = initialConfigDataPath;
@@ -93,9 +96,15 @@ public class SimulatedGnmiDeviceBuilder {
         return this;
     }
 
+    public SimulatedGnmiDeviceBuilder setSupportedEncodings(final EnumSet<Gnmi.Encoding> encodings) {
+        this.supportedEncodings = encodings;
+        return this;
+    }
+
 
     public SimulatedGnmiDevice build() {
         return new SimulatedGnmiDevice(bossGroup, workerGroup, host, port, maxConnections, certificatePath, keyPath,
-                yangsPath, initialConfigDataPath, initialStateDataPath, usernamePasswordAuth, plaintext, gson);
+                yangsPath, initialConfigDataPath, initialStateDataPath, usernamePasswordAuth, plaintext, gson,
+                supportedEncodings);
     }
 }

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/README.md
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/README.md
@@ -44,7 +44,7 @@ This module implements functionality to make CRUD operations on gNMI target.
 
 5. **withConfig(GnmiConfiguration)** - (Default empty) Configuration of gNMI south-bound.
 
-## Supported encodingsGnmiCapabilitiesService.java
+## Supported encodings
 Since we are operating solely with yang modeled data, which, as stated in [gNMI spec](https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#231-json-and-json_ietf),
  should be encoded in RFC7951 JSON format, only JSON_IETF encoding is supported for structured data types. That means each gNMI SetRequest sent by gNMI-module targeted to structured data
  (yang container,list ...) is encoded in JSON_IETF and each gNMI GetRequest has encoding set to JSON_IETF.

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/README.md
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/README.md
@@ -44,3 +44,14 @@ This module implements functionality to make CRUD operations on gNMI target.
 
 5. **withConfig(GnmiConfiguration)** - (Default empty) Configuration of gNMI south-bound.
 
+## Supported encodings
+Since we are operating solely with yang modeled data, which, as stated in [gNMI spec](https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#231-json-and-json_ietf),
+ should be encoded in RFC7951 JSON format, only JSON_IETF encoding is supported for structured data types. That means each gNMI SetRequest sent by gNMI-module targeted to structured data
+ (yang container,list ...) is encoded in JSON_IETF and each gNMI GetRequest has encoding set to JSON_IETF.
+This encoding is also expected encoding for gNMI GetResponse of structured data.
+This encoding enforcement does not apply to SetRequest/GetResponse which targets scalar types (single yang leaf), in this case,
+ [gNMI specification](https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#223-node-values) applies.
+### Encodings in gNMI CapabilityResponse
+As stated above, only JSON_IETF is supported for encoding structured data types. This means that device MUST declare it's
+ support of JSON_IETF encoding in [CapabilityResponse](https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#322-the-capabilityresponse-message)
+  supported_encodings field. If JSON_IETF is not present in supported_encoding field, connection of gNMI device is closed.

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/README.md
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/README.md
@@ -44,12 +44,12 @@ This module implements functionality to make CRUD operations on gNMI target.
 
 5. **withConfig(GnmiConfiguration)** - (Default empty) Configuration of gNMI south-bound.
 
-## Supported encodings
+## Supported encodingsGnmiCapabilitiesService.java
 Since we are operating solely with yang modeled data, which, as stated in [gNMI spec](https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#231-json-and-json_ietf),
  should be encoded in RFC7951 JSON format, only JSON_IETF encoding is supported for structured data types. That means each gNMI SetRequest sent by gNMI-module targeted to structured data
  (yang container,list ...) is encoded in JSON_IETF and each gNMI GetRequest has encoding set to JSON_IETF.
 This encoding is also expected encoding for gNMI GetResponse of structured data.
-This encoding enforcement does not apply to SetRequest/GetResponse which targets scalar types (single yang leaf), in this case,
+This encoding enforcement does not apply to SetRequest/GetResponse targeting scalar types (single yang leaf), in this case,
  [gNMI specification](https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#223-node-values) applies.
 ### Encodings in gNMI CapabilityResponse
 As stated above, only JSON_IETF is supported for encoding structured data types. This means that device MUST declare it's

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/capabilities/MissingEncodingException.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/capabilities/MissingEncodingException.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2021 PANTHEON.tech s.r.o. All Rights Reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ */
+
+package io.lighty.gnmi.southbound.capabilities;
+
+public class MissingEncodingException extends Exception {
+
+    public MissingEncodingException(final String message) {
+        super(message);
+    }
+
+}

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/java/io/lighty/gnmi/southbound/device/SessionInitializeTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/java/io/lighty/gnmi/southbound/device/SessionInitializeTest.java
@@ -159,7 +159,8 @@ class SessionInitializeTest {
         final List<Node> gnmiNodes = prepareGnmiNodes(NUMBER_OF_NODES);
 
         when(gnmiSessionMock.capabilities(any()))
-                .thenAnswer(invocation -> Futures.immediateFuture(CapabilityResponse.getDefaultInstance()));
+                .thenAnswer(invocation -> Futures.immediateFuture(CapabilityResponse.newBuilder()
+                        .addSupportedEncodings(Gnmi.Encoding.JSON_IETF).build()));
 
         // Connect devices
         final List<ListenableFuture<Void>> futureResults = new ArrayList<>();
@@ -189,7 +190,8 @@ class SessionInitializeTest {
 
         when(gnmiSessionMock.capabilities(any()))
                 .thenAnswer(invocation -> Futures.scheduleAsync(
-                    () -> Futures.immediateFuture(Gnmi.CapabilityResponse.getDefaultInstance()),
+                    () -> Futures.immediateFuture(CapabilityResponse.newBuilder()
+                            .addSupportedEncodings(Gnmi.Encoding.JSON_IETF).build()),
                         ThreadLocalRandom.current().nextLong(500),
                         TimeUnit.MILLISECONDS, scheduledService));
 

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiITBase.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiITBase.java
@@ -14,6 +14,7 @@ import static io.lighty.modules.gnmi.test.gnmi.rcgnmi.GnmiITBase.GeneralConstant
 import static io.lighty.modules.gnmi.test.gnmi.rcgnmi.GnmiITBase.GeneralConstants.GNMI_TOPOLOGY_PATH;
 import static io.lighty.modules.gnmi.test.gnmi.rcgnmi.GnmiITBase.GeneralConstants.OPENCONFIG_INTERFACES;
 
+import gnmi.Gnmi;
 import io.lighty.applications.rcgnmi.app.RCgNMIApp;
 import io.lighty.modules.gnmi.simulatordevice.impl.SimulatedGnmiDevice;
 import io.lighty.modules.gnmi.simulatordevice.impl.SimulatedGnmiDeviceBuilder;
@@ -26,6 +27,7 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
+import java.util.EnumSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -108,6 +110,15 @@ public abstract class GnmiITBase {
             .setYangsPath(TEST_SCHEMA_PATH)
             .setUsernamePasswordAuth(username, password)
             .build();
+    }
+
+    protected static SimulatedGnmiDevice getNonCompliableEncodingDevice(final String host, final int port) {
+        return new SimulatedGnmiDeviceBuilder().setHost(host).setPort(port)
+                .setInitialConfigDataPath(INITIAL_JSON_DATA_PATH + "/config.json")
+                .setInitialStateDataPath(INITIAL_JSON_DATA_PATH + "/state.json")
+                .setYangsPath(TEST_SCHEMA_PATH)
+                .setSupportedEncodings(EnumSet.of(Gnmi.Encoding.JSON))
+                .build();
     }
 
     protected static SimulatedGnmiDevice getSecureGnmiDevice(final String host, final int port,


### PR DESCRIPTION
- Switch to RFC7951 for gNMI json parsing
- Deny connection of gNMI device not supporting JSON_IETF encoding

Signed-off-by: marekzatko Marek.Zatko@pantheon.tech