### PR TITLE
 Uncomment tests for restconf/operations after fix in upstream

### DIFF
--- a/.github/workflows/lighty-rcgnmi-app/tests-lighty-rcgnmi-app.sh
+++ b/.github/workflows/lighty-rcgnmi-app/tests-lighty-rcgnmi-app.sh
@@ -90,17 +90,16 @@ do \
 ;done
 sleep 1
 
-# Pods healthcheck (:8888/restconf/operations)
-# TODO: Uncomment after bump to ODL netconf version 2.0.6 and yangtools 7.0.9. Where is this bug resolved https://jira.opendaylight.org/browse/NETCONF-822
+Pods healthcheck (:8888/restconf/operations)
 
-#for pod_controller_ip in $POD_CONTROLLER_IPS; \
-#do \
-#  assertHttpStatusCode $(curl -o /dev/null -s -w "%{http_code} GET %{url_effective}\n" --user admin:admin -H "Content-Type: application/json" --insecure http://$pod_controller_ip:8888/restconf/operations) \
-#;done
-#sleep 1
-#
-## Service healthcheck (:30888/restconf/operations)
-#assertHttpStatusCode $(curl -o /dev/null -s -w "%{http_code} GET %{url_effective}\n" --user admin:admin -H "Content-Type: application/json" --insecure http://$MINIKUBE_IP:$CONTROLLER_PORT/restconf/operations)
+for pod_controller_ip in $POD_CONTROLLER_IPS; \
+do \
+  assertHttpStatusCode $(curl -o /dev/null -s -w "%{http_code} GET %{url_effective}\n" --user admin:admin -H "Content-Type: application/json" --insecure http://$pod_controller_ip:8888/restconf/operations) \
+;done
+sleep 1
+
+ Service healthcheck (:30888/restconf/operations)
+assertHttpStatusCode $(curl -o /dev/null -s -w "%{http_code} GET %{url_effective}\n" --user admin:admin -H "Content-Type: application/json" --insecure http://$MINIKUBE_IP:$CONTROLLER_PORT/restconf/operations)
 
 # add gNMI node into gNMI topology
 assertHttpStatusCode $(curl -X PUT -o /dev/null -s -w "%{http_code} PUT %{url_effective}\n" \

--- a/.github/workflows/lighty-rcgnmi-app/tests-lighty-rcgnmi-app.sh
+++ b/.github/workflows/lighty-rcgnmi-app/tests-lighty-rcgnmi-app.sh
@@ -98,7 +98,7 @@ do \
 ;done
 sleep 1
 
- Service healthcheck (:30888/restconf/operations)
+#Service healthcheck (:30888/restconf/operations)
 assertHttpStatusCode $(curl -o /dev/null -s -w "%{http_code} GET %{url_effective}\n" --user admin:admin -H "Content-Type: application/json" --insecure http://$MINIKUBE_IP:$CONTROLLER_PORT/restconf/operations)
 
 # add gNMI node into gNMI topology

--- a/.github/workflows/lighty-rcgnmi-app/tests-lighty-rcgnmi-app.sh
+++ b/.github/workflows/lighty-rcgnmi-app/tests-lighty-rcgnmi-app.sh
@@ -90,7 +90,7 @@ do \
 ;done
 sleep 1
 
-Pods healthcheck (:8888/restconf/operations)
+#Pods healthcheck (:8888/restconf/operations)
 
 for pod_controller_ip in $POD_CONTROLLER_IPS; \
 do \

--- a/.github/workflows/lighty-rnc-app/tests-lighty-rnc-app.sh
+++ b/.github/workflows/lighty-rnc-app/tests-lighty-rnc-app.sh
@@ -82,7 +82,6 @@ do \
 sleep 1
 
 # Pods healthcheck (:8888/restconf/operations)
-# TODO: Uncomment after bump to ODL netconf version 2.0.6 and yangtools 7.0.9. Where is this bug resolved https://jira.opendaylight.org/browse/NETCONF-822
 
 for pod_controller_ip in $POD_CONTROLLER_IPS; \
 do \

--- a/.github/workflows/lighty-rnc-app/tests-lighty-rnc-app.sh
+++ b/.github/workflows/lighty-rnc-app/tests-lighty-rnc-app.sh
@@ -84,15 +84,15 @@ sleep 1
 # Pods healthcheck (:8888/restconf/operations)
 # TODO: Uncomment after bump to ODL netconf version 2.0.6 and yangtools 7.0.9. Where is this bug resolved https://jira.opendaylight.org/browse/NETCONF-822
 
-#for pod_controller_ip in $POD_CONTROLLER_IPS; \
-#do \
-#  assertHttpStatusCode $(curl -o /dev/null -s -w "%{http_code} GET %{url_effective}\n" --user admin:admin -H "Content-Type: application/json" --insecure http://$pod_controller_ip:8888/restconf/operations) \
-#;done
-#sleep 1
-#
-## Service healthcheck (:30888/restconf/operations)
-#assertHttpStatusCode $(curl -o /dev/null -s -w "%{http_code} GET %{url_effective}\n" --user admin:admin -H "Content-Type: application/json" --insecure http://$MINIKUBE_IP:$CONTROLLER_PORT/restconf/operations)
-#sleep 1
+for pod_controller_ip in $POD_CONTROLLER_IPS; \
+do \
+  assertHttpStatusCode $(curl -o /dev/null -s -w "%{http_code} GET %{url_effective}\n" --user admin:admin -H "Content-Type: application/json" --insecure http://$pod_controller_ip:8888/restconf/operations) \
+;done
+sleep 1
+
+# Service healthcheck (:30888/restconf/operations)
+assertHttpStatusCode $(curl -o /dev/null -s -w "%{http_code} GET %{url_effective}\n" --user admin:admin -H "Content-Type: application/json" --insecure http://$MINIKUBE_IP:$CONTROLLER_PORT/restconf/operations)
+sleep 1
 
 # add node into topology
   assertHttpStatusCode $(curl -X PUT -o /dev/null -s -w "%{http_code} PUT %{url_effective}\n" http://"$MINIKUBE_IP":$CONTROLLER_PORT/restconf/data/network-topology:network-topology/topology=topology-netconf/node=node-"${SIMULATOR_IP//.}" \

--- a/lighty-examples/lighty-community-restconf-actions-app/src/test/java/io/lighty/examples/controller/actions/RestconfActionsAppTest.java
+++ b/lighty-examples/lighty-community-restconf-actions-app/src/test/java/io/lighty/examples/controller/actions/RestconfActionsAppTest.java
@@ -54,12 +54,8 @@ public class RestconfActionsAppTest {
     @Test
     public void simpleApplicationTest() throws Exception {
         HttpResponse<String> operations;
-        /*
-        TODO: Uncomment after bump to ODL netconf version 2.0.6 and yangtools 7.0.9.
-              Where is this bug resolved https://jira.opendaylight.org/browse/NETCONF-822
         operations = restClient.GET("restconf/operations");
-        Assert.assertEquals(operations.statusCode(), 200);
-         */
+        assertEquals(operations.statusCode(), 200);
         operations = restClient.GET("restconf/data/network-topology:network-topology?content=config");
         assertEquals(operations.statusCode(), 200);
         operations = restClient.GET("restconf/data/network-topology:network-topology?content=nonconfig");

--- a/lighty-examples/lighty-community-restconf-netconf-app/src/test/java/io/lighty/examples/controllers/restconfapp/tests/RestconfAppTest.java
+++ b/lighty-examples/lighty-community-restconf-netconf-app/src/test/java/io/lighty/examples/controllers/restconfapp/tests/RestconfAppTest.java
@@ -47,12 +47,8 @@ public class RestconfAppTest {
     @Test
     public void simpleApplicationTest() throws IOException, InterruptedException {
         HttpResponse<String> operations;
-        /*
-        TODO: Uncomment after bump to ODL netconf version 2.0.6 and yangtools 7.0.9.
-              Where is this bug resolved https://jira.opendaylight.org/browse/NETCONF-822
         operations = restClient.GET("restconf/operations");
         Assert.assertEquals(operations.statusCode(), 200);
-         */
         operations = restClient.GET("restconf/data/network-topology:network-topology?content=config");
         Assert.assertEquals(operations.statusCode(), 200);
         operations = restClient.GET("restconf/data/network-topology:network-topology?content=nonconfig");


### PR DESCRIPTION
Uncommented assertion after netconf 2.0.6 & yangtools 7.0.9 bump.