### PR TITLE
Update k8s and helm versions inside RNC & RCgNMI apps to the latest - Master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,16 +75,16 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.3.0
+        uses: manusa/actions-setup-minikube@v2.4.2
         with:
-          minikube version: 'v1.17.1'
-          kubernetes version: 'v1.15.11'
+          minikube version: 'v1.24.0'
+          kubernetes version: 'v1.22.4'
       - name: Start Minikube cluster
         run: minikube start
-      - name: Install helm v2.17.0
-        uses: azure/setup-helm@v1
+      - name: Install helm v3.6.2
+        uses: azure/setup-helm@v1.1
         with:
-          version: '2.17.0'
+          version: '3.7.1'
       - name: "Setup, Install and Test. App: lighty_rnc_app"
         uses: ./.github/workflows/test-lighty-app-action
         with:
@@ -108,16 +108,16 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.3.0
+        uses: manusa/actions-setup-minikube@v2.4.2
         with:
-          minikube version: 'v1.17.1'
-          kubernetes version: 'v1.15.11'
+          minikube version: 'v1.24.0'
+          kubernetes version: 'v1.22.4'
       - name: Start Minikube cluster
         run: minikube start
-      - name: Install helm v2.17.0
-        uses: azure/setup-helm@v1
+      - name: Install helm v3.6.2
+        uses: azure/setup-helm@v1.1
         with:
-          version: '2.17.0'
+          version: '3.7.1'
       - name: "Setup, Install and Test. App: lighty_rcgnmi_app"
         uses: ./.github/workflows/test-lighty-app-action
         with:

--- a/.github/workflows/test-lighty-app-action/action.yml
+++ b/.github/workflows/test-lighty-app-action/action.yml
@@ -11,14 +11,6 @@ runs:
       run: |
         sudo apt-get -y install socat
       shell: bash
-    - name: Load image to minikube
-      run: |
-        minikube kubectl -- create serviceaccount tiller --namespace kube-system
-        minikube kubectl -- create clusterrolebinding tiller-cluster-rule \
-        --clusterrole=cluster-admin \
-        --serviceaccount=kube-system:tiller
-        helm init --stable-repo-url https://charts.helm.sh/stable --service-account tiller --wait
-      shell: bash
     - name: Helm version
       run: helm version
       shell: bash

--- a/.github/workflows/test-lighty-app-action/action.yml
+++ b/.github/workflows/test-lighty-app-action/action.yml
@@ -31,7 +31,7 @@ runs:
       shell: bash
     - name: Install app helm chart
       run: |
-        helm install lighty-applications/${{ inputs.app-name }}-aggregator/${{ inputs.app-name }}-helm/helm/${{ inputs.app-name }}-helm --name ${{ inputs.app-name }}
+        helm install ${{ inputs.app-name }} lighty-applications/${{ inputs.app-name }}-aggregator/${{ inputs.app-name }}-helm/helm/${{ inputs.app-name }}-helm
         sleep 35 # Wait for app to start
       shell: bash
     - name: Run apps testing scripts

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/README.md
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/README.md
@@ -361,15 +361,15 @@ For additional configurable parameters and their explanation, see previous chapt
 
 ## Deployment via helm chart
 ### Prerequisites
-* Kubernetes cluster 1.15.11 (minikube, microk8s, etc.)
-* Helm 2.17
+* Kubernetes cluster 1.22.4 (minikube, microk8s, etc.)
+* Helm 3.7.1
 
 ### Deploy
 To easily deploy the lighty.io RcGNMI application to Kubernetes, we provide a custom helm chart located [here](lighty-rcgnmi-app-helm/helm).
 
 To install, make sure that the docker image defined in `values.yaml` is accessible in your kubernetes (for microk8s you can use the [docker-microk8s-script](lighty-rcgnmi-app-helm/helm/microk8s-uploadDocker.sh)), then run the command:
 
-`microk8s helm install --name lighty-rcgnmi-app ./lighty-rcgnmi-app-helm/`
+`microk8s helm3 install lighty-rcgnmi-app ./lighty-rcgnmi-app-helm/`
 
 in the `/lighty-rcgnmi-app-helm/helm/` directory.  
 

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/ingress.yaml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.useIngress }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "lighty-rcgnmi-app-helm.fullname" . }}
@@ -9,16 +9,22 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: {{ include "lighty-rcgnmi-app-helm.fullname" . }}
-              servicePort: {{ .Values.lighty.restconf.restconfPort }}
+              service:
+                name: {{ include "lighty-rcgnmi-app-helm.fullname" . }}
+                port:
+                  number: {{ .Values.lighty.restconf.restconfPort }}
     {{- if .Values.ingress.exposeManagement }}
     - host: {{ .Values.ingress.managementHost }}
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: {{ include "lighty-rcgnmi-app-helm.fullname" . }}
-              servicePort: {{ .Values.lighty.akka.managementPort }}
+              service:
+                name: {{ include "lighty-rcgnmi-app-helm.fullname" . }}
+                port:
+                  number: {{ .Values.lighty.akka.managementPort }}
     {{- end }}
   {{- end }}

--- a/lighty-applications/lighty-rnc-app-aggregator/README.md
+++ b/lighty-applications/lighty-rnc-app-aggregator/README.md
@@ -128,12 +128,12 @@ For convenience, we provide [postman-collection](lighty-rnc-app/Lighty-RNC.postm
 _Note: IP addresses and port numbers may differ depending on deployment._
 ## Deployment via helm chart
 ### Prerequisites
-* Kubernetes cluster 1.15.11 (minikube / microk8s /..)
-* helm 2.17
+* Kubernetes cluster 1.22.4 (minikube / microk8s /..)
+* helm 3.7.1
 ### Deploy
 To easily deploy the lighty.io RNC application to Kubernetes, we provide a custom helm chart located in /lighty-rnc-app-helm/helm/.
 To install, make sure that the Docker image is defined in `values.yaml` and accessible, then run command:
-`helm install microk8s helm install --name lighty-rnc-app ./lighty-rnc-app-helm/`
+`microk8s helm3 install --name lighty-rnc-app ./lighty-rnc-app-helm/`
 in the `/lighty-rnc-app-helm/helm/` directory.
 ### Providing startup configuration
 By default, the deployed application is started with a custom configuration.json 

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/ingress.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.useIngress }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "lighty-rnc-app-helm.fullname" . }}
@@ -9,16 +9,22 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: {{ include "lighty-rnc-app-helm.fullname" . }}
-              servicePort: {{ .Values.lighty.restconf.restconfPort }}
+              service:
+                name: {{ include "lighty-rnc-app-helm.fullname" . }}
+                port:
+                  number: {{ .Values.lighty.restconf.restconfPort }}
     {{- if .Values.ingress.exposeManagement }}
     - host: {{ .Values.ingress.managementHost }}
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: {{ include "lighty-rnc-app-helm.fullname" . }}
-              servicePort: {{ .Values.lighty.akka.managementPort }}
+              service:
+                name: {{ include "lighty-rnc-app-helm.fullname" . }}
+                port:
+                  number: {{ .Values.lighty.akka.managementPort }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
-  kubernetes                                      1.15.11 -> 1.22.4
-  minikube                                         1.17.1   -> 1.24.0
-  helm                                                2.17.0   -> 3.7.1
- Azure/setup-helm                           v1         -> v1.1
- manusa/actions-setup-minikube    2.3.0     -> 2.4.2