### PR TITLE
Fix conflicts when multiple YANG modules with top-elements with same name

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/mountpoint/codecs/GetResponseToNormalizedNodeCodec.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/mountpoint/codecs/GetResponseToNormalizedNodeCodec.java
@@ -17,9 +17,11 @@ import io.lighty.modules.gnmi.commons.util.DataConverter;
 import io.lighty.modules.gnmi.commons.util.JsonUtils;
 import java.util.Map;
 import java.util.Optional;
+import org.opendaylight.yangtools.yang.common.QName;
 import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier;
 import org.opendaylight.yangtools.yang.data.api.schema.AugmentationNode;
 import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
+import org.opendaylight.yangtools.yang.model.api.Module;
 
 /**
  * Default codec which transforms (Gnmi.GetResponse, YangInstanceIdentifier) to NormalizedNode.
@@ -69,11 +71,17 @@ public class GetResponseToNormalizedNodeCodec implements BiCodec<Gnmi.GetRespons
                           the same level as identifier last path arg points to.
                          */
                         if (!identifier.isEmpty() && isResponseJsonDeeperThanRequested(identifier, responseJson)) {
+                            final QName lastName = identifier.getLastPathArgument().getNodeType();
+                            final Module moduleByQName =
+                                    DataConverter.findModuleByQName(lastName, schemaContextProvider.getSchemaContext())
+                                            .orElseThrow(() -> new GnmiCodecException(
+                                                    String.format("Unable to find module of node %s", lastName)));
+
+                            final String wrapWith = String.format("%s:%s", moduleByQName.getName(),
+                                    lastName.getLocalName());
                             responseJson = isMapEntryPath(identifier)
-                                    ? JsonUtils.wrapJsonWithArray(responseJson,
-                                    identifier.getLastPathArgument().getNodeType().getLocalName(), gson)
-                                    : JsonUtils.wrapJsonWithObject(responseJson,
-                                    identifier.getLastPathArgument().getNodeType().getLocalName(), gson);
+                                    ? JsonUtils.wrapJsonWithArray(responseJson, wrapWith, gson)
+                                    : JsonUtils.wrapJsonWithObject(responseJson, wrapWith, gson);
                         }
                         codecResult = resolveJsonResponse(identifier, responseJson);
                         break;

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/java/io/lighty/gnmi/southbound/schema/SchemaConstructTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/java/io/lighty/gnmi/southbound/schema/SchemaConstructTest.java
@@ -44,7 +44,7 @@ public class SchemaConstructTest {
     private static final List<String> REVISION_MODELS = Arrays.asList("iana-if-type",
             "openconfig-extensions");
     private static final List<String> NO_VERSION_MODELS = Arrays.asList("no-version", "test-dependency",
-            "test-dependency2");
+            "test-dependency2", "test-interfaces");
     private TestYangDataStoreService dataStoreService;
     private List<GnmiDeviceCapability> completeCapabilities;
 

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/resources/test_schema/test-interfaces.yang
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/resources/test_schema/test-interfaces.yang
@@ -1,0 +1,17 @@
+module test-interfaces {
+
+  yang-version "1";
+
+  namespace "test:it";
+
+  prefix "ti";
+
+  description
+    "Model used for testing purposes";
+
+  container interfaces {
+    leaf test-leaf {
+        type string;
+    }
+  }
+}


### PR DESCRIPTION
Fix the following scenario which might lead to parsing
 error:
1. Schema context contains openconfig-interfaces
   and ietf-interfaces models, which both define
   "interfaces" container.
2. We make gNMI GetRequest on
    openconfig-interfaces:interfaces
3. Device responds with response rooted one level deeper
   than we requested, it answers with interfaces child
    interface list: openconfig-interfaces:INTERFACE..
4. Codec detects this and wraps the response with
   interfaces: interfaces/openconfig-interfaces:interface
5. Since we have two interfaces defined (ietf, openconfig)
   JSON parser can't decide which one to use and fails.

The solution is to wrap the response also with module
 name.

Signed-off-by: marekzatko <Marek.Zatko@pantheon.tech>