### PR TITLE
Fix occasional gNMI test failure - master

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/GnmiWithoutRestconfTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/GnmiWithoutRestconfTest.java
@@ -202,29 +202,6 @@ public class GnmiWithoutRestconfTest {
     }
 
     @Test
-    public void testMultipleCrudOperation() throws ExecutionException, InterruptedException, TimeoutException,
-            InvalidAlgorithmParameterException, ConfigurationException, NoSuchPaddingException, IOException,
-            NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
-        testCrudOperation();
-        tearDown();
-        for (int i = 0; i < 50; i++) {
-            try {
-                startUp();
-                testCrudOperation();
-            } catch (InvalidAlgorithmParameterException | ConfigurationException | NoSuchPaddingException
-                    | IOException | NoSuchAlgorithmException | InvalidKeySpecException | ExecutionException
-                    | InvalidKeyException | InterruptedException | TimeoutException e) {
-                Assertions.fail(e);
-
-            } finally {
-                tearDown();
-            }
-        }
-        startUp();
-        testCrudOperation();
-    }
-
-    @Test
     public void testCrudOperation() throws ExecutionException, InterruptedException, TimeoutException {
         final DataBroker bindingDataBroker = lightyController.getServices().getBindingDataBroker();
         //Write device to data-store

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/GnmiWithoutRestconfTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/GnmiWithoutRestconfTest.java
@@ -287,7 +287,7 @@ public class GnmiWithoutRestconfTest {
         } catch (ExecutionException | InterruptedException e) {
             Assertions.fail("Failed to remove device data from gNMI", e);
         }
-
+        //Verify that device is already removed from data store
         Awaitility.waitAtMost(WAIT_TIME_DURATION)
                 .pollInterval(POLL_INTERVAL_DURATION)
                 .untilAsserted(() -> {

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/GnmiWithoutRestconfTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/GnmiWithoutRestconfTest.java
@@ -202,6 +202,29 @@ public class GnmiWithoutRestconfTest {
     }
 
     @Test
+    public void testMultipleCrudOperation() throws ExecutionException, InterruptedException, TimeoutException,
+            InvalidAlgorithmParameterException, ConfigurationException, NoSuchPaddingException, IOException,
+            NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException {
+        testCrudOperation();
+        tearDown();
+        for (int i = 0; i < 50; i++) {
+            try {
+                startUp();
+                testCrudOperation();
+            } catch (InvalidAlgorithmParameterException | ConfigurationException | NoSuchPaddingException
+                    | IOException | NoSuchAlgorithmException | InvalidKeySpecException | ExecutionException
+                    | InvalidKeyException | InterruptedException | TimeoutException e) {
+                Assertions.fail(e);
+
+            } finally {
+                tearDown();
+            }
+        }
+        startUp();
+        testCrudOperation();
+    }
+
+    @Test
     public void testCrudOperation() throws ExecutionException, InterruptedException, TimeoutException {
         final DataBroker bindingDataBroker = lightyController.getServices().getBindingDataBroker();
         //Write device to data-store

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/GnmiWithoutRestconfTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/GnmiWithoutRestconfTest.java
@@ -310,6 +310,13 @@ public class GnmiWithoutRestconfTest {
         } catch (ExecutionException | InterruptedException e) {
             Assertions.fail("Failed to remove device data from gNMI", e);
         }
+
+        Awaitility.waitAtMost(WAIT_TIME_DURATION)
+                .pollInterval(POLL_INTERVAL_DURATION)
+                .untilAsserted(() -> {
+                    final Optional<Node> node = readOperData(bindingDataBroker, nodeInstanceIdentifier);
+                    assertFalse(node.isPresent());
+                });
     }
 
     @Test


### PR DESCRIPTION
Occasional test failure on gNMI test:
https://github.com/PANTHEONtech/lighty/pull/797/checks?check_run_id=3341838196#step:8:2854

Sometimes device is still present in data store even after operation 'writeTransaction.delete(...).commit().get(...)'
is executed. When there is still delete process running, it can prevent to close ActorSystemProvider
in lighty controller.

Signed-off-by: Peter Suna <peter.suna@pantheon.tech>