### PR TITLE
Bump springboot dependencies to 2.5.6 for spring DI

### DIFF
--- a/lighty-core/lighty-controller-spring-di/pom.xml
+++ b/lighty-core/lighty-controller-spring-di/pom.xml
@@ -27,7 +27,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>2.1.5.RELEASE</version>
+                <version>2.5.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Use latest stable springboot dependencies, release 2.5.6.

This bump should fix also multiple vulnerabilities regarding older jackson-databind library used in previous spring
The vulnerabilities were reported by sonatype lift for last release 15.0.0
https://sbom.lift.sonatype.com/report/T1-0ff0976f7f21c391f20f-91d4652a4b2bc7-1634572521-4d260d2778bb424abf6da54babb8d35a