### PR TITLE
Use merge operation for gnmi-topolgy init

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/provider/GnmiSouthboundProvider.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/provider/GnmiSouthboundProvider.java
@@ -148,11 +148,11 @@ public class GnmiSouthboundProvider implements AutoCloseable {
                         .build())
                 .build();
         @NonNull WriteTransaction configTx = dataBroker.newWriteOnlyTransaction();
-        configTx.put(LogicalDatastoreType.CONFIGURATION, IdentifierUtils.GNMI_TOPO_IID, topology);
+        configTx.merge(LogicalDatastoreType.CONFIGURATION, IdentifierUtils.GNMI_TOPO_IID, topology);
         configTx.commit().get(TimeoutUtils.DATASTORE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 
         @NonNull WriteTransaction operTx = dataBroker.newWriteOnlyTransaction();
-        operTx.put(LogicalDatastoreType.OPERATIONAL, IdentifierUtils.GNMI_TOPO_IID, topology);
+        operTx.merge(LogicalDatastoreType.OPERATIONAL, IdentifierUtils.GNMI_TOPO_IID, topology);
         operTx.commit().get(TimeoutUtils.DATASTORE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
     }
 


### PR DESCRIPTION
Put does not make sense from persistency perspective
because it overwrites everything that could already
be in gnmi-topology, use merge operation instead.

Cherry picked from #724
Signed-off-by: marekzatko <Marek.Zatko@pantheon.tech>