### PR TITLE
Increase timeoute to 60s in GnmiWithoutRestconfTest - 14.0.x

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/GnmiWithoutRestconfTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/GnmiWithoutRestconfTest.java
@@ -100,7 +100,7 @@ public class GnmiWithoutRestconfTest {
     private static final Path CONFIGURATION_PATH = Path.of("src/test/resources/json/app_init_config.json");
     private static final Duration POLL_INTERVAL_DURATION = Duration.ofMillis(1_000L);
     private static final Duration WAIT_TIME_DURATION = Duration.ofMillis(10_000L);
-    public static final long TIMEOUT_MILLIS = 30_000;
+    public static final long TIMEOUT_MILLIS = 60_000;
     private static final String GNMI_NODE_ID = "gnmiNodeId";
     private static final String DEVICE_ADDRESS = "127.0.0.1";
     private static final int DEVICE_PORT = 3333;


### PR DESCRIPTION
 - Sometimes test failed because of lighty.core
   not closed resources under 30s.

Signed-off-by: PeterSuna <Peter.Suna@pantheon.tech>