### PR TITLE
Close gracefully lighty application when exception is thrown - Master

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppException.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppException.java
@@ -10,6 +10,14 @@ package io.lighty.applications.rcgnmi.module;
 
 public class RcGnmiAppException extends Exception {
 
+    public RcGnmiAppException() {
+        super();
+    }
+
+    public RcGnmiAppException(Throwable cause) {
+        super(cause);
+    }
+
     public RcGnmiAppException(String message) {
         super(message);
     }

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
 public class RcGnmiAppModule extends AbstractLightyModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(RcGnmiAppModule.class);
-    private static final long DEFAULT_LIGHTY_MODULE_TIMEOUT = 60;
+    private static final long DEFAULT_LIGHTY_MODULE_TIMEOUT = 90;
     private static final TimeUnit DEFAULT_LIGHTY_MODULE_TIME_UNIT = TimeUnit.SECONDS;
 
     private final RcGnmiAppConfiguration appModuleConfig;

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
@@ -162,7 +162,7 @@ public class RcGnmiAppModule extends AbstractLightyModule {
         if (this.lightyController != null && !stopAndWaitLightyModule(this.lightyController)) {
             success = false;
         }
-        if (this.lightyController != null && !stopAndWaitLightyModule(this.gnmiSouthboundModule)) {
+        if (this.gnmiSouthboundModule != null && !stopAndWaitLightyModule(this.gnmiSouthboundModule)) {
             success = false;
         }
 

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/RCgNMIApp.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/RCgNMIApp.java
@@ -12,6 +12,7 @@ import com.beust.jcommander.JCommander;
 import com.google.common.base.Stopwatch;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.lighty.applications.rcgnmi.module.RcGnmiAppConfiguration;
+import io.lighty.applications.rcgnmi.module.RcGnmiAppException;
 import io.lighty.applications.rcgnmi.module.RcGnmiAppModule;
 import io.lighty.applications.rcgnmi.module.RcGnmiAppModuleConfigUtils;
 import io.lighty.core.common.models.YangModuleUtils;
@@ -42,11 +43,16 @@ public class RCgNMIApp {
     @SuppressWarnings("squid:S4823")
     public static void main(final String[] args) {
         final RCgNMIApp app = new RCgNMIApp();
-        app.start(args);
+        try {
+            app.start(args);
+        } catch (RcGnmiAppException e) {
+            LOG.error(UNABLE_TO_START_APPLICATION, e);
+            System.exit(0);
+        }
     }
 
     @SuppressFBWarnings("SLF4J_SIGN_ONLY_FORMAT")
-    public void start(final String[] args) {
+    public void start(final String[] args) throws RcGnmiAppException {
         final Stopwatch stopwatch = Stopwatch.createStarted();
         LOG.info(".__  .__       .__     __              .__           ");
         LOG.info("|  | |__| ____ |  |___/  |_ ___.__.    |__| ____     ");
@@ -98,16 +104,16 @@ public class RCgNMIApp {
                 registerShutdownHook(rcgnmiLightyModule);
                 LOG.info("RCgNMI lighty.io application started in {}", stopwatch.stop());
             } else {
-                LOG.error(UNABLE_TO_START_APPLICATION);
                 stop();
+                throw new RcGnmiAppException();
             }
         } catch (ExecutionException e) {
-            LOG.error(UNABLE_TO_START_APPLICATION, e);
             stop();
+            throw new RcGnmiAppException(e);
         } catch (InterruptedException e) {
-            LOG.error(UNABLE_TO_START_APPLICATION, e);
             Thread.currentThread().interrupt();
             stop();
+            throw new RcGnmiAppException(e);
         }
 
     }

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/RCgNMIApp.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/RCgNMIApp.java
@@ -30,9 +30,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RCgNMIApp {
-    private static final Logger LOG = LoggerFactory.getLogger(RCgNMIApp.class);
 
-    private static final String UNABLE_TO_START_APPLICATION = "Unable to start lighty.io application!";
+    private static final Logger LOG = LoggerFactory.getLogger(RCgNMIApp.class);
+    private static final String UNABLE_TO_START_APPLICATION = "Unable to start RCgNMI lighty.io application!";
+    private static final String UNABLE_TO_STOP_APPLICATION
+            = "Exception was thrown while shutting down RCgNMI lighty.io application!";
 
     private AbstractLightyModule rcgnmiLightyModule;
 
@@ -92,12 +94,11 @@ public class RCgNMIApp {
         try {
             final boolean hasStarted = rcgnmiLightyModule.start().get();
             if (hasStarted) {
-                // Register shutdown hook for graceful shutdown
                 LOG.info("Registering ShutdownHook to gracefully shutdown application");
                 registerShutdownHook(rcgnmiLightyModule);
                 LOG.info("RCgNMI lighty.io application started in {}", stopwatch.stop());
             } else {
-                LOG.error("Unable to start RCgNMI lighty.io application!");
+                LOG.error(UNABLE_TO_START_APPLICATION);
                 stop();
             }
         } catch (ExecutionException e) {
@@ -124,15 +125,17 @@ public class RCgNMIApp {
     }
 
     private void shutdownModule(final AbstractLightyModule module) {
-        try {
-            LOG.info("ShutdownHook triggered. Shutting down RCgNMI lighty.io application...");
-            module.shutdown().get();
-            LOG.info("RCgNMI lighty.io application was shut down!");
-        } catch (ExecutionException e) {
-            LOG.error(UNABLE_TO_START_APPLICATION, e);
-        } catch (InterruptedException e) {
-            LOG.error("Unable to shut down RCgNMI lighty.io application! Exception was thrown!", e);
-            Thread.currentThread().interrupt();
+        if (module != null) {
+            try {
+                LOG.info("ShutdownHook triggered. Shutting down RCgNMI lighty.io application...");
+                module.shutdown().get();
+                LOG.info("RCgNMI lighty.io application was shut down!");
+            } catch (ExecutionException e) {
+                LOG.error(UNABLE_TO_STOP_APPLICATION, e);
+            } catch (InterruptedException e) {
+                LOG.error(UNABLE_TO_STOP_APPLICATION, e);
+                Thread.currentThread().interrupt();
+            }
         }
     }
 

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/RCgNMIApp.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/RCgNMIApp.java
@@ -98,12 +98,15 @@ public class RCgNMIApp {
                 LOG.info("RCgNMI lighty.io application started in {}", stopwatch.stop());
             } else {
                 LOG.error("Unable to start RCgNMI lighty.io application!");
+                stop();
             }
         } catch (ExecutionException e) {
             LOG.error(UNABLE_TO_START_APPLICATION, e);
+            stop();
         } catch (InterruptedException e) {
             LOG.error(UNABLE_TO_START_APPLICATION, e);
             Thread.currentThread().interrupt();
+            stop();
         }
 
     }

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/test/java/io/lighty/applications/rcgnmi/app/RCgNMIAppTest.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/test/java/io/lighty/applications/rcgnmi/app/RCgNMIAppTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.util.concurrent.Futures;
+import io.lighty.applications.rcgnmi.module.RcGnmiAppException;
 import io.lighty.applications.rcgnmi.module.RcGnmiAppModule;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -20,7 +21,7 @@ import org.mockito.Mockito;
 public class RCgNMIAppTest {
 
     @Test
-    public void testStartWithDefaultConfiguration() {
+    public void testStartWithDefaultConfiguration() throws RcGnmiAppException {
         final RCgNMIApp app = Mockito.spy(new RCgNMIApp());
         final RcGnmiAppModule appModule = Mockito.mock(RcGnmiAppModule.class);
         doReturn(Futures.immediateFuture(true)).when(appModule).start();
@@ -31,7 +32,7 @@ public class RCgNMIAppTest {
     }
 
     @Test
-    public void testStartWithConfigFile() {
+    public void testStartWithConfigFile() throws RcGnmiAppException {
         final RCgNMIApp app = Mockito.spy(new RCgNMIApp());
         final RcGnmiAppModule appModule = Mockito.mock(RcGnmiAppModule.class);
         doReturn(Futures.immediateFuture(true)).when(appModule).start();
@@ -42,7 +43,7 @@ public class RCgNMIAppTest {
     }
 
     @Test
-    public void testStartWithConfigFileNoSuchFile() {
+    public void testStartWithConfigFileNoSuchFile() throws RcGnmiAppException {
         final RCgNMIApp app = Mockito.spy(new RCgNMIApp());
         app.start(new String[]{"-c", "no_config.json"});
         verify(app, Mockito.times(0)).createRgnmiAppModule(any(), any(), any());

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Main.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Main.java
@@ -14,6 +14,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.lighty.applications.rnc.module.RncLightyModule;
 import io.lighty.applications.rnc.module.config.RncLightyModuleConfigUtils;
 import io.lighty.applications.rnc.module.config.RncLightyModuleConfiguration;
+import io.lighty.applications.rnc.module.exception.RncLightyAppStartException;
 import io.lighty.core.common.models.YangModuleUtils;
 import io.lighty.core.controller.api.AbstractLightyModule;
 import io.lighty.core.controller.impl.config.ConfigurationException;
@@ -48,11 +49,16 @@ public class Main {
     @SuppressWarnings("squid:S4823")
     public static void main(final String[] args) {
         Main app = new Main();
-        app.start(args);
+        try {
+            app.start(args);
+        } catch (RncLightyAppStartException e) {
+            LOG.error(UNABLE_TO_START_APPLICATION, e);
+            System.exit(0);
+        }
     }
 
     @SuppressFBWarnings("SLF4J_SIGN_ONLY_FORMAT")
-    public void start(final String[] args) {
+    public void start(final String[] args) throws RncLightyAppStartException {
         final Stopwatch stopwatch = Stopwatch.createStarted();
         LOG.info(".__  .__       .__     __              .__           ");
         LOG.info("|  | |__| ____ |  |___/  |_ ___.__.    |__| ____     ");
@@ -109,16 +115,16 @@ public class Main {
                 registerShutdownHook(this.rncLightyModule);
                 LOG.info("RNC lighty.io application started in {}", stopwatch.stop());
             } else {
-                LOG.error(UNABLE_TO_START_APPLICATION);
                 stop();
+                throw new RncLightyAppStartException();
             }
         } catch (ExecutionException e) {
-            LOG.error(UNABLE_TO_START_APPLICATION, e);
             stop();
+            throw new RncLightyAppStartException(e);
         } catch (InterruptedException e) {
-            LOG.error(UNABLE_TO_START_APPLICATION, e);
             Thread.currentThread().interrupt();
             stop();
+            throw new RncLightyAppStartException(e);
         }
     }
 

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Main.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Main.java
@@ -36,21 +36,23 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Main {
-    private static final Logger LOG = LoggerFactory.getLogger(Main.class);
 
-    private static final String UNABLE_TO_START_APPLICATION = "Unable to start lighty.io application!";
+    private static final Logger LOG = LoggerFactory.getLogger(Main.class);
+    private static final String UNABLE_TO_START_APPLICATION = "Unable to start RNC lighty.io application!";
+    private static final String UNABLE_TO_STOP_APPLICATION
+            = "Exception was thrown while shutting down RNC lighty.io application!";
 
     private AbstractLightyModule rncLightyModule;
 
     // Using args is safe as we need only a configuration file location here
     @SuppressWarnings("squid:S4823")
-    public static void main(String[] args) {
+    public static void main(final String[] args) {
         Main app = new Main();
         app.start(args);
     }
 
     @SuppressFBWarnings("SLF4J_SIGN_ONLY_FORMAT")
-    public void start(String[] args) {
+    public void start(final String[] args) {
         final Stopwatch stopwatch = Stopwatch.createStarted();
         LOG.info(".__  .__       .__     __              .__           ");
         LOG.info("|  | |__| ____ |  |___/  |_ ___.__.    |__| ____     ");
@@ -103,7 +105,6 @@ public class Main {
         try {
             Boolean hasStarted = this.rncLightyModule.start().get();
             if (hasStarted) {
-                // Register shutdown hook for graceful shutdown
                 LOG.info("Registering ShutdownHook to gracefully shutdown application");
                 registerShutdownHook(this.rncLightyModule);
                 LOG.info("RNC lighty.io application started in {}", stopwatch.stop());
@@ -121,11 +122,11 @@ public class Main {
         }
     }
 
-    public RncLightyModule createRncLightyModule(RncLightyModuleConfiguration rncModuleConfig) {
+    public RncLightyModule createRncLightyModule(final RncLightyModuleConfiguration rncModuleConfig) {
         return new RncLightyModule(rncModuleConfig);
     }
 
-    private void registerShutdownHook(AbstractLightyModule application) {
+    private void registerShutdownHook(final AbstractLightyModule application) {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             shutdownModule(application);
         }));
@@ -138,9 +139,9 @@ public class Main {
                 module.shutdown().get();
                 LOG.info("RNC lighty.io application was shut down!");
             } catch (ExecutionException e) {
-                LOG.error(UNABLE_TO_START_APPLICATION, e);
+                LOG.error(UNABLE_TO_STOP_APPLICATION, e);
             } catch (InterruptedException e) {
-                LOG.error("Unable to shut down RNC lighty.io application! Exception was thrown!", e);
+                LOG.error(UNABLE_TO_STOP_APPLICATION, e);
                 Thread.currentThread().interrupt();
             }
         }
@@ -160,10 +161,10 @@ public class Main {
      * @throws InstanceAlreadyExistsException if MBean is already registered
      * @throws MBeanRegistrationException if MBean cant be registered
      */
-    private void registerLoggerMBeans(MBeanServer server) throws MalformedObjectNameException,
+    private void registerLoggerMBeans(final MBeanServer server) throws MalformedObjectNameException,
             NotCompliantMBeanException, InstanceAlreadyExistsException, MBeanRegistrationException {
 
-        HierarchyDynamicMBean hierarchyDynamicMBean = new HierarchyDynamicMBean();
+        final HierarchyDynamicMBean hierarchyDynamicMBean = new HierarchyDynamicMBean();
         final ObjectName mbo = new ObjectName("log4j:hierarchy=LoggerHierarchy");
         server.registerMBean(hierarchyDynamicMBean, mbo);
 

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/test/java/io/lighty/applications/rnc/app/MainTest.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/test/java/io/lighty/applications/rnc/app/MainTest.java
@@ -16,12 +16,13 @@ import static org.mockito.Mockito.verify;
 
 import com.google.common.util.concurrent.Futures;
 import io.lighty.applications.rnc.module.RncLightyModule;
+import io.lighty.applications.rnc.module.exception.RncLightyAppStartException;
 import org.testng.annotations.Test;
 
 public class MainTest {
 
     @Test
-    public void testStartWithDefaultConfiguration() {
+    public void testStartWithDefaultConfiguration() throws RncLightyAppStartException {
         Main app = spy(new Main());
         RncLightyModule lighty = mock(RncLightyModule.class);
         doReturn(Futures.immediateFuture(true)).when(lighty).start();
@@ -31,7 +32,7 @@ public class MainTest {
     }
 
     @Test
-    public void testStartWithConfigFile() {
+    public void testStartWithConfigFile() throws RncLightyAppStartException {
         Main app = spy(new Main());
         RncLightyModule lighty = mock(RncLightyModule.class);
         doReturn(Futures.immediateFuture(true)).when(lighty).start();
@@ -41,7 +42,7 @@ public class MainTest {
     }
 
     @Test
-    public void testStartWithConfigFileNoSuchFile() {
+    public void testStartWithConfigFileNoSuchFile() throws RncLightyAppStartException {
         Main app = spy(new Main());
         verify(app, never()).createRncLightyModule(any());
         app.start(new String[] {"-c","no_config.json"});

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/RncLightyModule.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/RncLightyModule.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 public class RncLightyModule extends AbstractLightyModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(RncLightyModule.class);
-    private static final long DEFAULT_LIGHTY_MODULE_TIMEOUT = 60;
+    private static final long DEFAULT_LIGHTY_MODULE_TIMEOUT = 90;
     private static final TimeUnit DEFAULT_LIGHTY_MODULE_TIME_UNIT = TimeUnit.SECONDS;
 
     private final RncLightyModuleConfiguration rncModuleConfig;

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/exception/RncLightyAppStartException.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/exception/RncLightyAppStartException.java
@@ -9,6 +9,14 @@ package io.lighty.applications.rnc.module.exception;
 
 public class RncLightyAppStartException extends Exception {
 
+    public RncLightyAppStartException() {
+        super();
+    }
+
+    public RncLightyAppStartException(Throwable cause) {
+        super(cause);
+    }
+
     public RncLightyAppStartException(String message) {
         super(message);
     }

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiITBase.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiITBase.java
@@ -16,6 +16,7 @@ import static io.lighty.modules.gnmi.test.gnmi.rcgnmi.GnmiITBase.GeneralConstant
 
 import gnmi.Gnmi;
 import io.lighty.applications.rcgnmi.app.RCgNMIApp;
+import io.lighty.applications.rcgnmi.module.RcGnmiAppException;
 import io.lighty.modules.gnmi.simulatordevice.config.GnmiSimulatorConfiguration;
 import io.lighty.modules.gnmi.simulatordevice.impl.SimulatedGnmiDevice;
 import io.lighty.modules.gnmi.simulatordevice.utils.GnmiSimulatorConfUtils;
@@ -61,7 +62,7 @@ public abstract class GnmiITBase {
     protected static HttpClient httpClient;
 
     @BeforeAll
-    public static void setup() {
+    public static void setup() throws RcGnmiAppException {
         httpClientExecutor = Executors.newSingleThreadExecutor();
         httpClient = HttpClient.newBuilder().executor(httpClientExecutor).build();
 


### PR DESCRIPTION
- Close resources in RcGNMI and RNC application when initialization fail.
-  Increase default timeout for initializing lighty modules to 90s. In reported issue #881 was reported that lighty controller was not   initialized under 60s without addition exception message. Lighty controller initialization contain two future get call with 30s timeout. In case of longer loading, RcGNMI application can close controller initialization while waiting on one of those get calls.
- Close application RcGNMI and RNC application with System.exit(0) when initialization fail.
  Using System.exit(0) should be used with extreme care, and only when the intent is to stop the whole Java process.
  https://rules.sonarsource.com/java/RSPEC-1147 Main method is the only exception where this call can be used.