### PR TITLE
Make README links relative for this repository's sources

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/README.md
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/README.md
@@ -1,11 +1,11 @@
 # RESTCONF gNMI (RCgNMI) Application
 A lighty.io application, which starts and wires the following components:
 
-- [lighty.io Controller](https://github.com/PANTHEONtech/lighty/tree/master/lighty-core/lighty-controller)
+- [lighty.io Controller](../../lighty-core/lighty-controller)
   provides core OpenDaylight services (like MD-SAL, YANG Tools, global schema context, etc.), which are required for other services.
-- [lighty.io RESTCONF Northbound](https://github.com/PANTHEONtech/lighty/tree/master/lighty-modules/lighty-restconf-nb-community)
+- [lighty.io RESTCONF Northbound](../../lighty-modules/lighty-restconf-nb-community)
   provides the RESTCONF interface, that is used to communicate with the application using the RESTCONF protocol over HTTP.
-- [lighty.io gNMI Southbound](https://github.com/PANTHEONtech/lighty/tree/master/lighty-modules/lighty-gnmi/lighty-gnmi-sb) acts as a gNMI client, manages connections to gNMI devices and gNMI communication. Currently, only _gNMI Capabilities, gNMI Get_ & _gNMI Set_ are supported.
+- [lighty.io gNMI Southbound](../../lighty-modules/lighty-gnmi/lighty-gnmi-sb) acts as a gNMI client, manages connections to gNMI devices and gNMI communication. Currently, only _gNMI Capabilities, gNMI Get_ & _gNMI Set_ are supported.
 
 ![RCgNMI lighty.io architecture](docs/lighty-rcgnmi-architecture.png)
 
@@ -337,7 +337,7 @@ To build and start the RCgNMI lighty.io application using Docker in a local envi
    --rm lighty-rcgnmi -c configuration.json -l log4j.properties
   ```
 
-If your _configuration.json_ file specifies a path to the initial configuration data to load on start up (for more information, check the [lighty-controller](https://github.com/PANTHEONtech/lighty/tree/master/lighty-core/lighty-controller)), you need to mount the JSON/XML file as well:
+If your _configuration.json_ file specifies a path to the initial configuration data to load on start up (for more information, check the [lighty-controller](../../lighty-core/lighty-controller)), you need to mount the JSON/XML file as well:
 
 `-v /absolute/path/to/file/initData.xml:/lighty-rcgnmi/initData.xml`
 Then, your path to this file in configuration.json becomes just `./initData.xml`:
@@ -381,7 +381,7 @@ To ***uninstall** the deployment, run the command:
 
 ### Providing Startup Configuration
 
-By default, the deployed application is started with a custom _configuration.json_ (for more information check [lighty-controller]       (https://github.com/PANTHEONtech/lighty/tree/master/lighty-core/lighty-controller)). We supply this configuration file by passing the Kubernetes configmap (`configmaps.yaml`), which can be modified to your needs.
+By default, the deployed application is started with a custom _configuration.json_ (for more information check [lighty-controller](../../lighty-core/lighty-controller)). We supply this configuration file by passing the Kubernetes configmap (`configmaps.yaml`), which can be modified to your needs.
 
 To use the functionality of loading configuration data on startup, add a new entry to _configmaps.yaml_:
 

--- a/lighty-applications/lighty-rnc-app-aggregator/README.md
+++ b/lighty-applications/lighty-rnc-app-aggregator/README.md
@@ -2,15 +2,15 @@
 The lighty.io RESTCONF-NETCONF application allows to easily initialize, start and utilize the most used OpenDaylight services and optionally add custom business logic.
 
 Most important lighty.io components used are:
-- [lighty.io controller](https://github.com/PANTHEONtech/lighty/tree/master/lighty-core/lighty-controller)
+- [lighty.io controller](../../lighty-core/lighty-controller)
   provides core ODL services (like MDSAL, yangtools, global schema context,...) that are required
   for other services or plugins.
-- [RESTCONF Northbound plugin](https://github.com/PANTHEONtech/lighty/tree/master/lighty-modules/lighty-restconf-nb-community)
+- [RESTCONF Northbound plugin](../../lighty-modules/lighty-restconf-nb-community)
   provides the RESTCONF interface that is used to communicate with the application using the RESTCONF protocol over the HTTP.
-- [NETCONF Southbound plugin](https://github.com/PANTHEONtech/lighty/tree/master/lighty-modules/lighty-netconf-sb)
+- [NETCONF Southbound plugin](../../lighty-modules/lighty-netconf-sb)
   enables application to connect to the NETCONF devices using the NETCONF protocol and read/write configuration
   from them or execute RPCs.
-- [AAA Module](https://github.com/PANTHEONtech/lighty/tree/master/lighty-modules/lighty-aaa) provides authorization,
+- [AAA Module](../../lighty-modules/lighty-aaa-aggregator/lighty-aaa) provides authorization,
   authentication and accounting which for example enables to use Basic Authentication for RESTCONF northbound interface.
   This module is optional and can be turned ON/OFF using application configuration.
 
@@ -104,7 +104,7 @@ To build and start the lighty.io RNC application using Docker in a local environ
 
    If your configuration.json file specifies a path to the initial configuration data to load on startup
    (for more information, check 
-   [lighty-controller](https://github.com/PANTHEONtech/lighty/tree/master/lighty-core/lighty-controller))
+   [lighty-controller](../../lighty-core/lighty-controller))
    you need to mount the JSON/XML file as well:
    `-v /absolute/path/to/file/initData.xml:/lighty-rnc/initData.xml`
    , then your path to this file in configuration.json becomes just "./initData.xml":
@@ -137,7 +137,7 @@ To install, make sure that the Docker image is defined in `values.yaml` and acce
 in the `/lighty-rnc-app-helm/helm/` directory.
 ### Providing startup configuration
 By default, the deployed application is started with a custom configuration.json 
-(for more information check the [lighty-controller](https://github.com/PANTHEONtech/lighty/tree/master/lighty-core/lighty-controller)).
+(for more information check the [lighty-controller](../../lighty-core/lighty-controller)).
 We supply this configuration file by passing a Kubernetes configmap (`configmaps.yaml`), which you can modify to your needs.
 To use the functionality of loading configuration data on startup, add new entry to configmaps.yaml:
 `initData: |

--- a/lighty-examples/lighty-gnmi-community-restconf-app/README.md
+++ b/lighty-examples/lighty-gnmi-community-restconf-app/README.md
@@ -11,10 +11,10 @@ To communicate with gNMI device it is required to use TLS communication with cer
 authorization.
 
 This application starts:
-* [Lighty.io Controller](https://github.com/PANTHEONtech/lighty/tree/master/lighty-core/lighty-controller) with modules:
-  * [lighty.io RESTCONF module](https://github.com/PANTHEONtech/lighty/tree/master/lighty-modules/lighty-restconf-nb-community)
-  * [lighty.io gNMI module](https://github.com/PANTHEONtech/lighty/tree/master/lighty-modules/lighty-gnmi/lighty-gnmi-sb)
-* [lighty.io gNMI device simulator](https://github.com/PANTHEONtech/lighty/tree/14.0.x/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator)
+* [Lighty.io Controller](../../lighty-core/lighty-controller) with modules:
+  * [lighty.io RESTCONF module](../../lighty-modules/lighty-restconf-nb-community)
+  * [lighty.io gNMI module](../../lighty-modules/lighty-gnmi/lighty-gnmi-sb)
+* [lighty.io gNMI device simulator](https://github.com/PANTHEONtech/lighty/tree/14.2.0/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator)
 
 ![lighty.io gNMI / RESTCONF architecture](docs/lighty-gnmi-restconf-architecture.png)
 

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/README.md
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/README.md
@@ -1,10 +1,24 @@
 # gNMI Southbound Module
 
-A southbound [lighty.io](https://lighty.io/) module, which manages connections with gNMI targets. This module implements functionality to make **CRUD operations on multiple gNMI targets**. This make it easy to read and manipulate data in gNMI devices.
+A southbound [lighty.io](https://lighty.io/) module, which manages connections with gNMI targets.
+This module implements functionality to make **CRUD operations on multiple gNMI targets**.
+This make it easy to read and manipulate data in gNMI devices.
 
-lighty.io gNMI augments the OpenDaylight network-topology model with the [gnmi-topology](../../../lighty-models/lighty-gnmi-models/lighty-gnmi-topology-model/src/main/yang/gnmi-topology.yang) model. This provides the possibility to connect a gNMI device, by adding a new node with the desired [parameters](https://github.com/PANTHEONtech/lighty/blob/master/lighty-models/lighty-gnmi-models/lighty-gnmi-topology-model/src/main/yang/gnmi-topology.yang#L67) to the gnmi-topology in data store (as OpenDaylight NETCONF SBP does). 
+lighty.io gNMI augments the OpenDaylight network-topology model with the
+[gnmi-topology](../../../lighty-models/lighty-gnmi-models/lighty-gnmi-topology-model/src/main/yang/gnmi-topology.yang)
+model. This provides the possibility to connect a gNMI device, by adding a new node with the desired
+[parameters](../../../lighty-models/lighty-gnmi-models/lighty-gnmi-topology-model/src/main/yang/gnmi-topology.yang#L67)
+to the gnmi-topology in data store (as OpenDaylight NETCONF SBP does).
 
-Once a new node is added, gNMI-south-bound established a connection to the gNMI device and creates a mount point containing [GnmiDataBroker](src/main/java/io/lighty/gnmi/southbound/mountpoint/broker/GnmiDataBroker.java), which is used for communicating with gNMI device via transactions. GnmiDataBroker also contains [schemaContext](https://javadocs.opendaylight.org/org.opendaylight.yangtools/master/org/opendaylight/yangtools/yang/model/api/SchemaContext.html) created from capabilities received from the device. All YANG models which the gNMI device will use, should be provided in the [GnmiConfiguration](src/main/java/io/lighty/gnmi/southbound/lightymodule/config/GnmiConfiguration.java), as a path to the folder with requires YANG models or added via [upload-yang-model](https://github.com/PANTHEONtech/lighty/blob/master/lighty-models/lighty-gnmi-models/lighty-gnmi-yang-storage-model/src/main/yang/gnmi-yang-storage.yang#L57) RPC.
+Once a new node is added, gNMI-south-bound established a connection to the gNMI device and creates a mount point
+containing [GnmiDataBroker](src/main/java/io/lighty/gnmi/southbound/mountpoint/broker/GnmiDataBroker.java), which is
+used for communicating with gNMI device via transactions. GnmiDataBroker also contains
+[schemaContext](https://javadocs.opendaylight.org/org.opendaylight.yangtools/master/org/opendaylight/yangtools/yang/model/api/SchemaContext.html)
+created from capabilities received from the device. All YANG models which the gNMI device will use, should be provided
+in the [GnmiConfiguration](src/main/java/io/lighty/gnmi/southbound/lightymodule/config/GnmiConfiguration.java), as a
+path to the folder with requires YANG models or added via
+[upload-yang-model](../../../lighty-models/lighty-gnmi-models/lighty-gnmi-yang-storage-model/src/main/yang/gnmi-yang-storage.yang#L57)
+RPC.
 
 ## How To Use
 
@@ -84,7 +98,7 @@ Creating a device connection and CRUD operation, is performed by writing data di
         gnmiSouthboundModule.start().get();
 ```
 
-2. Connect gNMI device. More about configuring security or extension parameter on gNMI device can be found in the [RCgNMI Documentation](https://github.com/PANTHEONtech/lighty/blob/master/lighty-applications/lighty-rcgnmi-app-aggregator/README.md#how-to-use-rcgnmi-example-app) and in the [gnmi-topology.yang](https://github.com/PANTHEONtech/lighty/blob/master/lighty-models/lighty-gnmi-models/lighty-gnmi-topology-model/src/main/yang/gnmi-topology.yang) YANG model.
+2. Connect gNMI device. More about configuring security or extension parameter on gNMI device can be found in the [RCgNMI Documentation](../../../lighty-applications/lighty-rcgnmi-app-aggregator/README.md#how-to-use-rcgnmi-example-app) and in the [gnmi-topology.yang](../../../lighty-models/lighty-gnmi-models/lighty-gnmi-topology-model/src/main/yang/gnmi-topology.yang) YANG model.
 
 ```java
         final Node testGnmiNode = createNode(GNMI_NODE_ID, DEVICE_ADDRESS, DEVICE_PORT, getInsecureSecurityChoice());
@@ -96,7 +110,7 @@ Creating a device connection and CRUD operation, is performed by writing data di
 
 3. Wait until the gNMI device is successfully connected to gNMI-sb. The device is successfully connected, when the status is `NodeState.NodeStatus.READY`.
 
-Device [node-status](https://github.com/PANTHEONtech/lighty/blob/14.0.x/lighty-models/lighty-gnmi-models/lighty-gnmi-topology-model/src/main/yang/gnmi-topology.yang#L140) is available in operational memory, inside data store.
+Device [node-status](../../../lighty-models/lighty-gnmi-models/lighty-gnmi-topology-model/src/main/yang/gnmi-topology.yang#L140) is available in operational memory, inside data store.
 
 4. Get DOM GnmiDataBroker registered for specific gNMI device. For each successfully registered gNMI device, a new GnmiDataBroker with a device specific schema context is created.
 
@@ -145,7 +159,7 @@ Device [node-status](https://github.com/PANTHEONtech/lighty/blob/14.0.x/lighty-m
 ```
 
 ## Register Client Certificates
-This example shows how to programmatically add certificates for lighty.io gNMI. Certificates keystore should be created before connecting the actual gNMI device. Certificates could be assigned to device, with [keystore-id](https://github.com/PANTHEONtech/lighty/blob/master/lighty-models/lighty-gnmi-models/lighty-gnmi-topology-model/src/main/yang/gnmi-topology.yang#L45) parameter when the mountpoint is being created. YANG RPC and certificates keystore is modeled by [gnmi-certificate-storage.yang](../../../lighty-models/lighty-gnmi-models/lighty-gnmi-certificates-storage-model/src/main/yang/gnmi-certificate-storage.yang)
+This example shows how to programmatically add certificates for lighty.io gNMI. Certificates keystore should be created before connecting the actual gNMI device. Certificates could be assigned to device, with [keystore-id](../../../lighty-models/lighty-gnmi-models/lighty-gnmi-topology-model/src/main/yang/gnmi-topology.yang#L45) parameter when the mountpoint is being created. YANG RPC and certificates keystore is modeled by [gnmi-certificate-storage.yang](../../../lighty-models/lighty-gnmi-models/lighty-gnmi-certificates-storage-model/src/main/yang/gnmi-certificate-storage.yang)
 
 - Invoke RPC for adding certificates to lighty.io gNMI:
 


### PR DESCRIPTION
Update links used in README files for resources from this repository to be relative to the sources where they are used