### PR TITLE
Prepare release 15.1.0

### DIFF
--- a/.github/workflows/lighty-rcgnmi-app/tests-lighty-rcgnmi-app.sh
+++ b/.github/workflows/lighty-rcgnmi-app/tests-lighty-rcgnmi-app.sh
@@ -44,7 +44,7 @@ ls -1 yangs
 #Run simulator for testing purpose
 printLine
 echo -e "-- Starting gNMI simulator device --\n"
-java -jar ${GITHUB_WORKSPACE}/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/target/lighty-gnmi-device-simulator-15.0.1-SNAPSHOT.jar -c ./simulator/example_config.json > /dev/null 2>&1 &
+java -jar ${GITHUB_WORKSPACE}/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/target/lighty-gnmi-device-simulator-15.1.0.jar -c ./simulator/example_config.json > /dev/null 2>&1 &
 
 #Add yangs into controller through REST rpc
 ./add_yangs_via_rpc.sh

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>io.lighty.applications.rcgnmi</groupId>
     <artifactId>lighty-rcgnmi-app-docker</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0</version>
 
     <properties>
         <image.name>lighty-rcgnmi</image.name>

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/pom.xml
@@ -41,6 +41,7 @@
         <dependency>
             <groupId>io.lighty.resources</groupId>
             <artifactId>singlenode-configuration</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/pom.xml
@@ -29,19 +29,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.lighty.resources</groupId>
-            <artifactId>singlenode-configuration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.lighty.resources</groupId>
-            <artifactId>start-script</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.lighty.resources</groupId>
-            <artifactId>controller-application-assembly</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>io.lighty.core</groupId>
             <artifactId>lighty-common</artifactId>
         </dependency>

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.applications.rnc</groupId>
     <artifactId>lighty-rnc-app-docker</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0</version>
 
     <properties>
         <image.name>lighty-rnc</image.name>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -262,7 +262,7 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-      <tag>HEAD</tag>
+      <tag>15.1.0</tag>
   </scm>
     <developers>
         <developer>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
-                <version>9.0.6</version>
+                <version>9.0.8</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -34,14 +34,14 @@
             <dependency>
                 <groupId>org.opendaylight.aaa</groupId>
                 <artifactId>aaa-artifacts</artifactId>
-                <version>0.14.3</version>
+                <version>0.14.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>controller-artifacts</artifactId>
-                <version>4.0.3</version>
+                <version>4.0.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -50,35 +50,35 @@
                 This artifact dependency management was removed from odl-parent in Aluminium release. -->
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>bundle-parent</artifactId>
-                <version>4.0.3</version>
+                <version>4.0.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.infrautils</groupId>
                 <artifactId>infrautils-artifacts</artifactId>
-                <version>2.0.6</version>
+                <version>2.0.8</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.mdsal</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>8.0.5</version>
+                <version>8.0.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>netconf-artifacts</artifactId>
-                <version>2.0.5</version>
+                <version>2.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yangtools-artifacts</artifactId>
-                <version>7.0.8</version>
+                <version>7.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -54,12 +54,12 @@
             <plugin>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yang-maven-plugin</artifactId>
-                <version>7.0.8</version>
+                <version>7.0.9</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.opendaylight.mdsal</groupId>
                         <artifactId>mdsal-binding-java-api-generator</artifactId>
-                        <version>8.0.5</version>
+                        <version>8.0.7</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/lighty-core/lighty-bom/pom.xml
+++ b/lighty-core/lighty-bom/pom.xml
@@ -259,7 +259,7 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-      <tag>HEAD</tag>
+      <tag>15.1.0</tag>
   </scm>
     <developers>
         <developer>

--- a/lighty-core/lighty-controller/README.md
+++ b/lighty-core/lighty-controller/README.md
@@ -17,7 +17,7 @@ To use Lighty controller in your project:
   <dependency>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-controller</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0</version>
   </dependency>
 ```
 

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
@@ -318,8 +318,8 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
 
         // ENTITY OWNERSHIP
         try {
-            this.akkaEntityOwnershipService
-                    = new AkkaEntityOwnershipService(this.actorSystemProvider, this.rpcProviderService);
+            this.akkaEntityOwnershipService = new AkkaEntityOwnershipService(this.actorSystemProvider,
+                    this.rpcProviderService, bindingCodecContext);
         } catch (ExecutionException | InterruptedException e) {
             LOG.error("Exception occurred while creating AkkaEntityOwnershipService", e);
             Thread.currentThread().interrupt();

--- a/lighty-core/lighty-minimal-parent/pom.xml
+++ b/lighty-core/lighty-minimal-parent/pom.xml
@@ -103,7 +103,7 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-      <tag>HEAD</tag>
+      <tag>15.1.0</tag>
   </scm>
     <developers>
         <developer>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -174,7 +174,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>9.0.6</version>
+                            <version>9.0.8</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -191,7 +191,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>spotbugs</artifactId>
-                            <version>8.1.1</version>
+                            <version>9.0.8</version>
                         </dependency>
                         <dependency>
                             <!-- The SpotBugs Maven plugin uses SLF4J 1.8 beta 2 -->

--- a/lighty-examples/README.md
+++ b/lighty-examples/README.md
@@ -15,7 +15,7 @@ ODL core services represent MD-SAL layer, controller, DataStore, global schema c
    <dependency>
       <groupId>io.lighty.core.parents</groupId>
       <artifactId>lighty-dependency-artifacts</artifactId>
-      <version>15.0.1-SNAPSHOT</version>
+      <version>15.1.0</version>
       <type>pom</type>
       <scope>import</scope>
    </dependency>

--- a/lighty-examples/lighty-community-restconf-netconf-app/README.md
+++ b/lighty-examples/lighty-community-restconf-netconf-app/README.md
@@ -21,12 +21,12 @@ build the project: ```mvn clean install```
 ### Start this demo example
 * build the project using ```mvn clean install```
 * go to target directory ```cd lighty-examples/lighty-community-restconf-netconf-app/target``` 
-* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-15.0.1-SNAPSHOT-bin.zip```
-* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-15.0.1-SNAPSHOT```
-* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-15.0.1-SNAPSHOT.jar``` 
+* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-15.1.0-bin.zip```
+* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-15.1.0```
+* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-15.1.0.jar``` 
 
 ### Test example application
-Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-15.0.1-SNAPSHOT.jar``` 
+Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-15.1.0.jar``` 
 RESTCONF web interface is available at URL ```http://localhost:8888/restconf/*```
 
 ##### URLs to start with
@@ -43,7 +43,7 @@ URLs for Swagger (choose RESTCONF [draft18](https://tools.ietf.org/html/draft-ie
 
 ### Use custom config files
 There are two separated config files: for NETCONF SBP single node and for cluster.
-`java -jar lighty-community-restconf-netconf-app-15.0.1-SNAPSHOT.jar /path/to/singleNodeConfig.json`
+`java -jar lighty-community-restconf-netconf-app-15.1.0.jar /path/to/singleNodeConfig.json`
 
 Example configuration for single node is [here](src/main/assembly/resources/sampleConfigSingleNode.json)
 

--- a/lighty-examples/lighty-controller-springboot-netconf/README.md
+++ b/lighty-examples/lighty-controller-springboot-netconf/README.md
@@ -46,7 +46,7 @@ mvn spring-boot:run
 or
 
 ```
-java -jar target/lighty-controller-springboot-15.0.1-SNAPSHOT.jar
+java -jar target/lighty-controller-springboot-15.1.0.jar
 ```
 
 or in any IDE, run main in 

--- a/lighty-examples/lighty-gnmi-community-restconf-app/README.md
+++ b/lighty-examples/lighty-gnmi-community-restconf-app/README.md
@@ -42,22 +42,22 @@ cd lighty-examples/lighty-gnmi-community-restconf-app
 ### Start RCgNMI controller app
 Unzip lighty-rcgnmi-app to current location
 ```
-unzip ../../lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/target/lighty-rcgnmi-app-15.0.1-SNAPSHOT-bin.zip
+unzip ../../lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/target/lighty-rcgnmi-app-15.1.0-bin.zip
 ```
 Start application with pre-prepared configuration [example_config.json](example_config.json).
 ```
-java -jar lighty-rcgnmi-app-15.0.1-SNAPSHOT/lighty-rcgnmi-app-15.0.1-SNAPSHOT.jar -c example_config.json
+java -jar lighty-rcgnmi-app-15.1.0/lighty-rcgnmi-app-15.1.0.jar -c example_config.json
 ```
 
 ### Start lighty.io gNMI device simulator
 Unzip gNMI simulator app to current folder.
 ```
-unzip ../../lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/target/lighty-gnmi-device-simulator-15.0.1-SNAPSHOT-bin.zip
+unzip ../../lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/target/lighty-gnmi-device-simulator-15.1.0-bin.zip
 ```
 
 Start the application with pre-prepared configuration [simulator_config.json](simulator/simulator_config.json)
 ```
-java -jar lighty-gnmi-device-simulator-15.0.1-SNAPSHOT/lighty-gnmi-device-simulator-15.0.1-SNAPSHOT.jar  -c simulator/simulator_config.json 
+java -jar lighty-gnmi-device-simulator-15.1.0/lighty-gnmi-device-simulator-15.1.0.jar  -c simulator/simulator_config.json 
 ```
 
 ### Add client certificates to lighty.io gNMI keystore

--- a/lighty-models/README.md
+++ b/lighty-models/README.md
@@ -56,7 +56,7 @@ my-model/pom.xml
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>15.0.1-SNAPSHOT</version>
+        <version>15.1.0</version>
         <relativePath/>
     </parent>
 

--- a/lighty-modules/lighty-aaa-aggregator/lighty-aaa/pom.xml
+++ b/lighty-modules/lighty-aaa-aggregator/lighty-aaa/pom.xml
@@ -72,7 +72,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
-            <artifactId>jersey-container-servlet-core</artifactId>
+            <artifactId>jersey-container-servlet</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.inject</groupId>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/README.md
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/README.md
@@ -8,7 +8,7 @@ This simulator provides gNMI device driven by gNMI proto files, with datastore d
    <dependency>
       <groupId>io.lighty.modules.gnmi</groupId>
       <artifactId>lighty-gnmi-device-simulator</artifactId>
-      <version>15.0.1-SNAPSHOT</version>
+      <version>15.1.0</version>
    </dependency>
 ```
 

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiConnectionITTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiConnectionITTest.java
@@ -472,7 +472,7 @@ public class GnmiConnectionITTest extends GnmiITBase {
             assertEquals(HttpURLConnection.HTTP_OK, getDataFromDevice.statusCode());
             final HttpResponse<String> getIncorrectDataFromDevice =
                 sendGetRequestJSON(GNMI_DEVICE_MOUNTPOINT + OPENCONFIG_INTERFACES + "incorrect");
-            assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, getIncorrectDataFromDevice.statusCode());
+            assertEquals(HttpURLConnection.HTTP_CONFLICT, getIncorrectDataFromDevice.statusCode());
 
             final HttpResponse<String> setDataOnDevice =
                 sendPutRequestJSON(GNMI_DEVICE_MOUNTPOINT + OPENCONFIG_INTERFACES + "/interface=eth3/config/name",

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiGetITTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiGetITTest.java
@@ -83,11 +83,6 @@ public class GnmiGetITTest extends GnmiITBase {
     private static final String OC_INTERFACE_ETH3_CONFIG_TYPE_EXPECTED = "openconfig-if-types:IF_ETHERNET";
     private static final String OC_INTERFACE_ETH3_EXPECTED = "{\"name\":\"eth3\",\"config\":{\"name\":\"admin\","
         + "\"type\":\"openconfig-if-types:IF_ETHERNET\",\"loopback-mode\":false,\"enabled\":false,\"mtu\":1500}}";
-    private static final String OC_INTERFACES_INCORRECT_ERROR_MESSAGE_EXPECTED = "{\"errors\":{\"error\""
-          + ":[{\"error-tag\":\"malformed-message\",\"error-type\":\"protocol\",\"error-message\":"
-          + "\"Could not parse Instance Identifier 'openconfig-interfaces:interfacesincorrect'. Offset: '41' : Reason: "
-          + "'(http://openconfig.net/yang/interfaces?revision=2021-04-06)interfacesincorrect' is not correct "
-          + "schema node identifier.\"}]}}";
     private static SimulatedGnmiDevice device;
 
     @BeforeAll
@@ -186,13 +181,11 @@ public class GnmiGetITTest extends GnmiITBase {
     }
 
     @Test
-    public void getNonExistingDataTest() throws InterruptedException, IOException, JSONException {
+    public void getNonExistingDataTest() throws InterruptedException, IOException {
         //assert error for request to non existing interfacesincorrect container
         final HttpResponse<String> getOcInterfacesContainerWrongResponse =
             sendGetRequestJSON(INTERFACES_PATH + "incorrect");
-        assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, getOcInterfacesContainerWrongResponse.statusCode());
-        JSONAssert.assertEquals(OC_INTERFACES_INCORRECT_ERROR_MESSAGE_EXPECTED,
-                getOcInterfacesContainerWrongResponse.body(), false);
+        assertEquals(HttpURLConnection.HTTP_CONFLICT, getOcInterfacesContainerWrongResponse.statusCode());
     }
 
     private List<String> convertCapabilitiesJSONArrayToList(final JSONArray capabilitiesArray) throws JSONException {

--- a/lighty-modules/lighty-netconf-sb/README.md
+++ b/lighty-modules/lighty-netconf-sb/README.md
@@ -42,7 +42,7 @@ To use NETCONF in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-netconf-sb</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0</version>
   </dependency>  
 ```
 2. Initialize and start an instance of NETCONF SBP in your code:

--- a/lighty-modules/lighty-restconf-nb-community/README.md
+++ b/lighty-modules/lighty-restconf-nb-community/README.md
@@ -12,7 +12,7 @@ To use RESTCONF in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-restconf-nb-community</artifactId>
-    <version>15.0.1-SNAPSHOT</version>
+    <version>15.1.0</version>
   </dependency>
 ```
 

--- a/lighty-modules/lighty-restconf-nb-community/pom.xml
+++ b/lighty-modules/lighty-restconf-nb-community/pom.xml
@@ -43,6 +43,10 @@
 
         <!-- Jersey + Jetty for RESTCONF -->
         <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>
         </dependency>

--- a/lighty-modules/lighty-restconf-nb-community/pom.xml
+++ b/lighty-modules/lighty-restconf-nb-community/pom.xml
@@ -68,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
-            <artifactId>jersey-container-servlet-core</artifactId>
+            <artifactId>jersey-container-servlet</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.inject</groupId>

--- a/lighty-resources/singlenode-configuration/src/main/resources/singlenode/factory-akka-default.conf
+++ b/lighty-resources/singlenode-configuration/src/main/resources/singlenode/factory-akka-default.conf
@@ -60,6 +60,7 @@ akka {
   }
 
   actor {
+    allow-java-serialization = true
     warn-about-java-serializer-usage = off
     provider = "akka.cluster.ClusterActorRefProvider"
     serializers {

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-        <tag>HEAD</tag>
+        <tag>15.1.0</tag>
     </scm>
     <developers>
         <developer>


### PR DESCRIPTION
Update upstream dependencies to Phosphorus SR1 release versions:

-  odlparent 9.0.8
-  aaa-artifacts 0.14.7
-  controller-artifacts 4.0.7
-  bundle-parent 4.0.7
-  infrautils-artifacts 2.0.8
-  mdsal-artifacts 8.0.7
-  netconf-artifacts 2.0.9
-  yangtools-artifacts 7.0.9
-  yang-maven-plugin 7.0.9
-  mdsal-binding-java-api-generator 8.0.7
-  checkstyle 9.0.8

Release notes:
- Remove data store prepare request from gNMI module