### PR TITLE
Prepare release 14.3.0

### DIFF
--- a/.github/workflows/lighty-rcgnmi-app/tests-lighty-rcgnmi-app.sh
+++ b/.github/workflows/lighty-rcgnmi-app/tests-lighty-rcgnmi-app.sh
@@ -44,7 +44,7 @@ ls -1 yangs
 #Run simulator for testing purpose
 printLine
 echo -e "-- Starting gNMI simulator device --\n"
-java -jar ${GITHUB_WORKSPACE}/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/target/lighty-gnmi-device-simulator-14.2.2-SNAPSHOT.jar -c ./simulator/example_config.json > /dev/null 2>&1 &
+java -jar ${GITHUB_WORKSPACE}/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/target/lighty-gnmi-device-simulator-14.3.0.jar -c ./simulator/example_config.json > /dev/null 2>&1 &
 
 #Add yangs into controller through REST rpc
 ./add_yangs_via_rpc.sh

--- a/.github/workflows/publish-docker-helm.yml
+++ b/.github/workflows/publish-docker-helm.yml
@@ -21,7 +21,7 @@ on:
         description: Desired NAME of docker image, e.g. "lighty-rnc"
         required: true
       version:
-        description: Desired version of published docker image & helm charts, e.g. "14.0.0"
+        description: Desired version of published docker image & helm charts, e.g. "14.3.0"
         required: true
       image-tag-latest:
         description: Should be this docker labeled with tag latest? Enter `true` if the tag `latest` should be added for image.

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>io.lighty.applications.rcgnmi</groupId>
     <artifactId>lighty-rcgnmi-app-docker</artifactId>
-    <version>14.2.2-SNAPSHOT</version>
+    <version>14.3.0</version>
 
     <properties>
         <image.name>lighty-rcgnmi</image.name>

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.applications.rnc</groupId>
     <artifactId>lighty-rnc-app-docker</artifactId>
-    <version>14.2.2-SNAPSHOT</version>
+    <version>14.3.0</version>
 
     <properties>
         <image.name>lighty-rnc</image.name>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
-                <version>8.1.3</version>
+                <version>8.1.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -34,14 +34,14 @@
             <dependency>
                 <groupId>org.opendaylight.aaa</groupId>
                 <artifactId>aaa-artifacts</artifactId>
-                <version>0.13.5</version>
+                <version>0.13.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>controller-artifacts</artifactId>
-                <version>3.0.10</version>
+                <version>3.0.12</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -50,35 +50,35 @@
                 This artifact dependency management was removed from odl-parent in Aluminium release. -->
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>bundle-parent</artifactId>
-                <version>3.0.10</version>
+                <version>3.0.12</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.infrautils</groupId>
                 <artifactId>infrautils-artifacts</artifactId>
-                <version>1.9.9</version>
+                <version>1.9.10</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.mdsal</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>7.0.9</version>
+                <version>7.0.10</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>netconf-artifacts</artifactId>
-                <version>1.13.4</version>
+                <version>1.13.5</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yangtools-artifacts</artifactId>
-                <version>6.0.7</version>
+                <version>6.0.8</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -86,14 +86,14 @@
             <dependency>
                 <groupId>org.opendaylight.openflowplugin</groupId>
                 <artifactId>openflowplugin-artifacts</artifactId>
-                <version>0.12.2</version>
+                <version>0.12.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.serviceutils</groupId>
                 <artifactId>serviceutils-artifacts</artifactId>
-                <version>0.7.2</version>
+                <version>0.7.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -275,8 +275,8 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-        <tag>14.2.2-SNAPSHOT</tag>
-  </scm>
+        <tag>14.3.0</tag>
+    </scm>
     <developers>
         <developer>
             <id>rovarga</id>

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -54,12 +54,12 @@
             <plugin>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yang-maven-plugin</artifactId>
-                <version>6.0.7</version>
+                <version>6.0.8</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.opendaylight.mdsal</groupId>
                         <artifactId>maven-sal-api-gen-plugin</artifactId>
-                        <version>7.0.9</version>
+                        <version>7.0.10</version>
                         <type>jar</type>
                     </dependency>
                 </dependencies>

--- a/lighty-core/lighty-bom/pom.xml
+++ b/lighty-core/lighty-bom/pom.xml
@@ -264,8 +264,8 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-      <tag>14.2.2-SNAPSHOT</tag>
-  </scm>
+        <tag>14.3.0</tag>
+    </scm>
     <developers>
         <developer>
             <id>rovarga</id>

--- a/lighty-core/lighty-controller/README.md
+++ b/lighty-core/lighty-controller/README.md
@@ -17,7 +17,7 @@ To use Lighty controller in your project:
   <dependency>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-controller</artifactId>
-    <version>14.2.2-SNAPSHOT</version>
+    <version>14.3.0</version>
   </dependency>
 ```
 

--- a/lighty-core/lighty-minimal-parent/pom.xml
+++ b/lighty-core/lighty-minimal-parent/pom.xml
@@ -103,7 +103,7 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-        <tag>14.2.2-SNAPSHOT</tag>
+        <tag>14.3.0</tag>
     </scm>
     <developers>
         <developer>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -174,7 +174,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.1.3</version>
+                            <version>8.1.4</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -191,7 +191,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>spotbugs</artifactId>
-                            <version>8.1.3</version>
+                            <version>8.1.4</version>
                         </dependency>
                         <dependency>
                             <!-- The SpotBugs Maven plugin uses SLF4J 1.8 beta 2 -->

--- a/lighty-examples/README.md
+++ b/lighty-examples/README.md
@@ -17,7 +17,7 @@ ODL core services represent MD-SAL layer, controller, DataStore, global schema c
    <dependency>
       <groupId>io.lighty.core.parents</groupId>
       <artifactId>lighty-dependency-artifacts</artifactId>
-      <version>14.2.2-SNAPSHOT</version>
+      <version>14.3.0</version>
       <type>pom</type>
       <scope>import</scope>
    </dependency>

--- a/lighty-examples/lighty-community-netconf-quarkus-app/README.md
+++ b/lighty-examples/lighty-community-netconf-quarkus-app/README.md
@@ -30,7 +30,7 @@ mvn clean compile quarkus:dev
 ## Build package & Run
 ```
 mvn clean package
-java -Xms128m -Xmx128m -XX:MaxMetaspaceSize=128m -jar target/lighty-quarkus-netconf-app-14.2.2-SNAPSHOT-runner.jar
+java -Xms128m -Xmx128m -XX:MaxMetaspaceSize=128m -jar target/lighty-quarkus-netconf-app-14.3.0-runner.jar
 ```
 
 ## Build native image

--- a/lighty-examples/lighty-community-netconf-quarkus-app/pom.xml
+++ b/lighty-examples/lighty-community-netconf-quarkus-app/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.lighty.quarkus</groupId>
   <artifactId>lighty-quarkus-netconf-app</artifactId>
-  <version>14.2.2-SNAPSHOT</version>
+  <version>14.3.0</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -15,7 +15,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
     <application.attach.zip>true</application.attach.zip>
-    <lighty.version>14.2.2-SNAPSHOT</lighty.version>
+    <lighty.version>14.3.0</lighty.version>
   </properties>
 
   <dependencyManagement>

--- a/lighty-examples/lighty-community-restconf-netconf-app/README.md
+++ b/lighty-examples/lighty-community-restconf-netconf-app/README.md
@@ -21,12 +21,12 @@ build the project: ```mvn clean install```
 ### Start this demo example
 * build the project using ```mvn clean install```
 * go to target directory ```cd lighty-examples/lighty-community-restconf-netconf-app/target``` 
-* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-14.2.2-SNAPSHOT-bin.zip```
-* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-14.2.2-SNAPSHOT```
-* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-14.2.2-SNAPSHOT.jar``` 
+* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-14.3.0-bin.zip```
+* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-14.3.0```
+* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-14.3.0.jar``` 
 
 ### Test example application
-Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-14.2.2-SNAPSHOT.jar``` 
+Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-14.3.0.jar``` 
 RESTCONF web interface is available at URL ```http://localhost:8888/restconf/*```
 
 ##### URLs to start with
@@ -43,7 +43,7 @@ URLs for Swagger (choose RESTCONF [draft18](https://tools.ietf.org/html/draft-ie
 
 ### Use custom config files
 There are two separated config files: for NETCONF SBP single node and for cluster.
-`java -jar lighty-community-restconf-netconf-app-14.2.2-SNAPSHOT.jar /path/to/singleNodeConfig.json`
+`java -jar lighty-community-restconf-netconf-app-14.3.0.jar /path/to/singleNodeConfig.json`
 
 Example configuration for single node is [here](src/main/assembly/resources/sampleConfigSingleNode.json)
 

--- a/lighty-examples/lighty-community-restconf-ofp-app/Dockerfile
+++ b/lighty-examples/lighty-community-restconf-ofp-app/Dockerfile
@@ -1,16 +1,16 @@
 FROM openjdk:11-jre-slim
 
-COPY ./target/lighty-community-restconf-ofp-app-14.2.2-SNAPSHOT-bin.zip /
+COPY ./target/lighty-community-restconf-ofp-app-14.3.0-bin.zip /
 RUN apt-get update && apt-get install unzip \
-    && unzip /lighty-community-restconf-ofp-app-14.2.2-SNAPSHOT-bin.zip \
-    && rm /lighty-community-restconf-ofp-app-14.2.2-SNAPSHOT-bin.zip
+    && unzip /lighty-community-restconf-ofp-app-14.3.0-bin.zip \
+    && rm /lighty-community-restconf-ofp-app-14.3.0-bin.zip
 
 
 ##libstdc++ is required by leveldbjni-1.8 (Akka dispatcher)
 #Uncaught error from thread [opendaylight-cluster-data-akka.persistence.dispatchers.default-plugin-dispatcher-22]: Could not load library. Reasons: [no leveldbjni64-1.8 in java.library.path, no leveldbjni-1.8 in java.library.path, no leveldbjni in java.library.path, /tmp/libleveldbjni-64-1-3166161234556196376.8: Error loading shared library libstdc++.so.6: No such file or directory (needed by /tmp/libleveldbjni-64-1-3166161234556196376.8)], shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled for ActorSystem[opendaylight-cluster-data]
 RUN apt-get install libstdc++6
 
-WORKDIR /lighty-community-restconf-ofp-app-14.2.2-SNAPSHOT
+WORKDIR /lighty-community-restconf-ofp-app-14.3.0
 
 EXPOSE 8888
 EXPOSE 8185
@@ -19,4 +19,4 @@ EXPOSE 6653
 EXPOSE 2550
 EXPOSE 80
 
-CMD java -jar lighty-community-restconf-ofp-app-14.2.2-SNAPSHOT.jar sampleConfigSingleNode.json
+CMD java -jar lighty-community-restconf-ofp-app-14.3.0.jar sampleConfigSingleNode.json

--- a/lighty-examples/lighty-community-restconf-ofp-app/README.md
+++ b/lighty-examples/lighty-community-restconf-ofp-app/README.md
@@ -12,7 +12,7 @@ Build the project using maven command: ```mvn clean install```.
 This will create *.zip* archive in target directory. Extract this archive
 and run *.jar* file using java with command:
 ```
-java -jar lighty-community-restconf-ofp-app-14.2.2-SNAPSHOT.jar
+java -jar lighty-community-restconf-ofp-app-14.3.0.jar
 ```
 
 ### Use custom config files
@@ -24,7 +24,7 @@ after build.
 
 When running application pass path to configuration file as argument:
 ```
-java -jar lighty-community-restconf-ofp-app-14.2.2-SNAPSHOT.jar sampleConfigSingleNode.json
+java -jar lighty-community-restconf-ofp-app-14.3.0.jar sampleConfigSingleNode.json
 ```
 
 ### Building and running Docker Image

--- a/lighty-examples/lighty-controller-springboot-netconf/README.md
+++ b/lighty-examples/lighty-controller-springboot-netconf/README.md
@@ -46,7 +46,7 @@ mvn spring-boot:run
 or
 
 ```
-java -jar target/lighty-controller-springboot-14.2.2-SNAPSHOT.jar
+java -jar target/lighty-controller-springboot-14.3.0.jar
 ```
 
 or in any IDE, run main in 

--- a/lighty-examples/lighty-gnmi-community-restconf-app/README.md
+++ b/lighty-examples/lighty-gnmi-community-restconf-app/README.md
@@ -42,22 +42,22 @@ cd lighty-examples/lighty-gnmi-community-restconf-app
 ### Start RCgNMI controller app
 Unzip lighty-rcgnmi-app to current location
 ```
-unzip ../../lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/target/lighty-rcgnmi-app-14.2.2-SNAPSHOT-bin.zip
+unzip ../../lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/target/lighty-rcgnmi-app-14.3.0-bin.zip
 ```
 Start application with pre-prepared configuration [example_config.json](example_config.json).
 ```
-java -jar lighty-rcgnmi-app-14.2.2-SNAPSHOT/lighty-rcgnmi-app-14.2.2-SNAPSHOT.jar -c example_config.json
+java -jar lighty-rcgnmi-app-14.3.0/lighty-rcgnmi-app-14.3.0.jar -c example_config.json
 ```
 
 ### Start lighty.io gNMI device simulator
 Unzip gNMI simulator app to current folder.
 ```
-unzip ../../lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/target/lighty-gnmi-device-simulator-14.2.2-SNAPSHOT-bin.zip
+unzip ../../lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/target/lighty-gnmi-device-simulator-14.3.0-bin.zip
 ```
 
 Start the application with pre-prepared configuration [simulator_config.json](simulator/simulator_config.json)
 ```
-java -jar lighty-gnmi-device-simulator-14.2.2-SNAPSHOT/lighty-gnmi-device-simulator-14.2.2-SNAPSHOT.jar  -c simulator/simulator_config.json 
+java -jar lighty-gnmi-device-simulator-14.3.0/lighty-gnmi-device-simulator-14.3.0.jar  -c simulator/simulator_config.json 
 ```
 
 ### Add client certificates to lighty.io gNMI keystore

--- a/lighty-examples/lighty-gnmi-community-restconf-app/README.md
+++ b/lighty-examples/lighty-gnmi-community-restconf-app/README.md
@@ -11,10 +11,10 @@ To communicate with gNMI device it is required to use TLS communication with cer
 authorization.
 
 This application starts:
-* [Lighty.io Controller](https://github.com/PANTHEONtech/lighty/tree/master/lighty-core/lighty-controller) with modules:
-  * [lighty.io RESTCONF module](https://github.com/PANTHEONtech/lighty/tree/master/lighty-modules/lighty-restconf-nb-community)
-  * [lighty.io gNMI module](https://github.com/PANTHEONtech/lighty/tree/master/lighty-modules/lighty-gnmi/lighty-gnmi-sb)
-* [lighty.io gNMI device simulator](https://github.com/PANTHEONtech/lighty/tree/14.0.x/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator)
+* [Lighty.io Controller](https://github.com/PANTHEONtech/lighty/tree/14.3.0/lighty-core/lighty-controller) with modules:
+  * [lighty.io RESTCONF module](https://github.com/PANTHEONtech/lighty/tree/14.3.0/lighty-modules/lighty-restconf-nb-community)
+  * [lighty.io gNMI module](https://github.com/PANTHEONtech/lighty/tree/14.3.0/lighty-modules/lighty-gnmi/lighty-gnmi-sb)
+* [lighty.io gNMI device simulator](https://github.com/PANTHEONtech/lighty/tree/14.3.0/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator)
 
 ![lighty.io gNMI / RESTCONF architecture](docs/lighty-gnmi-restconf-architecture.png)
 

--- a/lighty-models/README.md
+++ b/lighty-models/README.md
@@ -56,7 +56,7 @@ my-model/pom.xml
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>14.2.2-SNAPSHOT</version>
+        <version>14.3.0</version>
         <relativePath/>
     </parent>
 

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/README.md
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/README.md
@@ -8,7 +8,7 @@ This simulator provides gNMI device driven by gNMI proto files, with datastore d
    <dependency>
       <groupId>io.lighty.modules.gnmi</groupId>
       <artifactId>lighty-gnmi-device-simulator</artifactId>
-      <version>14.2.2-SNAPSHOT</version>
+      <version>14.3.0</version>
    </dependency>
 ```
 

--- a/lighty-modules/lighty-netconf-sb/README.md
+++ b/lighty-modules/lighty-netconf-sb/README.md
@@ -42,7 +42,7 @@ To use NETCONF in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-netconf-sb</artifactId>
-    <version>14.2.2-SNAPSHOT</version>
+    <version>14.3.0</version>
   </dependency>  
 ```
 2. Initialize and start an instance of NETCONF SBP in your code:

--- a/lighty-modules/lighty-openflow-sb/README.md
+++ b/lighty-modules/lighty-openflow-sb/README.md
@@ -10,7 +10,7 @@ is Lighty's version of openflow plugin.
 <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-openflow-sb</artifactId>
-    <version>14.2.2-SNAPSHOT</version>
+    <version>14.3.0</version>
 </dependency>
 ```
 

--- a/lighty-modules/lighty-restconf-nb-community/README.md
+++ b/lighty-modules/lighty-restconf-nb-community/README.md
@@ -12,7 +12,7 @@ To use RESTCONF in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-restconf-nb-community</artifactId>
-    <version>14.2.2-SNAPSHOT</version>
+    <version>14.3.0</version>
   </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-        <tag>14.2.2-SNAPSHOT</tag>
+        <tag>14.3.0</tag>
     </scm>
     <developers>
         <developer>


### PR DESCRIPTION
Update upstream dependencies to Silicon SR3 release versions:

-  odlparent 8.1.4
-  aaa-artifacts 0.13.7
-  controller-artifacts 3.0.12
-  bundle-parent 3.0.12
-  infrautils-artifacts 1.9.10
-  mdsal-artifacts 7.0.10
-  netconf-artifacts 1.13.5
-  yangtools-artifacts 6.0.8
- openflowplugin-artifacts 0.12.3
- serviceutils-artifacts 0.7.3
-  yang-maven-plugin 6.0.8
-  mdsal-binding-java-api-generator 7.0.10
-  checkstyle 8.1.4