### PR TITLE
Add maven profile to collect & list all licenses for dependencies used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,8 @@
     <profiles>
         <profile>
             <!-- profile to collect all licenses and generate them to file
-             target/generated-sources/license/THIRD-PARTY.txt -->
+             target/generated-sources/license/THIRD-PARTY.txt
+             The process of generation can be executed simply by `mvn validate -P get-all-licenses`-->
             <id>get-all-licenses</id>
             <properties>
                 <license.sortArtifactByName>true</license.sortArtifactByName>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,36 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <!-- profile to collect all licenses and generate them to file
+             target/generated-sources/license/THIRD-PARTY.txt -->
+            <id>get-all-licenses</id>
+            <properties>
+                <license.sortArtifactByName>true</license.sortArtifactByName>
+                <license.force>true</license.force>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                        <version>2.0.0</version>
+                        <executions>
+                            <execution>
+                                <id>analyze-license</id>
+                                <goals>
+                                    <goal>aggregate-add-third-party</goal>
+                                </goals>
+                                <phase>validate</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <licenses>
         <license>
             <name>Eclipse Public License 1.0</name>


### PR DESCRIPTION
To generate list of licenses it is enough to run
 `mvn validate -P get-all-licenses` without compiling sources
 and profile will generate file
 `target/generated-sources/license/THIRD-PARTY.txt`
 which will contain list of all dependencies' licenses used

Signed-off-by: Michal Banik <michal.banik@pantheon.tech>