### PR TITLE
Remove duplicate JsonWriter closing - 14.0.x

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-commons/src/main/java/io/lighty/modules/gnmi/commons/util/DataConverter.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-commons/src/main/java/io/lighty/modules/gnmi/commons/util/DataConverter.java
@@ -105,7 +105,6 @@ public final class DataConverter {
         } catch (IOException e) {
             throw new IllegalStateException(e);
         } finally {
-            closeAutoCloseableResource(normalizedNodeWriter);
             closeAutoCloseableResource(nodeWriter);
             closeAutoCloseableResource(writer);
         }
@@ -125,7 +124,6 @@ public final class DataConverter {
         } catch (IOException e) {
             throw new IllegalStateException(e);
         } finally {
-            closeAutoCloseableResource(normalizedNodeWriter);
             closeAutoCloseableResource(nodeWriter);
             closeAutoCloseableResource(jsonWriter);
             closeAutoCloseableResource(writer);


### PR DESCRIPTION
 Close method in NormalizeNodeWriter will close and flush
 JsonWriter provided in its construction. ExclusiveWrtier do the same thing.
 NestedWriter only flush JsonWriter, but closing was done in final block.

 So JsonWriter was closed two times. First in close method in NormalizeNodeWriter
second time in ExclusiveWriter close method. This will cause error logs with information,
that JsonWriter is already closed. I have removed closing NormalizeNodeWriter,
to resolve this problem.

Signed-off-by: PeterSuna <Peter.Suna@pantheon.tech>