### PR TITLE
Fix sonarcloud reported vulnerabilities

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
@@ -23,9 +23,11 @@ import io.lighty.modules.northbound.restconf.community.impl.CommunityRestConfBui
 import io.lighty.modules.northbound.restconf.community.impl.config.RestConfConfiguration;
 import io.lighty.modules.northbound.restconf.community.impl.util.RestConfConfigUtils;
 import io.lighty.modules.southbound.netconf.impl.AAAEncryptionServiceImpl;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.util.Base64;
@@ -222,8 +224,12 @@ public class RcGnmiAppModule extends AbstractLightyModule {
     }
 
     private AaaEncryptServiceConfig getDefaultAaaEncryptServiceConfig() {
+        final SecureRandom random = new SecureRandom();
+        final byte[] bytes = new byte[16];
+        random.nextBytes(bytes);
+        final String salt = new String(Base64.getEncoder().encode(bytes), StandardCharsets.UTF_8);
         return new AaaEncryptServiceConfigBuilder().setEncryptKey("V1S1ED4OMeEh")
-                .setPasswordLength(12).setEncryptSalt("TdtWeHbch/7xP52/rp3Usw==")
+                .setPasswordLength(12).setEncryptSalt(salt)
                 .setEncryptMethod("PBKDF2WithHmacSHA1").setEncryptType("AES")
                 .setEncryptIterationCount(32768).setEncryptKeyLength(128)
                 .setCipherTransforms("AES/CBC/PKCS5Padding").build();

--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlUtil.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/xml/XmlUtil.java
@@ -203,7 +203,9 @@ public final class XmlUtil {
         }
 
         try {
-            return SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI).newSchema(sources);
+            final SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            schemaFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            return schemaFactory.newSchema(sources);
         } catch (final SAXException e) {
             throw new IllegalStateException("Failed to instantiate XML schema", e);
         }

--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/util/NetconfConfigUtils.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/util/NetconfConfigUtils.java
@@ -17,9 +17,11 @@ import io.lighty.modules.southbound.netconf.impl.AAAEncryptionServiceImpl;
 import io.lighty.modules.southbound.netconf.impl.config.NetconfConfiguration;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.util.Base64;
@@ -155,8 +157,12 @@ public final class NetconfConfigUtils {
      * @return default configuration.
      */
     public static AaaEncryptServiceConfig getDefaultAaaEncryptServiceConfig() {
+        final SecureRandom random = new SecureRandom();
+        final byte[] bytes = new byte[16];
+        random.nextBytes(bytes);
+        final String salt = new String(Base64.getEncoder().encode(bytes), StandardCharsets.UTF_8);
         return new AaaEncryptServiceConfigBuilder().setEncryptKey("V1S1ED4OMeEh")
-                .setPasswordLength(12).setEncryptSalt("TdtWeHbch/7xP52/rp3Usw==")
+                .setPasswordLength(12).setEncryptSalt(salt)
                 .setEncryptMethod("PBKDF2WithHmacSHA1").setEncryptType("AES")
                 .setEncryptIterationCount(32768).setEncryptKeyLength(128)
                 .setCipherTransforms("AES/CBC/PKCS5Padding").build();


### PR DESCRIPTION
Other vulnerabilities are all false positive or are not relevant, since they are present in example applications, which should not be used in production.

- use random salt for internal encryption service
- disallow doctype declarations when loading XML schema

Signed-off-by: marekzatko Marek.Zatko@pantheon.tech