### PR TITLE
Fix critical code smell reported by SonnarCloud - 14.2.x (cherry-pick #818)

### DIFF
--- a/lighty-core/lighty-common/src/main/java/io/lighty/core/common/models/YangModuleUtils.java
+++ b/lighty-core/lighty-common/src/main/java/io/lighty/core/common/models/YangModuleUtils.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 public final class YangModuleUtils {
     private static final Logger LOG = LoggerFactory.getLogger(YangModuleUtils.class);
+    private static final String ADDING_MODULE_INTO_KNOWN_MODULES = "Adding [{}] module into known modules";
 
     private YangModuleUtils() {
         throw new UnsupportedOperationException("do not instantiate utility class");
@@ -39,7 +40,7 @@ public final class YangModuleUtils {
         ServiceLoader<YangModelBindingProvider> yangProviderLoader = ServiceLoader.load(YangModelBindingProvider.class);
         for (YangModelBindingProvider yangModelBindingProvider : yangProviderLoader) {
             moduleInfos.add(yangModelBindingProvider.getModuleInfo());
-            LOG.info("Adding [{}] module into known modules", yangModelBindingProvider.getModuleInfo());
+            LOG.info(ADDING_MODULE_INTO_KNOWN_MODULES, yangModelBindingProvider.getModuleInfo());
         }
         return Collections.unmodifiableSet(moduleInfos);
     }
@@ -91,7 +92,7 @@ public final class YangModuleUtils {
             Set<YangModuleInfo> filteredSet = filterYangModelBindingProviders(moduleId, yangProviderLoader);
             for (YangModuleInfo yangModuleInfo : filteredSet) {
                 resolvedModules.put(ModuleId.from(yangModuleInfo), yangModuleInfo);
-                LOG.info("Adding [{}] module into known modules", yangModuleInfo);
+                LOG.info(ADDING_MODULE_INTO_KNOWN_MODULES, yangModuleInfo);
                 addDependencies(resolvedModules, yangModuleInfo.getImportedModules());
             }
         }
@@ -103,7 +104,7 @@ public final class YangModuleUtils {
             final Collection<YangModuleInfo> importedModules) {
         for (YangModuleInfo yangModuleInfo : importedModules) {
             resolvedModules.put(ModuleId.from(yangModuleInfo), yangModuleInfo);
-            LOG.info("Adding [{}] module into known modules", yangModuleInfo);
+            LOG.info(ADDING_MODULE_INTO_KNOWN_MODULES, yangModuleInfo);
             addDependencies(resolvedModules, yangModuleInfo.getImportedModules());
         }
     }

--- a/lighty-core/lighty-common/src/main/java/io/lighty/core/common/models/YangModulesTool.java
+++ b/lighty-core/lighty-common/src/main/java/io/lighty/core/common/models/YangModulesTool.java
@@ -17,8 +17,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class YangModulesTool {
+
     private static final Logger LOG = LoggerFactory.getLogger(YangModulesTool.class);
     private static final int PREFIX = 2;
+    private static final String TOP_LEVEL_MODELS_LIST = "# top-level models list: {}";
+    private static final String TOP_LEVEL_MODELS_TREE = "# top-level models tree: {}";
+    private static final String UNIQUE_MODELS_LIST = "# unique models list   : {}";
 
     private YangModulesTool() {
 
@@ -33,35 +37,37 @@ public final class YangModulesTool {
     public static void printModelInfo(final Set<YangModuleInfo> allModelsFromClasspath) {
         final int prefixLength = 0;
         final Set<YangModuleInfo> topLevelModels = YangModuleUtils.filterTopLevelModels(allModelsFromClasspath);
-        LOG.info("# top-level models tree: {}", topLevelModels.size());
+        LOG.info(TOP_LEVEL_MODELS_TREE, topLevelModels.size());
         for (final YangModuleInfo yangModuleInfo : topLevelModels) {
-            final QName qname = yangModuleInfo.getName();
-            LOG.info("{} {} {}", qname.getNamespace(), qname.getLocalName(), qname.getRevision());
+            logQNameInfo(yangModuleInfo.getName());
             printDependencies(yangModuleInfo.getImportedModules(), prefixLength + PREFIX);
         }
-        LOG.info("# top-level models list: {}", topLevelModels.size());
+        LOG.info(TOP_LEVEL_MODELS_LIST, topLevelModels.size());
         for (final YangModuleInfo yangModuleInfo : topLevelModels) {
-            final QName qname = yangModuleInfo.getName();
-            LOG.info("{} {} {}", qname.getNamespace(), qname.getLocalName(), qname.getRevision());
+            logQNameInfo(yangModuleInfo.getName());
         }
         final Set<YangModuleInfo> uniqueModels = YangModuleUtils.filterUniqueModels(allModelsFromClasspath);
-        LOG.info("# unique models list   : {}", uniqueModels.size());
+        LOG.info(UNIQUE_MODELS_LIST, uniqueModels.size());
         for (final YangModuleInfo yangModuleInfo : uniqueModels) {
-            final QName qname = yangModuleInfo.getName();
-            LOG.info("{} {} {}", qname.getNamespace(), qname.getLocalName(), qname.getRevision());
+            logQNameInfo(yangModuleInfo.getName());
         }
+    }
+
+    private static void logQNameInfo(QName qname) {
+        LOG.info("namespace: {}, localName: {}, revision {}", qname.getNamespace(), qname.getLocalName(),
+                qname.getRevision());
     }
 
     @SuppressWarnings("checkstyle:regexpSinglelineJava")
     public static void printConfiguration(final Set<YangModuleInfo> allModelsFromClasspath) {
         final Set<YangModuleInfo> topLevelModels = YangModuleUtils.filterTopLevelModels(allModelsFromClasspath);
-        LOG.info("# top-level models list: {}", topLevelModels.size());
+        LOG.info(TOP_LEVEL_MODELS_LIST, topLevelModels.size());
         for (final YangModuleInfo yangModuleInfo : topLevelModels) {
             final QName qname = yangModuleInfo.getName();
             System.out.println("{ \"nameSpace\": \"" + qname.getNamespace() + "\", \"name\": \""
                     + qname.getLocalName() + "\", \"revision\": \"" + qname.getRevision().orElse(null) + "\" },");
         }
-        LOG.info("# top-level models list: {}", topLevelModels.size());
+        LOG.info(TOP_LEVEL_MODELS_LIST, topLevelModels.size());
         for (final YangModuleInfo yangModuleInfo: topLevelModels) {
             System.out.println(yangModuleInfo.getClass().getCanonicalName() + ".getInstance(),");
         }

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/LightyServices.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/LightyServices.java
@@ -28,7 +28,7 @@ import org.opendaylight.mdsal.binding.api.MountPointService;
 import org.opendaylight.mdsal.binding.api.NotificationPublishService;
 import org.opendaylight.mdsal.binding.api.NotificationService;
 import org.opendaylight.mdsal.binding.api.RpcProviderService;
-import org.opendaylight.mdsal.binding.dom.adapter.AdapterContext;
+import org.opendaylight.mdsal.binding.dom.adapter.ConstantAdapterContext;
 import org.opendaylight.mdsal.binding.dom.codec.api.BindingCodecTreeFactory;
 import org.opendaylight.mdsal.binding.dom.codec.api.BindingNormalizedNodeSerializer;
 import org.opendaylight.mdsal.dom.api.DOMActionProviderService;
@@ -155,7 +155,7 @@ public interface LightyServices extends LightyModuleRegistryService {
 
     CacheProvider getCacheProvider();
 
-    AdapterContext getAdapterContext();
+    ConstantAdapterContext getAdapterContext();
 
     ActionProviderService getActionProviderService();
 

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerBuilder.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerBuilder.java
@@ -22,9 +22,6 @@ public class LightyControllerBuilder {
     private ControllerConfiguration controllerConfiguration = null;
     private ExecutorService executorService = null;
 
-    public LightyControllerBuilder() {
-    }
-
     /**
      * Create new instance of {@link LightyControllerBuilder} from {@link ControllerConfiguration}.
      *

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
@@ -88,9 +88,7 @@ import org.opendaylight.mdsal.binding.api.MountPointService;
 import org.opendaylight.mdsal.binding.api.NotificationPublishService;
 import org.opendaylight.mdsal.binding.api.NotificationService;
 import org.opendaylight.mdsal.binding.api.RpcProviderService;
-import org.opendaylight.mdsal.binding.dom.adapter.AdapterContext;
 import org.opendaylight.mdsal.binding.dom.adapter.BindingAdapterFactory;
-import org.opendaylight.mdsal.binding.dom.adapter.BindingDOMDataBrokerAdapter;
 import org.opendaylight.mdsal.binding.dom.adapter.BindingDOMMountPointServiceAdapter;
 import org.opendaylight.mdsal.binding.dom.adapter.BindingDOMNotificationPublishServiceAdapter;
 import org.opendaylight.mdsal.binding.dom.adapter.BindingDOMNotificationServiceAdapter;
@@ -185,7 +183,7 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
     private DOMClusterSingletonServiceProviderImpl clusterSingletonServiceProvider;
     private NotificationService notificationService;
     private NotificationPublishService notificationPublishService;
-    private BindingDOMDataBrokerAdapter domDataBroker;
+    private DataBroker dataBroker;
     private final LightyDiagStatusServiceImpl lightyDiagStatusService;
     private EventExecutor eventExecutor;
     private EventLoopGroup bossGroup;
@@ -196,7 +194,7 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
     private ModuleInfoSnapshot moduleInfoSnapshot;
     private ModuleInfoSnapshotResolver snapshotResolver;
     private DOMSchemaService schemaService;
-    private AdapterContext codec;
+    private ConstantAdapterContext codec;
     private BindingCodecTreeFactory bindingCodecTreeFactory;
     private YangParserFactory yangParserFactory;
     private BindingAdapterFactory bindingAdapterFactory;
@@ -353,8 +351,8 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
         this.notificationPublishService =
                 new BindingDOMNotificationPublishServiceAdapter(this.codec, this.domNotificationRouter);
 
-        //create binding data broker
-        this.domDataBroker = new BindingDOMDataBrokerAdapter(this.codec, this.concurrentDOMDataBroker);
+        //create data broker
+        this.dataBroker = bindingAdapterFactory.createDataBroker(concurrentDOMDataBroker);
 
         this.clusteringHandler.ifPresent(handler -> handler.start(clusterAdminRpcService));
 
@@ -668,11 +666,11 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
 
     @Override
     public DataBroker getBindingDataBroker() {
-        return this.domDataBroker;
+        return this.dataBroker;
     }
 
     @Override
-    public AdapterContext getAdapterContext() {
+    public ConstantAdapterContext getAdapterContext() {
         return codec;
     }
 

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/util/ControllerConfigUtils.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/util/ControllerConfigUtils.java
@@ -105,7 +105,7 @@ public final class ControllerConfigUtils {
         }
         JsonNode controllerNode = configNode.path(CONTROLLER_CONFIG_ROOT_ELEMENT_NAME);
 
-        ControllerConfiguration controllerConfiguration = getControllerConfiguration(mapper, jsonPath, controllerNode);
+        ControllerConfiguration controllerConfiguration = parseControllerConfig(mapper, jsonPath, controllerNode);
 
         injectActorSystemConfigToControllerConfig(controllerConfiguration);
 
@@ -123,9 +123,9 @@ public final class ControllerConfigUtils {
         return controllerConfiguration;
     }
 
-    private static ControllerConfiguration getControllerConfiguration(final ObjectMapper mapper,
+    private static ControllerConfiguration parseControllerConfig(final ObjectMapper mapper,
             final StringBuilder jsonPath, final JsonNode controllerNode) throws ConfigurationException {
-        ControllerConfiguration controllerConfiguration;
+        final ControllerConfiguration controllerConfiguration;
         try {
             controllerConfiguration = mapper.treeToValue(controllerNode, ControllerConfiguration.class);
             if (controllerNode.has(DatastoreConfigurationUtils.DATASTORECTX_CONFIG_ROOT_ELEMENT_NAME)) {
@@ -151,12 +151,12 @@ public final class ControllerConfigUtils {
             if (controllerNode.has(SCHEMA_SERVICE_CONFIG_ELEMENT_NAME)) {
                 setModelsToControllerConfiguration(mapper, jsonPath, controllerNode, controllerConfiguration);
             } else {
-                throw new ConfigurationException(String.format("JSON controller config file is missing %s element!",
-                        jsonPath));
+                throw new ConfigurationException(
+                        String.format("JSON controller config file is missing %s element!", jsonPath));
             }
         } catch (JsonProcessingException e) {
-            throw new ConfigurationException(String.format("Cannot bind Json tree to type: %s",
-                    ControllerConfiguration.class), e);
+            throw new ConfigurationException(
+                    String.format("Cannot bind Json tree to type: %s", ControllerConfiguration.class), e);
         }
         return controllerConfiguration;
     }
@@ -181,8 +181,8 @@ public final class ControllerConfigUtils {
                 throw new ConfigurationException("Expected JSON array at " + jsonPath);
             }
         } else {
-            throw new ConfigurationException(String.format("JSON controller config file is missing %s element!",
-                    jsonPath));
+            throw new ConfigurationException(
+                    String.format("JSON controller config file is missing %s element!", jsonPath));
         }
     }
 

--- a/lighty-examples/lighty-controller-springboot-netconf/src/main/java/io/lighty/core/controller/springboot/config/IsAdapter.java
+++ b/lighty-examples/lighty-controller-springboot-netconf/src/main/java/io/lighty/core/controller/springboot/config/IsAdapter.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 public class IsAdapter implements Adapter {
 
     private static final Logger LOG = LoggerFactory.getLogger(IsAdapter.class);
+    private static final String NOT_IMPLEMENTED = "not implemented";
 
     private final String classPath;
 
@@ -39,17 +40,17 @@ public class IsAdapter implements Adapter {
 
     @Override
     public void addPolicy(String sec, String ptype, List<String> rule) {
-        throw new Error("not implemented");
+        throw new Error(NOT_IMPLEMENTED);
     }
 
     @Override
     public void removePolicy(String sec, String ptype, List<String> rule) {
-        throw new Error("not implemented");
+        throw new Error(NOT_IMPLEMENTED);
     }
 
     @Override
     public void removeFilteredPolicy(String sec, String ptype, int fieldIndex, String... fieldValues) {
-        throw new Error("not implemented");
+        throw new Error(NOT_IMPLEMENTED);
     }
 
     private void loadPolicyClassPath(Model model, Helper.loadPolicyLineHandler<String, Model> handler) {

--- a/lighty-modules/lighty-aaa-aggregator/lighty-aaa/src/main/java/io/lighty/aaa/config/ShiroConfigurationConfig.java
+++ b/lighty-modules/lighty-aaa-aggregator/lighty-aaa/src/main/java/io/lighty/aaa/config/ShiroConfigurationConfig.java
@@ -17,6 +17,9 @@ import org.opendaylight.yang.gen.v1.urn.opendaylight.aaa.app.config.rev170619.sh
 import org.opendaylight.yang.gen.v1.urn.opendaylight.aaa.app.config.rev170619.shiro.configuration.UrlsBuilder;
 
 public final class ShiroConfigurationConfig {
+
+    private static final String ROLES_ADMIN = "authcBasic, roles[admin]";
+
     private ShiroConfigurationConfig() {
 
     }
@@ -31,9 +34,9 @@ public final class ShiroConfigurationConfig {
         mains.add(initMain("dynamicAuthorization", "org.opendaylight.aaa.shiro.realm.MDSALDynamicAuthorizationFilter"));
 
         final List<Urls> urls = new ArrayList<>();
-        urls.add(initUrl("/operations/cluster-admin**", "authcBasic, roles[admin]"));
-        urls.add(initUrl("/v1/**", "authcBasic, roles[admin]"));
-        urls.add(initUrl("/config/aaa*/**", "authcBasic, roles[admin]"));
+        urls.add(initUrl("/operations/cluster-admin**", ROLES_ADMIN));
+        urls.add(initUrl("/v1/**", ROLES_ADMIN));
+        urls.add(initUrl("/config/aaa*/**", ROLES_ADMIN));
         urls.add(initUrl("/**", "authcBasic"));
 
         return new ShiroConfigurationBuilder().setMain(mains).setUrls(urls).build();


### PR DESCRIPTION
Fixed critical code smells:
- String literals should not be duplicated
- Class members annotated with "VisibleForTesting" should not be accessed from production code
- Cognitive Complexity of methods should not be too high
- Methods should not be empty

Won't do code smells:
- Generic wildcard types should not be used in return types
Whole section comes from ODL as a yangtools generic behavior.
https://sonarcloud.io/project/issues?id=PantheonTechnologies_lighty-core&rules=java%3AS1452&severities=CRITICAL&types=CODE_SMELL

cherry-picks #818 