### PR TITLE
Prepare release 13.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Software-Defined Networking (SDN) solutions in Java. Developed by [PANTHEON.tech
 
 It utilizes core [OpenDaylight](https://www.opendaylight.org/) components, which are available as a set of libraries and are adapted to run in a __plain Java SE environment__.
 
-[![Build Status](https://github.com/PANTHEONtech/lighty/workflows/Build/badge.svg?branch=13.3.x)](https://github.com/PANTHEONtech/lighty/actions)
+[![Build Status](https://github.com/PANTHEONtech/lighty/workflows/Build/badge.svg?branch=13.4.x)](https://github.com/PANTHEONtech/lighty/actions)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.lighty.core/lighty-bom/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.lighty.core/lighty-bom)
 [![License](https://img.shields.io/badge/License-EPL%201.0-blue.svg)](https://opensource.org/licenses/EPL-1.0)
 

--- a/lighty-applications/lighty-rnc-app-aggregator/README.md
+++ b/lighty-applications/lighty-rnc-app-aggregator/README.md
@@ -2,15 +2,15 @@
 Lighty Restconf Netconf application allows to easily initialize, start and use most used OpenDaylight services and optionally add custom business logic.
 
 Most important lighty.io components used are:
-- [lighty.io controller](https://github.com/PANTHEONtech/lighty/tree/13.3.x/lighty-core/lighty-controller)
+- [lighty.io controller](https://github.com/PANTHEONtech/lighty/tree/13.4.x/lighty-core/lighty-controller)
   provides core ODL services (like MDSAL, yangtools, global schema context,...) that are required
   for other services or plugins.
-- [RESTCONF northbound plugin](https://github.com/PANTHEONtech/lighty/tree/13.3.x/lighty-modules/lighty-restconf-nb-community)
+- [RESTCONF northbound plugin](https://github.com/PANTHEONtech/lighty/tree/13.4.x/lighty-modules/lighty-restconf-nb-community)
   provides the RESTCONF interface that is used to communicate with the application using the RESTCONF protocol over the HTTP.
-- [NETCONF southbound plugin](https://github.com/PANTHEONtech/lighty/tree/13.3.x/lighty-modules/lighty-netconf-sb)
+- [NETCONF southbound plugin](https://github.com/PANTHEONtech/lighty/tree/13.4.x/lighty-modules/lighty-netconf-sb)
   enables application to connect to the NETCONF devices using the NETCONF protocol and read/write configuration
   from them or execute RPCs.
-- [AAA module](https://github.com/PANTHEONtech/lighty/tree/13.3.x/lighty-modules/lighty-aaa) provides authorization,
+- [AAA module](https://github.com/PANTHEONtech/lighty/tree/13.4.x/lighty-modules/lighty-aaa) provides authorization,
   authentication and accounting which for example enables to use Basic Authentication for RESTCONF northbound interface.
   This module is optional and can be turned ON/OFF using application configuration.
 
@@ -104,7 +104,7 @@ To build and start the RNC lighty.io application using docker in the local envir
 
    If your configuration.json file specifies path to initial configuration data to load on start up
    (for more information, check 
-   [lighty-controller](https://github.com/PANTHEONtech/lighty/tree/13.3.x/lighty-core/lighty-controller))
+   [lighty-controller](https://github.com/PANTHEONtech/lighty/tree/13.4.x/lighty-core/lighty-controller))
    you need to mount the json/xml file as well:
    `-v /absolute/path/to/file/initData.xml:/lighty-rnc/initData.xml`
    , then your path to this file in configuration.json becomes just "./initData.xml":
@@ -134,7 +134,7 @@ To install, make sure that the docker image defined in `values.yaml` is accessib
 in `/lighty-rnc-app-helm/helm/` directory.
 ### Providing startup configuration
 By default, the deployed application is started with custom configuration.json 
-(for more information check [lighty-controller](https://github.com/PANTHEONtech/lighty/tree/13.3.x/lighty-core/lighty-controller)).
+(for more information check [lighty-controller](https://github.com/PANTHEONtech/lighty/tree/13.4.x/lighty-core/lighty-controller)).
 We supply this configuration file by passing kubernetes configmap (`configmaps.yaml`), which you can modify to your needs.
 To use the functionality of loading configuration data on startup, add new entry to configmaps.yaml:
 `initData: |

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/example-config/configuration.json
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/example-config/configuration.json
@@ -25,7 +25,7 @@
             "topLevelModels":[
                 { "nameSpace": "urn:opendaylight:params:xml:ns:yang:mdsal:core:general-entity", "name": "odl-general-entity", "revision": "2015-09-30" },
                 { "nameSpace": "urn:opendaylight:callhome:device-status", "name": "callhome-status", "revision": "2017-01-12" },
-                { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library", "name": "ietf-yang-library", "revision": "2016-04-09" },
+                { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library", "name": "ietf-yang-library", "revision": "2019-01-04" },
                 { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-restconf-monitoring", "name": "ietf-restconf-monitoring", "revision": "2017-01-26" },
                 { "nameSpace": "urn:opendaylight:params:xml:ns:yang:aaa", "name": "aaa", "revision": "2016-12-14" },
                 { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-types", "name": "ietf-yang-types", "revision": "2010-09-24" },
@@ -47,7 +47,7 @@
                 { "nameSpace": "urn:opendaylight:params:xml:ns:yang:controller:md:sal:dom:pingpong", "name": "opendaylight-pingpong-broker", "revision": "2014-11-07" },
                 { "nameSpace": "urn:sal:restconf:event:subscription", "name": "sal-remote-augment", "revision": "2014-07-08" },
                 { "nameSpace": "urn:opendaylight:params:xml:ns:yang:controller:netty", "name": "netty", "revision": "2013-11-19" },
-                { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library", "name": "ietf-yang-library", "revision": "2016-06-21" },
+                { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library", "name": "ietf-yang-library", "revision": "2019-01-04" },
                 { "nameSpace": "urn:ietf:params:xml:ns:yang:ospf-topology", "name": "ospf-topology", "revision": "2013-07-12" },
                 { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-netconf-notifications", "name": "ietf-netconf-notifications", "revision": "2012-02-06" },
                 { "nameSpace": "urn:opendaylight:netconf:keystore", "name": "netconf-keystore", "revision": "2017-10-17" },

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.applications.rnc</groupId>
     <artifactId>lighty-rnc-app-docker</artifactId>
-    <version>13.3.1-SNAPSHOT</version>
+    <version>13.4.0</version>
 
     <properties>
         <image.name>lighty-rnc</image.name>

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/configmaps.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/configmaps.yaml
@@ -32,7 +32,7 @@ data:
                 "topLevelModels":[
                     { "nameSpace": "urn:opendaylight:params:xml:ns:yang:mdsal:core:general-entity", "name": "odl-general-entity", "revision": "2015-09-30" },
                     { "nameSpace": "urn:opendaylight:callhome:device-status", "name": "callhome-status", "revision": "2017-01-12" },
-                    { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library", "name": "ietf-yang-library", "revision": "2016-04-09" },
+                    { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library", "name": "ietf-yang-library", "revision": "2019-01-04" },
                     { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-restconf-monitoring", "name": "ietf-restconf-monitoring", "revision": "2017-01-26" },
                     { "nameSpace": "urn:opendaylight:params:xml:ns:yang:aaa", "name": "aaa", "revision": "2016-12-14" },
                     { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-types", "name": "ietf-yang-types", "revision": "2010-09-24" },
@@ -54,7 +54,7 @@ data:
                     { "nameSpace": "urn:opendaylight:params:xml:ns:yang:controller:md:sal:dom:pingpong", "name": "opendaylight-pingpong-broker", "revision": "2014-11-07" },
                     { "nameSpace": "urn:sal:restconf:event:subscription", "name": "sal-remote-augment", "revision": "2014-07-08" },
                     { "nameSpace": "urn:opendaylight:params:xml:ns:yang:controller:netty", "name": "netty", "revision": "2013-11-19" },
-                    { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library", "name": "ietf-yang-library", "revision": "2016-06-21" },
+                    { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library", "name": "ietf-yang-library", "revision": "2019-01-04" },
                     { "nameSpace": "urn:ietf:params:xml:ns:yang:ospf-topology", "name": "ospf-topology", "revision": "2013-07-12" },
                     { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-netconf-notifications", "name": "ietf-netconf-notifications", "revision": "2012-02-06" },
                     { "nameSpace": "urn:opendaylight:netconf:keystore", "name": "netconf-keystore", "revision": "2017-10-17" },

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/config.json
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/config.json
@@ -21,7 +21,7 @@
             "topLevelModels":[
                 { "nameSpace": "urn:opendaylight:params:xml:ns:yang:mdsal:core:general-entity", "name": "odl-general-entity", "revision": "2015-09-30" },
                 { "nameSpace": "urn:opendaylight:callhome:device-status", "name": "callhome-status", "revision": "2017-01-12" },
-                { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library", "name": "ietf-yang-library", "revision": "2016-04-09" },
+                { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library", "name": "ietf-yang-library", "revision": "2019-01-04" },
                 { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-restconf-monitoring", "name": "ietf-restconf-monitoring", "revision": "2017-01-26" },
                 { "nameSpace": "urn:opendaylight:params:xml:ns:yang:aaa", "name": "aaa", "revision": "2016-12-14" },
                 { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-types", "name": "ietf-yang-types", "revision": "2010-09-24" },
@@ -43,7 +43,7 @@
                 { "nameSpace": "urn:opendaylight:params:xml:ns:yang:controller:md:sal:dom:pingpong", "name": "opendaylight-pingpong-broker", "revision": "2014-11-07" },
                 { "nameSpace": "urn:sal:restconf:event:subscription", "name": "sal-remote-augment", "revision": "2014-07-08" },
                 { "nameSpace": "urn:opendaylight:params:xml:ns:yang:controller:netty", "name": "netty", "revision": "2013-11-19" },
-                { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library", "name": "ietf-yang-library", "revision": "2016-06-21" },
+                { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library", "name": "ietf-yang-library", "revision": "2019-01-04" },
                 { "nameSpace": "urn:ietf:params:xml:ns:yang:ospf-topology", "name": "ospf-topology", "revision": "2013-07-12" },
                 { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-netconf-notifications", "name": "ietf-netconf-notifications", "revision": "2012-02-06" },
                 { "nameSpace": "urn:opendaylight:netconf:keystore", "name": "netconf-keystore", "revision": "2017-10-17" },

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
-                <version>7.0.10</version>
+                <version>7.0.11</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>controller-artifacts</artifactId>
-                <version>2.0.8</version>
+                <version>2.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -55,7 +55,7 @@
             <dependency>
                 <groupId>org.opendaylight.mdsal</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>6.0.10</version>
+                <version>6.0.11</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
-                <version>7.0.8</version>
+                <version>7.0.10</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -34,42 +34,42 @@
             <dependency>
                 <groupId>org.opendaylight.aaa</groupId>
                 <artifactId>aaa-artifacts</artifactId>
-                <version>0.12.3</version>
+                <version>0.12.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>controller-artifacts</artifactId>
-                <version>2.0.7</version>
+                <version>2.0.8</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.infrautils</groupId>
                 <artifactId>infrautils-artifacts</artifactId>
-                <version>1.8.3</version>
+                <version>1.8.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.mdsal</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>6.0.9</version>
+                <version>6.0.10</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>netconf-artifacts</artifactId>
-                <version>1.9.3</version>
+                <version>1.9.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yangtools-artifacts</artifactId>
-                <version>5.0.9</version>
+                <version>5.0.10</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -77,14 +77,14 @@
             <dependency>
                 <groupId>org.opendaylight.openflowplugin</groupId>
                 <artifactId>openflowplugin-artifacts</artifactId>
-                <version>0.11.3</version>
+                <version>0.11.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.serviceutils</groupId>
                 <artifactId>serviceutils-artifacts</artifactId>
-                <version>0.6.3</version>
+                <version>0.6.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -181,7 +181,7 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-        <tag>HEAD</tag>
+        <tag>13.4.0</tag>
     </scm>
     <developers>
         <developer>

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -54,12 +54,12 @@
             <plugin>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yang-maven-plugin</artifactId>
-                <version>5.0.9</version>
+                <version>5.0.10</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.opendaylight.mdsal</groupId>
                         <artifactId>maven-sal-api-gen-plugin</artifactId>
-                        <version>6.0.9</version>
+                        <version>6.0.10</version>
                         <type>jar</type>
                     </dependency>
                 </dependencies>

--- a/lighty-core/lighty-bom/pom.xml
+++ b/lighty-core/lighty-bom/pom.xml
@@ -163,7 +163,7 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-      <tag>HEAD</tag>
+      <tag>13.4.0</tag>
   </scm>
     <developers>
         <developer>

--- a/lighty-core/lighty-controller/README.md
+++ b/lighty-core/lighty-controller/README.md
@@ -116,7 +116,7 @@ or completely override it if required.
                 { "nameSpace": "urn:opendaylight:params:xml:ns:yang:controller:config:actor-system-provider:impl", "name": "actor-system-provider-impl", "revision": "2015-10-05" },
                 { "nameSpace": "urn:ietf:params:xml:ns:yang:ospf-topology", "name": "ospf-topology", "revision": "2013-07-12" },
                 { "nameSpace": "urn:opendaylight:params:xml:ns:yang:controller:config:distributed-datastore-provider", "name": "distributed-datastore-provider", "revision": "2014-06-12" },
-                { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library", "name": "ietf-yang-library", "revision": "2016-06-21" },
+                { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library", "name": "ietf-yang-library", "revision": "2019-01-04" },
                 { "nameSpace": "urn:TBD:params:xml:ns:yang:network:isis-topology", "name": "isis-topology", "revision": "2013-10-21" },
                 { "nameSpace": "urn:opendaylight:params:xml:ns:yang:controller:inmemory-datastore-provider", "name": "opendaylight-inmemory-datastore-provider", "revision": "2014-06-17" },
                 { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-restconf", "name": "ietf-restconf", "revision": "2013-10-19" },

--- a/lighty-core/lighty-controller/README.md
+++ b/lighty-core/lighty-controller/README.md
@@ -17,7 +17,7 @@ To use Lighty controller in your project:
   <dependency>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-controller</artifactId>
-    <version>13.3.1-SNAPSHOT</version>
+    <version>13.4.0</version>
   </dependency>
 ```
 

--- a/lighty-core/lighty-minimal-parent/pom.xml
+++ b/lighty-core/lighty-minimal-parent/pom.xml
@@ -103,7 +103,7 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-      <tag>HEAD</tag>
+      <tag>13.4.0</tag>
   </scm>
     <developers>
         <developer>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -174,7 +174,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>7.0.8</version>
+                            <version>7.0.10</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -191,7 +191,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>spotbugs</artifactId>
-                            <version>7.0.8</version>
+                            <version>7.0.10</version>
                         </dependency>
                         <dependency>
                             <!-- The SpotBugs Maven plugin uses SLF4J 1.8 beta 2 -->

--- a/lighty-examples/README.md
+++ b/lighty-examples/README.md
@@ -17,7 +17,7 @@ ODL core services represent MD-SAL layer, controller, DataStore, global schema c
    <dependency>
       <groupId>io.lighty.core.parents</groupId>
       <artifactId>lighty-dependency-artifacts</artifactId>
-      <version>13.3.1-SNAPSHOT</version>
+      <version>13.4.0</version>
       <type>pom</type>
       <scope>import</scope>
    </dependency>

--- a/lighty-examples/lighty-cluster-app/Dockerfile.k8s
+++ b/lighty-examples/lighty-cluster-app/Dockerfile.k8s
@@ -1,9 +1,9 @@
 FROM openjdk:11-jre-slim
 
-COPY target/lighty-cluster-app-13.3.1-SNAPSHOT-bin.zip /
+COPY target/lighty-cluster-app-13.4.0-bin.zip /
 
 RUN apt-get update && apt-get install unzip \
-    && unzip /lighty-cluster-app-13.3.1-SNAPSHOT-bin.zip \
-    && rm /lighty-cluster-app-13.3.1-SNAPSHOT-bin.zip
+    && unzip /lighty-cluster-app-13.4.0-bin.zip \
+    && rm /lighty-cluster-app-13.4.0-bin.zip
 
-ENTRYPOINT ["/lighty-cluster-app-13.3.1-SNAPSHOT/start-controller-node-k8s.sh"]
+ENTRYPOINT ["/lighty-cluster-app-13.4.0/start-controller-node-k8s.sh"]

--- a/lighty-examples/lighty-cluster-app/src/main/assembly/resources/start-controller-node-k8s.sh
+++ b/lighty-examples/lighty-cluster-app/src/main/assembly/resources/start-controller-node-k8s.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 #start controller
-cd /lighty-cluster-app-13.3.1-SNAPSHOT
-java -ms128m -mx128m -XX:MaxMetaspaceSize=128m -jar lighty-cluster-app-13.3.1-SNAPSHOT.jar -n 0 -k
+cd /lighty-cluster-app-13.4.0
+java -ms128m -mx128m -XX:MaxMetaspaceSize=128m -jar lighty-cluster-app-13.4.0.jar -n 0 -k

--- a/lighty-examples/lighty-community-aaa-restconf-app/src/main/assembly/resources/sampleConfigSingleNode.json
+++ b/lighty-examples/lighty-community-aaa-restconf-app/src/main/assembly/resources/sampleConfigSingleNode.json
@@ -33,7 +33,7 @@
                 { "nameSpace":"urn:ietf:params:xml:ns:yang:ietf-lisp-address-types","name":"ietf-lisp-address-types","revision":"2015-11-05"},
                 { "nameSpace":"urn:ietf:params:xml:ns:yang:ietf-restconf-monitoring","name":"ietf-restconf-monitoring","revision":"2017-01-26"},
                 { "nameSpace":"urn:ietf:params:xml:ns:yang:ietf-restconf","name":"ietf-restconf","revision":"2017-01-26"},
-                { "nameSpace":"urn:ietf:params:xml:ns:yang:ietf-yang-library","name":"ietf-yang-library","revision":"2016-06-21"},
+                { "nameSpace":"urn:ietf:params:xml:ns:yang:ietf-yang-library","name":"ietf-yang-library","revision":"2019-01-04"},
                 { "nameSpace":"urn:opendaylight:params:xml:ns:yang:controller:md:sal:remote","name": "sal-remote","revision":"2014-01-14"},
                 { "nameSpace":"urn:sal:restconf:event:subscription","name": "sal-remote-augment","revision":"2014-07-08"},
                 { "nameSpace":"subscribe:to:notification","name": "subscribe-to-notification","revision":"2016-10-28"},

--- a/lighty-examples/lighty-community-netconf-quarkus-app/README.md
+++ b/lighty-examples/lighty-community-netconf-quarkus-app/README.md
@@ -30,7 +30,7 @@ mvn clean compile quarkus:dev
 ## Build package & Run
 ```
 mvn clean package
-java -Xms128m -Xmx128m -XX:MaxMetaspaceSize=128m -jar target/lighty-quarkus-netconf-app-13.3.1-SNAPSHOT-runner.jar
+java -Xms128m -Xmx128m -XX:MaxMetaspaceSize=128m -jar target/lighty-quarkus-netconf-app-13.4.0-runner.jar
 ```
 
 ## Build native image

--- a/lighty-examples/lighty-community-netconf-quarkus-app/pom.xml
+++ b/lighty-examples/lighty-community-netconf-quarkus-app/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.lighty.quarkus</groupId>
   <artifactId>lighty-quarkus-netconf-app</artifactId>
-  <version>13.3.1-SNAPSHOT</version>
+  <version>13.4.0</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -15,7 +15,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
     <application.attach.zip>true</application.attach.zip>
-    <lighty.version>13.3.1-SNAPSHOT</lighty.version>
+    <lighty.version>13.4.0</lighty.version>
   </properties>
 
   <dependencyManagement>

--- a/lighty-examples/lighty-community-restconf-netconf-app/README.md
+++ b/lighty-examples/lighty-community-restconf-netconf-app/README.md
@@ -21,12 +21,12 @@ build the project: ```mvn clean install```
 ### Start this demo example
 * build the project using ```mvn clean install```
 * go to target directory ```cd lighty-examples/lighty-community-restconf-netconf-app/target``` 
-* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-13.3.1-SNAPSHOT-bin.zip```
-* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-13.3.1-SNAPSHOT```
-* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-13.3.1-SNAPSHOT.jar``` 
+* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-13.4.0-bin.zip```
+* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-13.4.0```
+* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-13.4.0.jar``` 
 
 ### Test example application
-Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-13.3.1-SNAPSHOT.jar``` 
+Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-13.4.0.jar``` 
 RESTCONF web interface is available at URL ```http://localhost:8888/restconf/*```
 
 ##### URLs to start with
@@ -43,7 +43,7 @@ URLs for Swagger (choose RESTCONF [draft18](https://tools.ietf.org/html/draft-ie
 
 ### Use custom config files
 There are two separated config files: for NETCONF SBP single node and for cluster.
-`java -jar lighty-community-restconf-netconf-app-13.3.1-SNAPSHOT.jar /path/to/singleNodeConfig.json`
+`java -jar lighty-community-restconf-netconf-app-13.4.0.jar /path/to/singleNodeConfig.json`
 
 Example configuration for single node is [here](src/main/assembly/resources/sampleConfigSingleNode.json)
 

--- a/lighty-examples/lighty-community-restconf-netconf-app/src/main/assembly/resources/sampleConfigSingleNode.json
+++ b/lighty-examples/lighty-community-restconf-netconf-app/src/main/assembly/resources/sampleConfigSingleNode.json
@@ -34,7 +34,7 @@
                 { "nameSpace":"urn:opendaylight:params:xml:ns:yang:controller:md:sal:clustering:entity-owners","name":"entity-owners","revision":"2015-08-04"},
                 { "nameSpace":"urn:opendaylight:params:xml:ns:yang:controller:md:sal:clustering:prefix-shard-configuration","name":"prefix-shard-configuration","revision":"2017-01-10"},
                 { "nameSpace":"urn:opendaylight:params:xml:ns:yang:controller:md:sal:cluster:admin","name":"cluster-admin","revision":"2015-10-13"},
-                { "nameSpace":"urn:ietf:params:xml:ns:yang:ietf-yang-library","name":"ietf-yang-library","revision":"2016-06-21"},
+                { "nameSpace":"urn:ietf:params:xml:ns:yang:ietf-yang-library","name":"ietf-yang-library","revision":"2019-01-04"},
                 { "nameSpace":"urn:ietf:params:xml:ns:yang:ietf-restconf","name":"ietf-restconf","revision":"2017-01-26"},
                 { "nameSpace":"urn:ietf:params:xml:ns:yang:ietf-restconf-monitoring","name":"ietf-restconf-monitoring","revision":"2017-01-26"},
                 { "nameSpace":"urn:opendaylight:params:xml:ns:yang:controller:md:sal:remote","name": "sal-remote","revision":"2014-01-14"},

--- a/lighty-examples/lighty-community-restconf-ofp-app/Dockerfile
+++ b/lighty-examples/lighty-community-restconf-ofp-app/Dockerfile
@@ -1,16 +1,16 @@
 FROM openjdk:11-jre-slim
 
-COPY ./target/lighty-community-restconf-ofp-app-13.3.1-SNAPSHOT-bin.zip /
+COPY ./target/lighty-community-restconf-ofp-app-13.4.0-bin.zip /
 
 RUN apt-get update && apt-get install unzip \
-    && unzip /lighty-community-restconf-ofp-app-13.3.1-SNAPSHOT-bin.zip \
-    && rm /lighty-community-restconf-ofp-app-13.3.1-SNAPSHOT-bin.zip
+    && unzip /lighty-community-restconf-ofp-app-13.4.0-bin.zip \
+    && rm /lighty-community-restconf-ofp-app-13.4.0-bin.zip
 
 ##libstdc++ is required by leveldbjni-1.8 (Akka dispatcher)
 #Uncaught error from thread [opendaylight-cluster-data-akka.persistence.dispatchers.default-plugin-dispatcher-22]: Could not load library. Reasons: [no leveldbjni64-1.8 in java.library.path, no leveldbjni-1.8 in java.library.path, no leveldbjni in java.library.path, /tmp/libleveldbjni-64-1-3166161234556196376.8: Error loading shared library libstdc++.so.6: No such file or directory (needed by /tmp/libleveldbjni-64-1-3166161234556196376.8)], shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled for ActorSystem[opendaylight-cluster-data]
 RUN apt-get install libstdc++6
 
-WORKDIR /lighty-community-restconf-ofp-app-13.3.1-SNAPSHOT
+WORKDIR /lighty-community-restconf-ofp-app-13.4.0
 
 EXPOSE 8888
 EXPOSE 8185
@@ -19,4 +19,4 @@ EXPOSE 6653
 EXPOSE 2550
 EXPOSE 80
 
-CMD java -jar lighty-community-restconf-ofp-app-13.3.1-SNAPSHOT.jar sampleConfigSingleNode.json
+CMD java -jar lighty-community-restconf-ofp-app-13.4.0.jar sampleConfigSingleNode.json

--- a/lighty-examples/lighty-community-restconf-ofp-app/README.md
+++ b/lighty-examples/lighty-community-restconf-ofp-app/README.md
@@ -12,7 +12,7 @@ Build the project using maven command: ```mvn clean install```.
 This will create *.zip* archive in target directory. Extract this archive
 and run *.jar* file using java with command:
 ```
-java -jar lighty-community-restconf-ofp-app-13.3.1-SNAPSHOT.jar
+java -jar lighty-community-restconf-ofp-app-13.4.0.jar
 ```
 
 ### Use custom config files
@@ -24,7 +24,7 @@ after build.
 
 When running application pass path to configuration file as argument:
 ```
-java -jar lighty-community-restconf-ofp-app-13.3.1-SNAPSHOT.jar sampleConfigSingleNode.json
+java -jar lighty-community-restconf-ofp-app-13.4.0.jar sampleConfigSingleNode.json
 ```
 
 ### Building and running Docker Image

--- a/lighty-examples/lighty-community-restconf-ofp-app/src/main/assembly/resources/sampleConfigSingleNode.json
+++ b/lighty-examples/lighty-community-restconf-ofp-app/src/main/assembly/resources/sampleConfigSingleNode.json
@@ -103,7 +103,7 @@
         { "nameSpace":"urn:opendaylight:params:xml:ns:yang:controller:md:sal:clustering:entity-owners", "name":"entity-owners","revision":"2015-08-04"},
         { "nameSpace":"urn:opendaylight:params:xml:ns:yang:controller:md:sal:clustering:prefix-shard-configuration", "name":"prefix-shard-configuration","revision":"2017-01-10"},
         { "nameSpace":"urn:opendaylight:params:xml:ns:yang:controller:md:sal:cluster:admin", "name":"cluster-admin","revision":"2015-10-13"},
-        { "nameSpace":"urn:ietf:params:xml:ns:yang:ietf-yang-library", "name":"ietf-yang-library","revision":"2016-06-21"},
+        { "nameSpace":"urn:ietf:params:xml:ns:yang:ietf-yang-library", "name":"ietf-yang-library","revision":"2019-01-04"},
         { "nameSpace":"urn:ietf:params:xml:ns:yang:ietf-restconf", "name":"ietf-restconf","revision":"2017-01-26"},
         { "nameSpace":"urn:ietf:params:xml:ns:yang:ietf-restconf-monitoring", "name":"ietf-restconf-monitoring","revision":"2017-01-26"},
         { "nameSpace":"urn:opendaylight:params:xml:ns:yang:controller:md:sal:remote", "name": "sal-remote","revision":"2014-01-14"},

--- a/lighty-examples/lighty-controller-springboot-netconf/README.md
+++ b/lighty-examples/lighty-controller-springboot-netconf/README.md
@@ -46,7 +46,7 @@ mvn spring-boot:run
 or
 
 ```
-java -jar target/lighty-controller-springboot-13.3.1-SNAPSHOT.jar
+java -jar target/lighty-controller-springboot-13.4.0.jar
 ```
 
 or in any IDE, run main in 

--- a/lighty-models/README.md
+++ b/lighty-models/README.md
@@ -56,7 +56,7 @@ my-model/pom.xml
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>13.3.1-SNAPSHOT</version>
+        <version>13.4.0</version>
         <relativePath/>
     </parent>
 

--- a/lighty-modules/lighty-netconf-sb/README.md
+++ b/lighty-modules/lighty-netconf-sb/README.md
@@ -42,7 +42,7 @@ To use NETCONF in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-netconf-sb</artifactId>
-    <version>13.3.1-SNAPSHOT</version>
+    <version>13.4.0</version>
   </dependency>  
 ```
 2. Initialize and start an instance of NETCONF SBP in your code:

--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/util/NetconfConfigUtils.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/util/NetconfConfigUtils.java
@@ -58,7 +58,7 @@ public final class NetconfConfigUtils {
                     .$YangModuleInfoImpl.getInstance(),
             org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.netconf.monitoring.extension.rev131210
                     .$YangModuleInfoImpl.getInstance(),
-            org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.yang.library.rev160621
+            org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.yang.library.rev190104
                     .$YangModuleInfoImpl.getInstance()
     );
     public static final Set<YangModuleInfo> NETCONF_CALLHOME_MODELS = ImmutableSet.of(

--- a/lighty-modules/lighty-openflow-sb/README.md
+++ b/lighty-modules/lighty-openflow-sb/README.md
@@ -10,7 +10,7 @@ is Lighty's version of openflow plugin.
 <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-openflow-sb</artifactId>
-    <version>13.3.1-SNAPSHOT</version>
+    <version>13.4.0</version>
 </dependency>
 ```
 

--- a/lighty-modules/lighty-restconf-nb-community/README.md
+++ b/lighty-modules/lighty-restconf-nb-community/README.md
@@ -12,7 +12,7 @@ To use RESTCONF in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-restconf-nb-community</artifactId>
-    <version>13.3.1-SNAPSHOT</version>
+    <version>13.4.0</version>
   </dependency>
 ```
 

--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
@@ -28,7 +28,7 @@ public final class RestConfConfigUtils {
 
     public static final String RESTCONF_CONFIG_ROOT_ELEMENT_NAME = "restconf";
     public static final Set<YangModuleInfo> YANG_MODELS = ImmutableSet.of(
-            org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.yang.library.rev160621
+            org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.yang.library.rev190104
                     .$YangModuleInfoImpl.getInstance(),
             org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.restconf.rev170126
                     .$YangModuleInfoImpl.getInstance(),

--- a/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyTest.java
+++ b/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyTest.java
@@ -22,7 +22,7 @@ import org.testng.Assert;
 public abstract class SwaggerLightyTest extends SwaggerLightyTestBase {
 
     protected static final String DEFAULT_MODEL_NAME = "ietf-yang-library";
-    protected static final String DEFAULT_REVISION_DATE = "2016-06-21";
+    protected static final String DEFAULT_REVISION_DATE = "2019-01-04";
 
     protected SwaggerLightyTest(JsonRestConfServiceType restConfServiceType) {
         super(restConfServiceType);

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-        <tag>13.3.0</tag>
+        <tag>13.4.0</tag>
     </scm>
     <developers>
         <developer>


### PR DESCRIPTION
Update upstream dependencies to Aluminium SR4 release versions:
- odlparent 7.0.11
- aaa-artifacts 0.12.4
- controller-artifacts 2.0.9
- infrautils-artifacts 1.8.4
- mdsal-artifacts 6.0.11
- netconf-artifacts 1.9.4
- yangtools-artifacts 5.0.10
- openflowplugin-artifacts 0.11.4
- serviceutils-artifacts 0.6.4
- yang-maven-plugin 5.0.10
- maven-sal-api-gen-plugin 6.0.10
- checkstyle 7.0.10
- spotbugs 7.0.10

Release notes:
- Refactor JsonNodeConverter to use parameterized JSONCodecFactorySupplier

