### PR TITLE
Bump akka config files to 2.6

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Kubernetes version
         run: |
           minikube kubectl -- version
+      - name: List kube-system pods
+        run: |
+          minikube kubectl -- get pods -n kube-system
       - name: Load image to minikube
         run: |
           echo "Exporting Docker image to .tar ..."
@@ -88,10 +91,51 @@ jobs:
           echo "Loading docker image to minikube"
           docker load --input ./${{ github.event.inputs.app-name }}.tar
           rm ./${{ github.event.inputs.app-name }}.tar
-      - name: Install app helm chart
+      - name: Install app helm chart, SINGLENODE
         run: |
           helm install ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-helm/helm/${{ github.event.inputs.app-name }}-helm --name ${{ github.event.inputs.app-name }}
           sleep 35 # Wait for app to start
+      - name: List pods
+        run: |
+          minikube kubectl -- get pods
+      - name: Cluster state (:8558/cluster/members)
+        run: |
+          pod_names=$(minikube kubectl -- get pods --no-headers -o custom-columns=":metadata.name")
+          for pod_name in $pod_names; \
+          do \
+            pod_ip=$(minikube kubectl -- get pod $pod_name --template={{.status.podIP}}) && \
+            curl --user admin:admin -H "Content-Type: application/json" --insecure http://$pod_ip:8558/cluster/members \
+          ;done
+      - name: Logs pods
+        run: |
+          pod_names=$(minikube kubectl -- get pods --no-headers -o custom-columns=":metadata.name")
+          for pod_name in $pod_names; \
+          do \
+            minikube kubectl -- logs $pod_name \
+          ;done
+      - name: Pods healthcheck (:8888/restconf/operations)
+        run: |
+          pod_names=$(minikube kubectl -- get pods --no-headers -o custom-columns=":metadata.name")
+          for pod_name in $pod_names; \
+          do \
+            pod_ip=$(minikube kubectl -- get pod $pod_name --template={{.status.podIP}}) && \
+            curl --user admin:admin -H "Content-Type: application/json" --insecure http://$pod_ip:8888/restconf/operations \
+          ;done
+      - name: List Services
+        run: |
+          minikube kubectl -- get services
+      - name: Service healthcheck (:30888/restconf/operations)
+        run: |
+          minikube_ip=$(minikube ip)
+          curl --user admin:admin -H "Content-Type: application/json" --insecure http://$minikube_ip:30888/restconf/operations
+      - name: Uninstall deployment
+        run: |
+          helm del ${{ github.event.inputs.app-name }} --purge
+          sleep 25 # Wait for helm to del deployment
+      - name: Install app helm chart, CLUSTER
+        run: |
+          helm install ${{ env.app-aggregator-dir}}/${{ github.event.inputs.app-name }}-helm/helm/${{ github.event.inputs.app-name }}-helm --name ${{ github.event.inputs.app-name }} --set lighty.replicaCount=3 --set lighty.akka.isSingleNode=false
+          sleep 120 # Wait for app to start and form cluster
       - name: List pods
         run: |
           minikube kubectl -- get pods

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/configmaps.yaml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/configmaps.yaml
@@ -87,13 +87,27 @@ data:
       log-level = "debug"
 
       actor {
+        warn-about-java-serializer-usage = off
         provider = "akka.cluster.ClusterActorRefProvider"
+        serializers {
+          java = "akka.serialization.JavaSerializer"
+          proto = "akka.remote.serialization.ProtobufSerializer"
+          readylocal = "org.opendaylight.controller.cluster.datastore.messages.ReadyLocalTransactionSerializer"
+          simpleReplicatedLogEntry = "org.opendaylight.controller.cluster.raft.persisted.SimpleReplicatedLogEntrySerializer"
+        }
+
+        serialization-bindings {
+          "com.google.protobuf.Message" = proto
+          "org.opendaylight.controller.cluster.datastore.messages.ReadyLocalTransaction" = readylocal
+          "org.opendaylight.controller.cluster.raft.persisted.SimpleReplicatedLogEntry" = simpleReplicatedLogEntry
+        }
       }
 
+
       remote {
-        netty.tcp {
-          hostname = ${?HOSTNAME}
-          port = {{ .Values.lighty.akka.remotingPort }}
+        artery {
+          canonical.hostname = ${?HOSTNAME}
+          canonical.port = {{ .Values.lighty.akka.remotingPort }}
           bind-hostname = 0.0.0.0
           bind-port = {{ .Values.lighty.akka.remotingPort }}
         }

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/microk8s-saveLightyLogs.sh
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/microk8s-saveLightyLogs.sh
@@ -3,7 +3,6 @@
 IFS=$(printf '\n.'); IFS=${IFS%.}
 
 for LINE in $(microk8s kubectl get pods -o wide | grep 'lighty-rcgnmi-app'); do
-        echo ${LINE}
         POD=`echo "${LINE}" | awk '{ print $1 }'`
         PODIP=`echo "${LINE}" | awk '{ print $6 }'`
         echo "Saving logs from POD ${POD}"

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/configmaps.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/configmaps.yaml
@@ -123,13 +123,27 @@ data:
       log-level = "debug"
 
       actor {
+        warn-about-java-serializer-usage = off
         provider = "akka.cluster.ClusterActorRefProvider"
+        serializers {
+          java = "akka.serialization.JavaSerializer"
+          proto = "akka.remote.serialization.ProtobufSerializer"
+          readylocal = "org.opendaylight.controller.cluster.datastore.messages.ReadyLocalTransactionSerializer"
+          simpleReplicatedLogEntry = "org.opendaylight.controller.cluster.raft.persisted.SimpleReplicatedLogEntrySerializer"
+        }
+
+        serialization-bindings {
+          "com.google.protobuf.Message" = proto
+          "org.opendaylight.controller.cluster.datastore.messages.ReadyLocalTransaction" = readylocal
+          "org.opendaylight.controller.cluster.raft.persisted.SimpleReplicatedLogEntry" = simpleReplicatedLogEntry
+        }
       }
 
+
       remote {
-        netty.tcp {
-          hostname = ${?HOSTNAME}
-          port = {{ .Values.lighty.akka.remotingPort }}
+        artery {
+          canonical.hostname = ${?HOSTNAME}
+          canonical.port = {{ .Values.lighty.akka.remotingPort }}
           bind-hostname = 0.0.0.0
           bind-port = {{ .Values.lighty.akka.remotingPort }}
         }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/microk8s-saveLightyLogs.sh
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/microk8s-saveLightyLogs.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-IFS=$'\n'
-for LINE in $(microk8s kubectl get pods -o wide | grep 'lighty-helm'); do
+IFS=$(printf '\n.'); IFS=${IFS%.}
+
+for LINE in $(microk8s kubectl get pods -o wide | grep 'lighty-rnc-app'); do
         POD=`echo "${LINE}" | awk '{ print $1 }'`
         PODIP=`echo "${LINE}" | awk '{ print $6 }'`
         echo "Saving logs from POD ${POD}"

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
@@ -421,7 +421,7 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
             final CompletableFuture<Terminated> actorSystemTerminatedFuture = this.actorSystemProvider
                     .getActorSystem()
                     .getWhenTerminated().toCompletableFuture();
-            final int actorSystemPort = this.actorSystemConfig.getInt("akka.remote.classic.netty.tcp.port");
+            final int actorSystemPort = this.actorSystemConfig.getInt("akka.remote.artery.canonical.port");
 
             try {
                 this.actorSystemProvider.close();

--- a/lighty-resources/singlenode-configuration/src/main/resources/singlenode/akka-default.conf
+++ b/lighty-resources/singlenode-configuration/src/main/resources/singlenode/akka-default.conf
@@ -1,19 +1,10 @@
 akka {
   remote {
     artery {
-      enabled = off
+      transport = tcp
       canonical.hostname = "127.0.0.1"
       canonical.port = 2550
     }
-    classic.netty.tcp {
-      hostname = "127.0.0.1"
-      port = 2550
-    }
-    # when under load we might trip a false positive on the failure detector
-    # transport-failure-detector {
-    # heartbeat-interval = 4 s
-    # acceptable-heartbeat-pause = 16s
-    # }
   }
 
   actor {
@@ -26,12 +17,17 @@ akka {
 
   cluster {
     # Remove ".tcp" when using artery.
-    seed-nodes = ["akka.tcp://opendaylight-cluster-data@127.0.0.1:2550"]
+    seed-nodes = ["akka://opendaylight-cluster-data@127.0.0.1:2550"]
 
     roles = [
       "member-1"
     ]
 
+    # when under load we might trip a false positive on the failure detector
+    # failure-detector {
+      # heartbeat-interval = 4 s
+      # acceptable-heartbeat-pause = 16s
+    # }
   }
 
   persistence {

--- a/lighty-resources/singlenode-configuration/src/main/resources/singlenode/factory-akka-default.conf
+++ b/lighty-resources/singlenode-configuration/src/main/resources/singlenode/factory-akka-default.conf
@@ -89,19 +89,16 @@ akka {
     # with read-only associations
     use-passive-connections = off
 
-    classic.netty.tcp {
-      maximum-frame-size = 419430400
-      send-buffer-size = 52428800
-      receive-buffer-size = 52428800
-    }
+      artery {
+        enabled = on
+        transport = tcp
 
-    artery {
-      advanced {
-        maximum-frame-size = 1 GiB
-        maximum-large-frame-size = 1 GiB
+        advanced {
+          maximum-frame-size = 400 MiB
+          #maximum-large-frame-size = 2 MiB
+        }
       }
     }
-  }
 
   cluster {
     seed-node-timeout = 12s


### PR DESCRIPTION
- Use akka artery
- Explicitly enable Java serialization, since it is no longer enabled by default.
- Add tests for cluster helm deployment
Sample test run for RNC app: https://github.com/marekzatko/lighty-core/actions/runs/1026258454
Sample test run RcGNMI app: https://github.com/marekzatko/lighty-core/actions/runs/1026258748