### PR TITLE
Skip unnecessary artifacts when publishing to maven.central

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/pom.xml
@@ -17,6 +17,11 @@
     <version>15.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
+    </properties>
+
     <modules>
         <module>lighty-rcgnmi-app</module>
         <module>lighty-rcgnmi-app-module</module>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/pom.xml
@@ -23,6 +23,10 @@
     <artifactId>lighty-gnmi-test</artifactId>
     <version>15.0.0-SNAPSHOT</version>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.lighty.modules.gnmi</groupId>

--- a/lighty-modules/lighty-gnmi/pom.xml
+++ b/lighty-modules/lighty-gnmi/pom.xml
@@ -17,6 +17,11 @@
     <version>15.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
+    </properties>
+
     <modules>
         <module>lighty-gnmi-connector</module>
         <module>lighty-gnmi-commons</module>


### PR DESCRIPTION
Skip gnmi aggregator artifacts, which help to hold just structure in project
 modules
Skip gnmi test module, containing only the integration tests used on build,
 which are not needed when depending on gnmi module implementation

Signed-off-by: Michal Banik <michal.banik@pantheon.tech>