### PR TITLE
Load yang models as resource in gNMI plugin

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/yang/YangDataService.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/yang/YangDataService.java
@@ -16,8 +16,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.EnumMap;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -97,11 +95,13 @@ public class YangDataService {
                                      final EffectiveModelContext schemaContext) throws IOException {
         // Init config data
         if (StringUtils.isNotEmpty(initialConfigDataPath)) {
-            final InputStream configFile = Files.newInputStream(Path.of(initialConfigDataPath));
+            final InputStream configFile =
+                    this.getClass().getClassLoader().getResourceAsStream(initialConfigDataPath);
             initDataTree(configFile, DatastoreType.CONFIGURATION, schemaContext);
         }
         if (StringUtils.isNotEmpty(initialStateDataPath)) {
-            final InputStream configFile = Files.newInputStream(Path.of(initialStateDataPath));
+            final InputStream configFile =
+                    this.getClass().getClassLoader().getResourceAsStream(initialStateDataPath);
             initDataTree(configFile, DatastoreType.STATE, schemaContext);
         }
     }

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/test/java/io/lighty/modules/gnmi/simulatordevice/test/DeviceCreationTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/test/java/io/lighty/modules/gnmi/simulatordevice/test/DeviceCreationTest.java
@@ -21,7 +21,7 @@ import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
 
 public class DeviceCreationTest {
 
-    private static final String SCHEMA_PATH = "src/test/resources/test_schema";
+    private static final String SCHEMA_PATH = "test_schema";
     private static final String INIT_DATA_PATH = "src/test/resources/initData";
     private static final int TARGET_PORT = 10161;
     private static final String TARGET_HOST = "127.0.0.1";

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/java/io/lighty/gnmi/southbound/mountpoint/codecs/testcases/CodecTestCasesBase.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/java/io/lighty/gnmi/southbound/mountpoint/codecs/testcases/CodecTestCasesBase.java
@@ -39,7 +39,7 @@ import org.opendaylight.yangtools.yang.model.api.SchemaContext;
  */
 public class CodecTestCasesBase {
 
-    protected static final String BASE_YANGS_PATH = "src/test/resources/test_schema";
+    protected static final String BASE_YANGS_PATH = "test_schema";
     protected static final String IT_ID = "openconfig-interfaces";
     protected static final String IT_AGGR_ID = "openconfig-if-aggregate";
     protected static final String IT_TYPES_ID = "openconfig-if-types";
@@ -50,7 +50,8 @@ public class CodecTestCasesBase {
     private final SchemaContextProvider schemaContextProvider;
 
     public CodecTestCasesBase() throws YangLoadException, SchemaException {
-        this.schemaContextProvider = TestSchemaContextProvider.createFromPath(Paths.get(BASE_YANGS_PATH));
+        this.schemaContextProvider = TestSchemaContextProvider.createFromPath(
+                Paths.get(this.getClass().getClassLoader().getResource(BASE_YANGS_PATH).getPath()));
     }
 
     /**

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/java/io/lighty/gnmi/southbound/schema/SchemaConstructTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/java/io/lighty/gnmi/southbound/schema/SchemaConstructTest.java
@@ -34,8 +34,8 @@ import org.opendaylight.yangtools.yang.parser.stmt.reactor.EffectiveSchemaContex
 
 public class SchemaConstructTest {
 
-    private static final String SCHEMA_PATH = "src/test/resources/test_schema";
-    private static final String SYNTAX_ERROR_YANGS_PATH = "src/test/resources/syntax_error_yangs";
+    private static final String SCHEMA_PATH = "test_schema";
+    private static final String SYNTAX_ERROR_YANGS_PATH = "syntax_error_yangs";
     private static final List<String> MODELS_TO_MISS = Arrays.asList("openconfig-alarms",
             "openconfig-platform");
     private static final List<String> CAPABILITIES_TO_MISS = Arrays.asList("openconfig-alarm-types",
@@ -54,7 +54,8 @@ public class SchemaConstructTest {
     @BeforeEach
     public void setup() throws YangLoadException {
         dataStoreService = new TestYangDataStoreService();
-        completeCapabilities = new ByPathYangLoaderService(Path.of(SCHEMA_PATH), null)
+        completeCapabilities = new ByPathYangLoaderService(
+                Path.of(this.getClass().getClassLoader().getResource(SCHEMA_PATH).getPath()), null)
                 .load(dataStoreService);
         Assertions.assertFalse(completeCapabilities.isEmpty());
     }
@@ -185,7 +186,8 @@ public class SchemaConstructTest {
     @Test
     public void schemaConstructWrongSyntaxTest() throws IOException {
         // Delete models with correct syntax and add them back with wrong syntax
-        final List<File> filesInFolder = Files.walk(Path.of(SYNTAX_ERROR_YANGS_PATH))
+        final List<File> filesInFolder = Files.walk(
+                Path.of(this.getClass().getClassLoader().getResource(SYNTAX_ERROR_YANGS_PATH).getPath()))
                 .filter(Files::isRegularFile)
                 .map(Path::toFile)
                 .collect(Collectors.toList());
@@ -216,7 +218,8 @@ public class SchemaConstructTest {
     @Test
     public void schemaConstructWrongSyntaxAndMissingModelsTest() throws IOException {
         // Delete models with correct syntax and add them back with wrong syntax
-        final List<File> filesInFolder = Files.walk(Path.of(SYNTAX_ERROR_YANGS_PATH))
+        final List<File> filesInFolder = Files
+                .walk(Path.of(this.getClass().getClassLoader().getResource(SYNTAX_ERROR_YANGS_PATH).getPath()))
                 .filter(Files::isRegularFile)
                 .map(Path::toFile)
                 .collect(Collectors.toList());

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/resources/lightyconfigs/config.json
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/resources/lightyconfigs/config.json
@@ -1,11 +1,11 @@
 {
     "gnmi": {
         "initialYangsPaths" : [
-            "src/test/resources/initialYangs",
-            "src/test/resources/initialYangs1",
-            "src/test/resources/initialYangs2",
-            "src/test/resources/initialYangs3",
-            "src/test/resources/initialYangs4"
+            "initialYangs",
+            "initialYangs1",
+            "initialYangs2",
+            "initialYangs3",
+            "initialYangs4"
         ]
     }
 

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiITBase.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiITBase.java
@@ -52,7 +52,7 @@ public abstract class GnmiITBase {
     protected static final Duration WAIT_TIME_DURATION = Duration.ofMillis(10_000L);
 
     protected static final String INITIAL_JSON_DATA_PATH = "src/test/resources/json/initData";
-    protected static final String TEST_SCHEMA_PATH = "src/test/resources/simulator_models";
+    protected static final String TEST_SCHEMA_PATH = "simulator_models";
 
     protected static ExecutorService httpClientExecutor;
     protected static RCgNMIApp application;

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/resources/json/app_init_config.json
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/resources/json/app_init_config.json
@@ -64,7 +64,7 @@
   },
   "gnmi": {
     "initialYangsPaths" : [
-      "src/test/resources/models/plugin_models"
+      "models/plugin_models"
     ]
   }
 }


### PR DESCRIPTION
Change loading YANG models for gNMI as resources, providing possibility to load
 models from class-path as well as specified by exact path on file-system.

Signed-off-by: Michal Banik <michal.banik@pantheon.tech>