### PR TITLE
Increase timeoute to 60s in GnmiWithoutRestconfTest - master

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/GnmiWithoutRestconfTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/GnmiWithoutRestconfTest.java
@@ -202,6 +202,29 @@ public class GnmiWithoutRestconfTest {
     }
 
     @Test
+    public void testMultipleCrudOperation() throws ExecutionException, InterruptedException, TimeoutException,
+            InvalidAlgorithmParameterException, ConfigurationException, NoSuchPaddingException, IOException,
+            NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
+        testCrudOperation();
+        tearDown();
+        for (int i = 0; i < 50; i++) {
+            try {
+                startUp();
+                testCrudOperation();
+            } catch (InvalidAlgorithmParameterException | ConfigurationException | NoSuchPaddingException
+                    | IOException | NoSuchAlgorithmException | InvalidKeySpecException | ExecutionException
+                    | InvalidKeyException | InterruptedException | TimeoutException e) {
+                Assertions.fail(e);
+
+            } finally {
+                tearDown();
+            }
+        }
+        startUp();
+        testCrudOperation();
+    }
+
+    @Test
     public void testCrudOperation() throws ExecutionException, InterruptedException, TimeoutException {
         final DataBroker bindingDataBroker = lightyController.getServices().getBindingDataBroker();
         //Write device to data-store

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/GnmiWithoutRestconfTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/GnmiWithoutRestconfTest.java
@@ -310,6 +310,13 @@ public class GnmiWithoutRestconfTest {
         } catch (ExecutionException | InterruptedException e) {
             Assertions.fail("Failed to remove device data from gNMI", e);
         }
+
+        Awaitility.waitAtMost(WAIT_TIME_DURATION)
+                .pollInterval(POLL_INTERVAL_DURATION)
+                .untilAsserted(() -> {
+                    final Optional<Node> node = readOperData(bindingDataBroker, nodeInstanceIdentifier);
+                    assertFalse(node.isPresent());
+                });
     }
 
     @Test


### PR DESCRIPTION
 - Sometimes test failed because of lighty.core
   not closed resources under 30s.

cherry-picks #789 

Signed-off-by: PeterSuna <Peter.Suna@pantheon.tech>