### PR TITLE
Update deploy config for lighty-gnmi-models

### DIFF
--- a/lighty-models/lighty-gnmi-models/pom.xml
+++ b/lighty-models/lighty-gnmi-models/pom.xml
@@ -18,7 +18,6 @@
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty</url>
     <description>
         The artifact contains models for lighty.io gNMI southbound module.
     </description>
@@ -35,56 +34,4 @@
         <module>lighty-gnmi-force-capabilities</module>
         <module>lighty-gnoi-sonic-yang-model</module>
     </modules>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                    <tagNameFormat>@{project.version}</tagNameFormat>
-                    <useReleaseProfile>false</useReleaseProfile>
-                    <releaseProfiles>release</releaseProfiles>
-                    <preparationGoals>clean install</preparationGoals>
-                    <localCheckout>true</localCheckout>
-                    <pushChanges>false</pushChanges>
-                    <goals>deploy</goals>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
-    <licenses>
-        <license>
-            <name>Eclipse Public License 1.0</name>
-            <url>https://www.eclipse.org/legal/epl-v10.html</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-    <scm>
-        <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
-        <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
-        <url>https://github.com/PANTHEONtech/lighty</url>
-        <tag>14.1.0</tag>
-    </scm>
-    <developers>
-        <developer>
-            <id>rovarga</id>
-            <name>Robert Varga</name>
-            <email>robert.varga@pantheon.tech</email>
-            <organization>PANTHEON.tech s.r.o.</organization>
-            <organizationUrl>https://www.pantheon.tech</organizationUrl>
-        </developer>
-    </developers>
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 </project>

--- a/lighty-models/lighty-gnmi-models/pom.xml
+++ b/lighty-models/lighty-gnmi-models/pom.xml
@@ -17,6 +17,17 @@
     <version>15.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+    <url>https://github.com/PANTHEONtech/lighty</url>
+    <description>
+        The artifact contains models for lighty.io gNMI southbound module.
+    </description>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
+    </properties>
+
     <modules>
         <module>lighty-gnmi-topology-model</module>
         <module>lighty-gnmi-yang-storage-model</module>
@@ -25,4 +36,55 @@
         <module>lighty-gnoi-sonic-yang-model</module>
     </modules>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <tagNameFormat>@{project.version}</tagNameFormat>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <releaseProfiles>release</releaseProfiles>
+                    <preparationGoals>clean install</preparationGoals>
+                    <localCheckout>true</localCheckout>
+                    <pushChanges>false</pushChanges>
+                    <goals>deploy</goals>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <licenses>
+        <license>
+            <name>Eclipse Public License 1.0</name>
+            <url>https://www.eclipse.org/legal/epl-v10.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <scm>
+        <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
+        <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
+        <url>https://github.com/PANTHEONtech/lighty</url>
+        <tag>14.1.0</tag>
+    </scm>
+    <developers>
+        <developer>
+            <id>rovarga</id>
+            <name>Robert Varga</name>
+            <email>robert.varga@pantheon.tech</email>
+            <organization>PANTHEON.tech s.r.o.</organization>
+            <organizationUrl>https://www.pantheon.tech</organizationUrl>
+        </developer>
+    </developers>
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 </project>


### PR DESCRIPTION
cherry-picks #799 and clean the unnecessary metadata for `lighty-gnmi-models` aggregator artifact, all deploy-able submodules inherit necessary metadata from parents