### PR TITLE
Minimize metadata for lighty-gnmi-models aggregator

### DIFF
--- a/lighty-models/lighty-gnmi-models/pom.xml
+++ b/lighty-models/lighty-gnmi-models/pom.xml
@@ -16,7 +16,6 @@
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
-    <url>https://github.com/PANTHEONtech/lighty</url>
     <description>
         The artifact contains models for lighty.io gNMI southbound module.
     </description>
@@ -33,56 +32,4 @@
         <module>lighty-gnoi-sonic-yang-model</module>
         <module>lighty-gnmi-force-capabilities</module>
     </modules>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                    <tagNameFormat>@{project.version}</tagNameFormat>
-                    <useReleaseProfile>false</useReleaseProfile>
-                    <releaseProfiles>release</releaseProfiles>
-                    <preparationGoals>clean install</preparationGoals>
-                    <localCheckout>true</localCheckout>
-                    <pushChanges>false</pushChanges>
-                    <goals>deploy</goals>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
-    <licenses>
-        <license>
-            <name>Eclipse Public License 1.0</name>
-            <url>https://www.eclipse.org/legal/epl-v10.html</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-    <scm>
-        <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
-        <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
-        <url>https://github.com/PANTHEONtech/lighty</url>
-        <tag>HEAD</tag>
-    </scm>
-    <developers>
-        <developer>
-            <id>rovarga</id>
-            <name>Robert Varga</name>
-            <email>robert.varga@pantheon.tech</email>
-            <organization>PANTHEON.tech s.r.o.</organization>
-            <organizationUrl>https://www.pantheon.tech</organizationUrl>
-        </developer>
-    </developers>
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 </project>


### PR DESCRIPTION
(cherry picked from commit 2ada02be8dd4955fcffb67a201a296a470a72b47)

extends #799 (targets to `14.1.x` branch) by cherry-picking second commit of #800 (2ada02be8dd4955fcffb67a201a296a470a72b47) (targets to `master` branch), 
which makes all the `14.1.x` and `master` branches contain same changes, regarding deployment metadata for gNMI models