### PR TITLE
Fix closing lighty apps and add option to increase time-out - Master

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/README.md
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/README.md
@@ -32,8 +32,8 @@ To build and start the RCgNMI application in your local environment, follow thes
    Example configuration files are located on following path:  
    `lighty-rcgnmi-app-docker/example-config/*`
 
-5. (Optional) To extend lighty modules time-out use the argument `-t/--timeout-in-seconds`. This argument increases the time after which the exception is thrown if the module is not successfully initialized by then. (Default 30)
-   `java -jar lighty-rcgnmi-app-<version>.jar -t 60`
+5. (Optional) To extend lighty modules time-out use the argument `-t/--timeout-in-seconds`. This argument increases the time after which the exception is thrown if the module is not successfully initialized by then. (Default 60)
+   `java -jar lighty-rcgnmi-app-<version>.jar -t 90`
 
 6. If the application was started successfully, then a log similar should be present in the console:  
   ` INFO [main] (RCgNMIApp.java:98) - RCgNMI lighty.io application started in 10.10 s`

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/README.md
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/README.md
@@ -29,16 +29,16 @@ To build and start the RCgNMI application in your local environment, follow thes
 4. To start the application with a custom lighty.io configuration, use the argument _-c_ and for a custom initial log4j configuration, use argument _-l_:  
    `java -jar lighty-rcgnmi-app-<version>.jar -c /path/to/config-file -l /path/to/log4j-config-file`  
 
-    To extend application time-out use the argument `-t/--timeout-in-seconds`. This argument override current default application time-out set to 60s.
-    `java -jar lighty-rcgnmi-app-<version>.jar -t 90`
-
    Example configuration files are located on following path:  
    `lighty-rcgnmi-app-docker/example-config/*`
 
-5. If the application was started successfully, then a log similar should be present in the console:  
+5. (Optional) To extend lighty modules time-out use the argument `-t/--timeout-in-seconds`. This argument increases the time after which the exception is thrown if the module is not successfully initialized by then. (Default 30)
+   `java -jar lighty-rcgnmi-app-<version>.jar -t 60`
+
+6. If the application was started successfully, then a log similar should be present in the console:  
   ` INFO [main] (RCgNMIApp.java:98) - RCgNMI lighty.io application started in 10.10 s`
 
-6. Test the RCgNMI lighty.io application. Default RESTCONF port is `8888`  
+7. Test the RCgNMI lighty.io application. Default RESTCONF port is `8888`  
    The default credential for http requests is login:`admin`, password: `admin`. 
 
 ## How to Use the RCgNMI Example App

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/README.md
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/README.md
@@ -29,6 +29,9 @@ To build and start the RCgNMI application in your local environment, follow thes
 4. To start the application with a custom lighty.io configuration, use the argument _-c_ and for a custom initial log4j configuration, use argument _-l_:  
    `java -jar lighty-rcgnmi-app-<version>.jar -c /path/to/config-file -l /path/to/log4j-config-file`  
 
+    To extend application time-out use the argument `-t/--timeout-in-seconds`. This argument override current default application time-out set to 60s.
+    `java -jar lighty-rcgnmi-app-<version>.jar -t 90`
+
    Example configuration files are located on following path:  
    `lighty-rcgnmi-app-docker/example-config/*`
 

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
@@ -56,7 +56,7 @@ public class RcGnmiAppModule extends AbstractLightyModule {
     private static final Logger LOG = LoggerFactory.getLogger(RcGnmiAppModule.class);
     private static final TimeUnit DEFAULT_LIGHTY_MODULE_TIME_UNIT = TimeUnit.SECONDS;
 
-    private Integer lightyModuleTimeout = 60;
+    private final int lightyModuleTimeout;
     private final RcGnmiAppConfiguration appModuleConfig;
     private final ExecutorService gnmiExecutorService;
     private final CrossSourceStatementReactor customReactor;
@@ -66,17 +66,14 @@ public class RcGnmiAppModule extends AbstractLightyModule {
 
     public RcGnmiAppModule(final RcGnmiAppConfiguration appModuleConfig,
                            final ExecutorService gnmiExecutorService,
+                           final int lightyModuleTimeout,
                            @Nullable final CrossSourceStatementReactor customReactor) {
         LOG.info("Creating instance of RgNMI lighty.io module...");
         this.appModuleConfig = Objects.requireNonNull(appModuleConfig);
         this.gnmiExecutorService = Objects.requireNonNull(gnmiExecutorService);
+        this.lightyModuleTimeout = lightyModuleTimeout;
         this.customReactor = customReactor;
         LOG.info("Instance of RCgNMI lighty.io module created!");
-    }
-
-    public RcGnmiAppModule setRcGnmiModuleTimeout(final Integer rcGnmiModuleTimeout) {
-        this.lightyModuleTimeout = rcGnmiModuleTimeout;
-        return this;
     }
 
     @Override

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
@@ -54,9 +54,9 @@ import org.slf4j.LoggerFactory;
 public class RcGnmiAppModule extends AbstractLightyModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(RcGnmiAppModule.class);
-    private static final long DEFAULT_LIGHTY_MODULE_TIMEOUT = 60;
     private static final TimeUnit DEFAULT_LIGHTY_MODULE_TIME_UNIT = TimeUnit.SECONDS;
 
+    private Integer lightyModuleTimeout = 60;
     private final RcGnmiAppConfiguration appModuleConfig;
     private final ExecutorService gnmiExecutorService;
     private final CrossSourceStatementReactor customReactor;
@@ -72,6 +72,11 @@ public class RcGnmiAppModule extends AbstractLightyModule {
         this.gnmiExecutorService = Objects.requireNonNull(gnmiExecutorService);
         this.customReactor = customReactor;
         LOG.info("Instance of RCgNMI lighty.io module created!");
+    }
+
+    public RcGnmiAppModule setRcGnmiModuleTimeout(final Integer rcGnmiModuleTimeout) {
+        this.lightyModuleTimeout = rcGnmiModuleTimeout;
+        return this;
     }
 
     @Override
@@ -132,7 +137,7 @@ public class RcGnmiAppModule extends AbstractLightyModule {
         try {
             LOG.info("Initializing lighty.io module ({})...", lightyModule.getClass());
             final boolean startSuccess = lightyModule.start()
-                    .get(DEFAULT_LIGHTY_MODULE_TIMEOUT, DEFAULT_LIGHTY_MODULE_TIME_UNIT);
+                    .get(lightyModuleTimeout, DEFAULT_LIGHTY_MODULE_TIME_UNIT);
             if (startSuccess) {
                 LOG.info("lighty.io module ({}) initialized successfully!", lightyModule.getClass());
             } else {
@@ -180,7 +185,7 @@ public class RcGnmiAppModule extends AbstractLightyModule {
         try {
             LOG.info("Stopping lighty.io module ({})...", lightyModule.getClass());
             final boolean stopSuccess =
-                    lightyModule.shutdown().get(DEFAULT_LIGHTY_MODULE_TIMEOUT, DEFAULT_LIGHTY_MODULE_TIME_UNIT);
+                    lightyModule.shutdown().get(lightyModuleTimeout, DEFAULT_LIGHTY_MODULE_TIME_UNIT);
             if (stopSuccess) {
                 LOG.info("lighty.io module ({}) stopped successfully!", lightyModule.getClass());
                 return true;

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
@@ -167,7 +167,7 @@ public class RcGnmiAppModule extends AbstractLightyModule {
         if (this.lightyController != null && !stopAndWaitLightyModule(this.lightyController)) {
             success = false;
         }
-        if (this.lightyController != null && !stopAndWaitLightyModule(this.gnmiSouthboundModule)) {
+        if (this.gnmiSouthboundModule != null && !stopAndWaitLightyModule(this.gnmiSouthboundModule)) {
             success = false;
         }
 

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
@@ -9,7 +9,6 @@
 package io.lighty.applications.rcgnmi.module;
 
 import io.lighty.aaa.encrypt.service.impl.AAAEncryptionServiceImpl;
-import io.lighty.core.controller.api.AbstractLightyModule;
 import io.lighty.core.controller.api.LightyController;
 import io.lighty.core.controller.api.LightyModule;
 import io.lighty.core.controller.api.LightyServices;
@@ -51,7 +50,7 @@ import org.opendaylight.yangtools.yang.parser.stmt.reactor.CrossSourceStatementR
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class RcGnmiAppModule extends AbstractLightyModule {
+public class RcGnmiAppModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(RcGnmiAppModule.class);
     private static final TimeUnit DEFAULT_LIGHTY_MODULE_TIME_UNIT = TimeUnit.SECONDS;
@@ -76,8 +75,7 @@ public class RcGnmiAppModule extends AbstractLightyModule {
         LOG.info("Instance of RCgNMI lighty.io module created!");
     }
 
-    @Override
-    protected boolean initProcedure() {
+    public boolean initModules() {
         LOG.info("Initializing RCgNMI lighty.io module...");
         try {
             this.lightyController = initController(this.appModuleConfig.getControllerConfig());
@@ -153,8 +151,7 @@ public class RcGnmiAppModule extends AbstractLightyModule {
         }
     }
 
-    @Override
-    protected boolean stopProcedure() {
+    public boolean close() {
         LOG.info("Stopping RCgNMI lighty.io application...");
         boolean success = true;
 

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/test/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModuleTest.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/test/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModuleTest.java
@@ -20,14 +20,14 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class RcGnmiAppModuleTest {
-    private static final long MODULE_TIMEOUT = 60;
+    private static final int MODULE_TIMEOUT = 60;
     private static final TimeUnit MODULE_TIME_UNIT = TimeUnit.SECONDS;
 
     @Test
     public void gnmiModuleSmokeTest() throws InterruptedException, ExecutionException, TimeoutException,
             ConfigurationException {
         final RcGnmiAppModule module = new RcGnmiAppModule(RcGnmiAppModuleConfigUtils.loadDefaultConfig(),
-                Executors.newCachedThreadPool(), null);
+                Executors.newCachedThreadPool(), MODULE_TIMEOUT, null);
         Assertions.assertTrue(module.start().get(MODULE_TIMEOUT, MODULE_TIME_UNIT));
         Assertions.assertTrue(module.shutdown().get(MODULE_TIMEOUT, MODULE_TIME_UNIT));
     }
@@ -37,7 +37,8 @@ public class RcGnmiAppModuleTest {
             ConfigurationException {
         final RcGnmiAppConfiguration config = spy(RcGnmiAppModuleConfigUtils.loadDefaultConfig());
         when(config.getControllerConfig()).thenReturn(null);
-        final RcGnmiAppModule rgnmiAppModule = new RcGnmiAppModule(config, Executors.newCachedThreadPool(), null);
+        final RcGnmiAppModule rgnmiAppModule = new RcGnmiAppModule(config, Executors.newCachedThreadPool(),
+                MODULE_TIMEOUT, null);
         Assertions.assertFalse(rgnmiAppModule.start().get(MODULE_TIMEOUT, MODULE_TIME_UNIT));
     }
 }

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/test/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModuleTest.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/test/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModuleTest.java
@@ -12,34 +12,28 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import io.lighty.core.controller.impl.config.ConfigurationException;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class RcGnmiAppModuleTest {
     private static final int MODULE_TIMEOUT = 60;
-    private static final TimeUnit MODULE_TIME_UNIT = TimeUnit.SECONDS;
 
     @Test
-    public void gnmiModuleSmokeTest() throws InterruptedException, ExecutionException, TimeoutException,
-            ConfigurationException {
+    public void gnmiModuleSmokeTest() throws ConfigurationException {
         final RcGnmiAppModule module = new RcGnmiAppModule(RcGnmiAppModuleConfigUtils.loadDefaultConfig(),
                 Executors.newCachedThreadPool(), MODULE_TIMEOUT, null);
-        Assertions.assertTrue(module.start().get(MODULE_TIMEOUT, MODULE_TIME_UNIT));
-        Assertions.assertTrue(module.shutdown().get(MODULE_TIMEOUT, MODULE_TIME_UNIT));
+        Assertions.assertTrue(module.initModules());
+        Assertions.assertTrue(module.close());
     }
 
     @Test
-    public void gnmiModuleStartFailedTest() throws InterruptedException, ExecutionException, TimeoutException,
-            ConfigurationException {
+    public void gnmiModuleStartFailedTest() throws ConfigurationException {
         final RcGnmiAppConfiguration config = spy(RcGnmiAppModuleConfigUtils.loadDefaultConfig());
         when(config.getControllerConfig()).thenReturn(null);
         final RcGnmiAppModule rgnmiAppModule = new RcGnmiAppModule(config, Executors.newCachedThreadPool(),
                 MODULE_TIMEOUT, null);
-        Assertions.assertFalse(rgnmiAppModule.start().get(MODULE_TIMEOUT, MODULE_TIME_UNIT));
+        Assertions.assertFalse(rgnmiAppModule.initModules());
     }
 }
 

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/Arguments.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/Arguments.java
@@ -24,8 +24,8 @@ public class Arguments {
 
     @Parameter(names = {"-t", "--timeout-in-seconds"}, validateWith = ModuleTimeoutValidator.class,
                description = "Lighty modules timeout in seconds. Timeout exception is thrown when lighty module fails "
-                       + "to start within the specified time. Default value is 30. (range: 15 - Integer.MAX_VALUE)")
-    private Integer moduleTimeout = 30;
+                       + "to start within the specified time. Default value is 60. (range: 15 - Integer.MAX_VALUE)")
+    private Integer moduleTimeout = 60;
 
     public String getConfigPath() {
         return configPath;

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/Arguments.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/Arguments.java
@@ -50,8 +50,8 @@ public class Arguments {
                         + "Provided: " + value, e);
             }
             if (intValue < 15) {
-                throw new ParameterException("Provided application timeout " + value
-                        + " is not in range (15 - Integer.MAX_VALUE)");
+                throw new ParameterException("Provided module timeout value: [" + value
+                        + "] is not in range (15 - Integer.MAX_VALUE)");
             }
         }
     }

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/Arguments.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/Arguments.java
@@ -20,11 +20,20 @@ public class Arguments {
             + " (If absent, will look on classpath for it")
     private String loggerPath;
 
+    @Parameter(names = {"-t", "--timeout-in-seconds"}, description = "Application timeout in seconds. "
+            + "This parameter specifies max time which application will wait until a timeout exception will be thrown. "
+            + "Default value is 60. (15 - INT.MAX)")
+    private Integer applicationTimeout = 60;
+
     public String getConfigPath() {
         return configPath;
     }
 
     public String getLoggerPath() {
         return loggerPath;
+    }
+
+    public Integer getApplicationTimeout() {
+        return applicationTimeout;
     }
 }

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/Arguments.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/Arguments.java
@@ -44,8 +44,14 @@ public class Arguments {
     public static final class ApplicationTimeoutValidator implements IParameterValidator {
 
         @Override
-        public void validate(String name, String value) throws ParameterException {
-            int intValue = Integer.parseInt(value);
+        public void validate(final String name, final String value) throws ParameterException {
+            final int intValue;
+            try {
+                intValue = Integer.parseInt(value);
+            } catch (NumberFormatException e) {
+                throw new ParameterException("Expected number after parameter \"-t\", \"--timeout-in-seconds\". "
+                        + "Provided: " + value, e);
+            }
             if (intValue < 15) {
                 throw new ParameterException("Provided application timeout " + value
                         + " is not in range (15 - INT.MAX)");

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/Arguments.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/Arguments.java
@@ -23,10 +23,9 @@ public class Arguments {
     private String loggerPath;
 
     @Parameter(names = {"-t", "--timeout-in-seconds"}, validateWith = ApplicationTimeoutValidator.class,
-               description = "Application timeout in seconds. "
-            + "This parameter specifies max time which application will wait until a timeout exception will be thrown. "
-            + "Default value is 60. (15 - INT.MAX)")
-    private Integer applicationTimeout = 60;
+               description = "Lighty modules timeout in seconds. Timeout exception is thrown when lighty module fails "
+                       + "to start within the specified time. Default value is 30. (range: 15 - Integer.MAX_VALUE)")
+    private Integer applicationTimeout = 30;
 
     public String getConfigPath() {
         return configPath;
@@ -54,7 +53,7 @@ public class Arguments {
             }
             if (intValue < 15) {
                 throw new ParameterException("Provided application timeout " + value
-                        + " is not in range (15 - INT.MAX)");
+                        + " is not in range (15 - Integer.MAX_VALUE)");
             }
         }
     }

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/Arguments.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/Arguments.java
@@ -22,10 +22,10 @@ public class Arguments {
             + " (If absent, will look on classpath for it")
     private String loggerPath;
 
-    @Parameter(names = {"-t", "--timeout-in-seconds"}, validateWith = ApplicationTimeoutValidator.class,
+    @Parameter(names = {"-t", "--timeout-in-seconds"}, validateWith = ModuleTimeoutValidator.class,
                description = "Lighty modules timeout in seconds. Timeout exception is thrown when lighty module fails "
                        + "to start within the specified time. Default value is 30. (range: 15 - Integer.MAX_VALUE)")
-    private Integer applicationTimeout = 30;
+    private Integer moduleTimeout = 30;
 
     public String getConfigPath() {
         return configPath;
@@ -35,13 +35,11 @@ public class Arguments {
         return loggerPath;
     }
 
-    public Integer getApplicationTimeout() {
-        return applicationTimeout;
+    public Integer getModuleTimeout() {
+        return moduleTimeout;
     }
 
-
-    public static final class ApplicationTimeoutValidator implements IParameterValidator {
-
+    public static final class ModuleTimeoutValidator implements IParameterValidator {
         @Override
         public void validate(final String name, final String value) throws ParameterException {
             final int intValue;
@@ -57,5 +55,4 @@ public class Arguments {
             }
         }
     }
-
 }

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/Arguments.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/Arguments.java
@@ -8,7 +8,9 @@
 
 package io.lighty.applications.rcgnmi.app;
 
+import com.beust.jcommander.IParameterValidator;
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
 
 public class Arguments {
 
@@ -20,7 +22,8 @@ public class Arguments {
             + " (If absent, will look on classpath for it")
     private String loggerPath;
 
-    @Parameter(names = {"-t", "--timeout-in-seconds"}, description = "Application timeout in seconds. "
+    @Parameter(names = {"-t", "--timeout-in-seconds"}, validateWith = ApplicationTimeoutValidator.class,
+               description = "Application timeout in seconds. "
             + "This parameter specifies max time which application will wait until a timeout exception will be thrown. "
             + "Default value is 60. (15 - INT.MAX)")
     private Integer applicationTimeout = 60;
@@ -36,4 +39,18 @@ public class Arguments {
     public Integer getApplicationTimeout() {
         return applicationTimeout;
     }
+
+
+    public static final class ApplicationTimeoutValidator implements IParameterValidator {
+
+        @Override
+        public void validate(String name, String value) throws ParameterException {
+            int intValue = Integer.parseInt(value);
+            if (intValue < 15) {
+                throw new ParameterException("Provided application timeout " + value
+                        + " is not in range (15 - INT.MAX)");
+            }
+        }
+    }
+
 }

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/RCgNMIApp.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/RCgNMIApp.java
@@ -37,7 +37,6 @@ public class RCgNMIApp {
             = "Exception was thrown while shutting down RCgNMI lighty.io application!";
 
     private RcGnmiAppModule rcgnmiLightyModule;
-    private Integer lightyModuleTimeout;
 
     // Using args is safe as we need only a configuration file location here
     @SuppressWarnings("squid:S4823")
@@ -69,8 +68,6 @@ public class RCgNMIApp {
                 .addObject(arguments)
                 .build()
                 .parse(args);
-
-        lightyModuleTimeout = arguments.getApplicationTimeout();
         if (arguments.getLoggerPath() != null) {
             LOG.debug("Argument for custom logging settings path is present: {} ", arguments.getLoggerPath());
             PropertyConfigurator.configure(arguments.getLoggerPath());
@@ -96,7 +93,8 @@ public class RCgNMIApp {
                 .getControllerConfig().getSchemaServiceConfig().getModels()));
         final ExecutorService executorService = SpecialExecutors.newBoundedCachedThreadPool(10,
                 100, "gnmi_executor", Logger.class);
-        rcgnmiLightyModule = createRgnmiAppModule(rgnmiModuleConfig, executorService, null);
+        rcgnmiLightyModule = createRgnmiAppModule(rgnmiModuleConfig, executorService, arguments.getApplicationTimeout(),
+                null);
         try {
             final boolean hasStarted = rcgnmiLightyModule.start().get();
             if (hasStarted) {
@@ -118,6 +116,7 @@ public class RCgNMIApp {
 
     public RcGnmiAppModule createRgnmiAppModule(final RcGnmiAppConfiguration rcGnmiAppConfiguration,
                                                 final ExecutorService gnmiExecutorService,
+                                                final Integer lightyModuleTimeout,
                                                 @Nullable final CrossSourceStatementReactor customReactor) {
         return new RcGnmiAppModule(rcGnmiAppConfiguration, gnmiExecutorService, lightyModuleTimeout, customReactor);
     }

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/RCgNMIApp.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/RCgNMIApp.java
@@ -99,8 +99,7 @@ public class RCgNMIApp {
                 .getControllerConfig().getSchemaServiceConfig().getModels()));
         final ExecutorService executorService = SpecialExecutors.newBoundedCachedThreadPool(10,
                 100, "gnmi_executor", Logger.class);
-        rcgnmiLightyModule = createRgnmiAppModule(rgnmiModuleConfig, executorService, null)
-                .setRcGnmiModuleTimeout(lightyModuleTimeout);
+        rcgnmiLightyModule = createRgnmiAppModule(rgnmiModuleConfig, executorService, null);
         try {
             final boolean hasStarted = rcgnmiLightyModule.start().get(lightyModuleTimeout, DEFAULT_TIME_UNIT);
             if (hasStarted) {
@@ -123,7 +122,7 @@ public class RCgNMIApp {
     public RcGnmiAppModule createRgnmiAppModule(final RcGnmiAppConfiguration rcGnmiAppConfiguration,
                                                 final ExecutorService gnmiExecutorService,
                                                 @Nullable final CrossSourceStatementReactor customReactor) {
-        return new RcGnmiAppModule(rcGnmiAppConfiguration, gnmiExecutorService, customReactor);
+        return new RcGnmiAppModule(rcGnmiAppConfiguration, gnmiExecutorService, lightyModuleTimeout, customReactor);
     }
 
     private void registerShutdownHook(final AbstractLightyModule application) {

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/RCgNMIApp.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/RCgNMIApp.java
@@ -82,7 +82,7 @@ public class RCgNMIApp {
         final ExecutorService executorService = SpecialExecutors.newBoundedCachedThreadPool(10,
                 100, "gnmi_executor", Logger.class);
         rcgnmiLightyModule = createRgnmiAppModule(rgnmiModuleConfig, executorService,
-                arguments.getApplicationTimeout(), null);
+                arguments.getModuleTimeout(), null);
 
         // Initialize RcGNMI modules
         if (rcgnmiLightyModule.initModules()) {

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/RCgNMIApp.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/RCgNMIApp.java
@@ -73,17 +73,11 @@ public class RCgNMIApp {
                 .build()
                 .parse(args);
 
+        lightyModuleTimeout = arguments.getApplicationTimeout();
         if (arguments.getLoggerPath() != null) {
             LOG.debug("Argument for custom logging settings path is present: {} ", arguments.getLoggerPath());
             PropertyConfigurator.configure(arguments.getLoggerPath());
             LOG.info("Custom logger properties loaded successfully");
-        }
-        lightyModuleTimeout = arguments.getApplicationTimeout();
-        if (lightyModuleTimeout < 15) {
-            final Integer defaultValue = new Arguments().getApplicationTimeout();
-            LOG.info("Provided application timeout [{}] is not in range (15 - INT.MAX). Using default value [{}]",
-                    lightyModuleTimeout, defaultValue);
-            lightyModuleTimeout = defaultValue;
         }
         try {
             if (arguments.getConfigPath() != null) {

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/RCgNMIApp.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/RCgNMIApp.java
@@ -23,8 +23,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import org.apache.log4j.PropertyConfigurator;
 import org.eclipse.jdt.annotation.Nullable;
 import org.opendaylight.yangtools.util.concurrent.SpecialExecutors;
@@ -37,7 +35,6 @@ public class RCgNMIApp {
     private static final String UNABLE_TO_START_APPLICATION = "Unable to start RCgNMI lighty.io application!";
     private static final String UNABLE_TO_STOP_APPLICATION
             = "Exception was thrown while shutting down RCgNMI lighty.io application!";
-    private static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.SECONDS;
 
     private RcGnmiAppModule rcgnmiLightyModule;
     private Integer lightyModuleTimeout;
@@ -101,7 +98,7 @@ public class RCgNMIApp {
                 100, "gnmi_executor", Logger.class);
         rcgnmiLightyModule = createRgnmiAppModule(rgnmiModuleConfig, executorService, null);
         try {
-            final boolean hasStarted = rcgnmiLightyModule.start().get(lightyModuleTimeout, DEFAULT_TIME_UNIT);
+            final boolean hasStarted = rcgnmiLightyModule.start().get();
             if (hasStarted) {
                 // Register shutdown hook for graceful shutdown
                 LOG.info("Registering ShutdownHook to gracefully shutdown application");
@@ -110,7 +107,7 @@ public class RCgNMIApp {
             } else {
                 throw new RcGnmiAppException(UNABLE_TO_START_APPLICATION);
             }
-        } catch (ExecutionException | TimeoutException e) {
+        } catch (ExecutionException  e) {
             throw new RcGnmiAppException(UNABLE_TO_START_APPLICATION, e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -135,9 +132,9 @@ public class RCgNMIApp {
         if (module != null) {
             try {
                 LOG.info("ShutdownHook triggered. Shutting down RCgNMI lighty.io application...");
-                module.shutdown().get(lightyModuleTimeout, DEFAULT_TIME_UNIT);
+                module.shutdown().get();
                 LOG.info("RCgNMI lighty.io application was shut down!");
-            } catch (ExecutionException | TimeoutException e) {
+            } catch (ExecutionException e) {
                 LOG.error(UNABLE_TO_STOP_APPLICATION, e);
             } catch (InterruptedException e) {
                 LOG.error(UNABLE_TO_STOP_APPLICATION, e);

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/test/java/io/lighty/applications/rcgnmi/app/RCgNMIAppTest.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/test/java/io/lighty/applications/rcgnmi/app/RCgNMIAppTest.java
@@ -8,10 +8,15 @@
 
 package io.lighty.applications.rcgnmi.app;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
+import com.beust.jcommander.ParameterException;
 import com.google.common.util.concurrent.Futures;
 import io.lighty.applications.rcgnmi.module.RcGnmiAppException;
 import io.lighty.applications.rcgnmi.module.RcGnmiAppModule;
@@ -26,9 +31,9 @@ public class RCgNMIAppTest {
         final RcGnmiAppModule appModule = Mockito.mock(RcGnmiAppModule.class);
         doReturn(Futures.immediateFuture(true)).when(appModule).start();
         doReturn(Futures.immediateFuture(true)).when(appModule).shutdown();
-        doReturn(appModule).when(app).createRgnmiAppModule(any(), any(), any());
+        doReturn(appModule).when(app).createRgnmiAppModule(any(), any(), eq(30), any());
         app.start(new String[]{});
-        verify(app, Mockito.times(1)).createRgnmiAppModule(any(), any(), any());
+        verify(app, Mockito.times(1)).createRgnmiAppModule(any(), any(), eq(30), any());
     }
 
     @Test
@@ -37,16 +42,22 @@ public class RCgNMIAppTest {
         final RcGnmiAppModule appModule = Mockito.mock(RcGnmiAppModule.class);
         doReturn(Futures.immediateFuture(true)).when(appModule).start();
         doReturn(Futures.immediateFuture(true)).when(appModule).shutdown();
-        doReturn(appModule).when(app).createRgnmiAppModule(any(), any(), any());
-        app.start(new String[]{"-c", "src/main/resources/example-config/example_config.json"});
-        verify(app, Mockito.times(1)).createRgnmiAppModule(any(), any(), any());
+        doReturn(appModule).when(app).createRgnmiAppModule(any(), any(), eq(90), any());
+        app.start(new String[]{"-c", "src/main/resources/example-config/example_config.json", "-t", "90"});
+        verify(app, Mockito.times(1)).createRgnmiAppModule(any(), any(), eq(90), any());
     }
 
     @Test
     public void testStartWithConfigFileNoSuchFile() throws RcGnmiAppException {
         final RCgNMIApp app = Mockito.spy(new RCgNMIApp());
         app.start(new String[]{"-c", "no_config.json"});
-        verify(app, Mockito.times(0)).createRgnmiAppModule(any(), any(), any());
+        verify(app, Mockito.times(0)).createRgnmiAppModule(any(), any(), eq(30), any());
     }
 
+    @Test
+    public void testStartWithWrongTimeOut() {
+        final RCgNMIApp app = spy(new RCgNMIApp());
+        verify(app, never()).createRgnmiAppModule(any(), any(), eq(30), any());
+        assertThrows(ParameterException.class, () -> app.start(new String[]{"-t", "WRONG_TIME_OUT"}));
+    }
 }

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/test/java/io/lighty/applications/rcgnmi/app/RCgNMIAppTest.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/test/java/io/lighty/applications/rcgnmi/app/RCgNMIAppTest.java
@@ -24,7 +24,6 @@ public class RCgNMIAppTest {
     public void testStartWithDefaultConfiguration() throws RcGnmiAppException {
         final RCgNMIApp app = Mockito.spy(new RCgNMIApp());
         final RcGnmiAppModule appModule = Mockito.mock(RcGnmiAppModule.class);
-        doReturn(appModule).when(appModule).setRcGnmiModuleTimeout(any());
         doReturn(Futures.immediateFuture(true)).when(appModule).start();
         doReturn(Futures.immediateFuture(true)).when(appModule).shutdown();
         doReturn(appModule).when(app).createRgnmiAppModule(any(), any(), any());
@@ -36,7 +35,6 @@ public class RCgNMIAppTest {
     public void testStartWithConfigFile() throws RcGnmiAppException {
         final RCgNMIApp app = Mockito.spy(new RCgNMIApp());
         final RcGnmiAppModule appModule = Mockito.mock(RcGnmiAppModule.class);
-        doReturn(appModule).when(appModule).setRcGnmiModuleTimeout(any());
         doReturn(Futures.immediateFuture(true)).when(appModule).start();
         doReturn(Futures.immediateFuture(true)).when(appModule).shutdown();
         doReturn(appModule).when(app).createRgnmiAppModule(any(), any(), any());

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/test/java/io/lighty/applications/rcgnmi/app/RCgNMIAppTest.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/test/java/io/lighty/applications/rcgnmi/app/RCgNMIAppTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.util.concurrent.Futures;
+import io.lighty.applications.rcgnmi.module.RcGnmiAppException;
 import io.lighty.applications.rcgnmi.module.RcGnmiAppModule;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -20,7 +21,7 @@ import org.mockito.Mockito;
 public class RCgNMIAppTest {
 
     @Test
-    public void testStartWithDefaultConfiguration() {
+    public void testStartWithDefaultConfiguration() throws RcGnmiAppException {
         final RCgNMIApp app = Mockito.spy(new RCgNMIApp());
         final RcGnmiAppModule appModule = Mockito.mock(RcGnmiAppModule.class);
         doReturn(appModule).when(appModule).setRcGnmiModuleTimeout(any());
@@ -32,7 +33,7 @@ public class RCgNMIAppTest {
     }
 
     @Test
-    public void testStartWithConfigFile() {
+    public void testStartWithConfigFile() throws RcGnmiAppException {
         final RCgNMIApp app = Mockito.spy(new RCgNMIApp());
         final RcGnmiAppModule appModule = Mockito.mock(RcGnmiAppModule.class);
         doReturn(appModule).when(appModule).setRcGnmiModuleTimeout(any());
@@ -44,7 +45,7 @@ public class RCgNMIAppTest {
     }
 
     @Test
-    public void testStartWithConfigFileNoSuchFile() {
+    public void testStartWithConfigFileNoSuchFile() throws RcGnmiAppException {
         final RCgNMIApp app = Mockito.spy(new RCgNMIApp());
         app.start(new String[]{"-c", "no_config.json"});
         verify(app, Mockito.times(0)).createRgnmiAppModule(any(), any(), any());

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/test/java/io/lighty/applications/rcgnmi/app/RCgNMIAppTest.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/test/java/io/lighty/applications/rcgnmi/app/RCgNMIAppTest.java
@@ -23,6 +23,7 @@ public class RCgNMIAppTest {
     public void testStartWithDefaultConfiguration() {
         final RCgNMIApp app = Mockito.spy(new RCgNMIApp());
         final RcGnmiAppModule appModule = Mockito.mock(RcGnmiAppModule.class);
+        doReturn(appModule).when(appModule).setRcGnmiModuleTimeout(any());
         doReturn(Futures.immediateFuture(true)).when(appModule).start();
         doReturn(Futures.immediateFuture(true)).when(appModule).shutdown();
         doReturn(appModule).when(app).createRgnmiAppModule(any(), any(), any());
@@ -34,6 +35,7 @@ public class RCgNMIAppTest {
     public void testStartWithConfigFile() {
         final RCgNMIApp app = Mockito.spy(new RCgNMIApp());
         final RcGnmiAppModule appModule = Mockito.mock(RcGnmiAppModule.class);
+        doReturn(appModule).when(appModule).setRcGnmiModuleTimeout(any());
         doReturn(Futures.immediateFuture(true)).when(appModule).start();
         doReturn(Futures.immediateFuture(true)).when(appModule).shutdown();
         doReturn(appModule).when(app).createRgnmiAppModule(any(), any(), any());

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/test/java/io/lighty/applications/rcgnmi/app/RCgNMIAppTest.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/test/java/io/lighty/applications/rcgnmi/app/RCgNMIAppTest.java
@@ -29,9 +29,9 @@ public class RCgNMIAppTest {
         final RcGnmiAppModule appModule = Mockito.mock(RcGnmiAppModule.class);
         doReturn(true).when(appModule).initModules();
         doReturn(true).when(appModule).close();
-        doReturn(appModule).when(app).createRgnmiAppModule(any(), any(), eq(30), any());
+        doReturn(appModule).when(app).createRgnmiAppModule(any(), any(), eq(60), any());
         app.start(new String[]{});
-        verify(app, Mockito.times(1)).createRgnmiAppModule(any(), any(), eq(30), any());
+        verify(app, Mockito.times(1)).createRgnmiAppModule(any(), any(), eq(60), any());
     }
 
     @Test
@@ -49,13 +49,13 @@ public class RCgNMIAppTest {
     public void testStartWithConfigFileNoSuchFile() {
         final RCgNMIApp app = Mockito.spy(new RCgNMIApp());
         app.start(new String[]{"-c", "no_config.json"});
-        verify(app, Mockito.times(0)).createRgnmiAppModule(any(), any(), eq(30), any());
+        verify(app, Mockito.times(0)).createRgnmiAppModule(any(), any(), eq(60), any());
     }
 
     @Test
     public void testStartWithWrongTimeOut() {
         final RCgNMIApp app = spy(new RCgNMIApp());
-        verify(app, never()).createRgnmiAppModule(any(), any(), eq(30), any());
+        verify(app, never()).createRgnmiAppModule(any(), any(), eq(60), any());
         assertThrows(ParameterException.class, () -> app.start(new String[]{"-t", "WRONG_TIME_OUT"}));
     }
 }

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/test/java/io/lighty/applications/rcgnmi/app/RCgNMIAppTest.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/test/java/io/lighty/applications/rcgnmi/app/RCgNMIAppTest.java
@@ -17,8 +17,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import com.beust.jcommander.ParameterException;
-import com.google.common.util.concurrent.Futures;
-import io.lighty.applications.rcgnmi.module.RcGnmiAppException;
 import io.lighty.applications.rcgnmi.module.RcGnmiAppModule;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -26,29 +24,29 @@ import org.mockito.Mockito;
 public class RCgNMIAppTest {
 
     @Test
-    public void testStartWithDefaultConfiguration() throws RcGnmiAppException {
+    public void testStartWithDefaultConfiguration() {
         final RCgNMIApp app = Mockito.spy(new RCgNMIApp());
         final RcGnmiAppModule appModule = Mockito.mock(RcGnmiAppModule.class);
-        doReturn(Futures.immediateFuture(true)).when(appModule).start();
-        doReturn(Futures.immediateFuture(true)).when(appModule).shutdown();
+        doReturn(true).when(appModule).initModules();
+        doReturn(true).when(appModule).close();
         doReturn(appModule).when(app).createRgnmiAppModule(any(), any(), eq(30), any());
         app.start(new String[]{});
         verify(app, Mockito.times(1)).createRgnmiAppModule(any(), any(), eq(30), any());
     }
 
     @Test
-    public void testStartWithConfigFile() throws RcGnmiAppException {
+    public void testStartWithConfigFile() {
         final RCgNMIApp app = Mockito.spy(new RCgNMIApp());
         final RcGnmiAppModule appModule = Mockito.mock(RcGnmiAppModule.class);
-        doReturn(Futures.immediateFuture(true)).when(appModule).start();
-        doReturn(Futures.immediateFuture(true)).when(appModule).shutdown();
+        doReturn(true).when(appModule).initModules();
+        doReturn(true).when(appModule).close();
         doReturn(appModule).when(app).createRgnmiAppModule(any(), any(), eq(90), any());
         app.start(new String[]{"-c", "src/main/resources/example-config/example_config.json", "-t", "90"});
         verify(app, Mockito.times(1)).createRgnmiAppModule(any(), any(), eq(90), any());
     }
 
     @Test
-    public void testStartWithConfigFileNoSuchFile() throws RcGnmiAppException {
+    public void testStartWithConfigFileNoSuchFile() {
         final RCgNMIApp app = Mockito.spy(new RCgNMIApp());
         app.start(new String[]{"-c", "no_config.json"});
         verify(app, Mockito.times(0)).createRgnmiAppModule(any(), any(), eq(30), any());

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/test/java/io/lighty/applications/rcgnmi/app/RCgNMIAppTest.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/test/java/io/lighty/applications/rcgnmi/app/RCgNMIAppTest.java
@@ -55,7 +55,7 @@ public class RCgNMIAppTest {
     @Test
     public void testStartWithWrongTimeOut() {
         final RCgNMIApp app = spy(new RCgNMIApp());
-        verify(app, never()).createRgnmiAppModule(any(), any(), eq(60), any());
         assertThrows(ParameterException.class, () -> app.start(new String[]{"-t", "WRONG_TIME_OUT"}));
+        verify(app, never()).createRgnmiAppModule(any(), any(), eq(60), any());
     }
 }

--- a/lighty-applications/lighty-rnc-app-aggregator/README.md
+++ b/lighty-applications/lighty-rnc-app-aggregator/README.md
@@ -36,7 +36,10 @@ To build and start the lighty.io RNC application in the local environment, follo
    
 4. To start the application with custom lighty configuration, use arg -c and for custom initial log4j configuration use argument -l:  
    `java -jar lighty-rnc-app-<version>.jar -c /path/to/config-file -l /path/to/log4j-config-file`  
-   
+
+    To extend application time-out use the argument `-t/--timeout-in-seconds`. This argument override current default application time-out set to 60s.
+   `java -jar lighty-rnc-app-<version>.jar -t 90`
+
    Example configuration files are located on following path:  
    `lighty-rnc-app-docker/example-config/*`
 

--- a/lighty-applications/lighty-rnc-app-aggregator/README.md
+++ b/lighty-applications/lighty-rnc-app-aggregator/README.md
@@ -36,19 +36,19 @@ To build and start the lighty.io RNC application in the local environment, follo
    
 4. To start the application with custom lighty configuration, use arg -c and for custom initial log4j configuration use argument -l:  
    `java -jar lighty-rnc-app-<version>.jar -c /path/to/config-file -l /path/to/log4j-config-file`  
-
-    To extend application time-out use the argument `-t/--timeout-in-seconds`. This argument override current default application time-out set to 60s.
-   `java -jar lighty-rnc-app-<version>.jar -t 90`
-
+   
    Example configuration files are located on following path:  
    `lighty-rnc-app-docker/example-config/*`
 
-5. If the application was started successfully, then a log similar should be present in the console:  
+5. (Optional) To extend lighty modules time-out use the argument `-t/--timeout-in-seconds`. This argument increases the time after which the exception is thrown if the module is not successfully initialized by then. (Default 30)
+   `java -jar lighty-rcgnmi-app-<version>.jar -t 60`
+
+6. If the application was started successfully, then a log similar should be present in the console:  
    `INFO [main] (Main.java:80) - RNC lighty.io application started in 5989.108ms`
 
-6. Test the lighty.io RNC application. The default RESTCONF port is `8888`
+7. Test the lighty.io RNC application. The default RESTCONF port is `8888`
 
-7. The default credentials for http requests is login:`admin`, password: `admin`. 
+8. The default credentials for http requests is login:`admin`, password: `admin`. 
 To edit the user's credentials, [idmtool](https://docs.opendaylight.org/projects/aaa/en/stable-aluminium/user-guide.html#idmtool) can be used to:
     - create new `etc` directory and create there `org.ops4j.pax.web.cfg` file
     - add this two lines in the `org.ops4j.pax.web.cfg` file: 
@@ -76,7 +76,7 @@ To edit the user's credentials, [idmtool](https://docs.opendaylight.org/projects
     
     Also, it is possible to configure user's credentials via [REST](https://docs.opendaylight.org/projects/aaa/en/latest/user-guide.html#configuration-using-the-restful-web-service)
 
-8. For using a SSL connection, the correct certificate must be used.
+9. For using a SSL connection, the correct certificate must be used.
 By default, a test certificate is used (`lighty-rnc-module/src/main/resources/keystore/lightyio.jks`).
 For generating a JKS file `keytool` utility can be used. Example of command to regenerate keystore with self-signed certificate:
 

--- a/lighty-applications/lighty-rnc-app-aggregator/README.md
+++ b/lighty-applications/lighty-rnc-app-aggregator/README.md
@@ -40,8 +40,8 @@ To build and start the lighty.io RNC application in the local environment, follo
    Example configuration files are located on following path:  
    `lighty-rnc-app-docker/example-config/*`
 
-5. (Optional) To extend lighty modules time-out use the argument `-t/--timeout-in-seconds`. This argument increases the time after which the exception is thrown if the module is not successfully initialized by then. (Default 30)
-   `java -jar lighty-rcgnmi-app-<version>.jar -t 60`
+5. (Optional) To extend lighty modules time-out use the argument `-t/--timeout-in-seconds`. This argument increases the time after which the exception is thrown if the module is not successfully initialized by then. (Default 60)
+   `java -jar lighty-rcgnmi-app-<version>.jar -t 90`
 
 6. If the application was started successfully, then a log similar should be present in the console:  
    `INFO [main] (Main.java:80) - RNC lighty.io application started in 5989.108ms`

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Arguments.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Arguments.java
@@ -24,9 +24,9 @@ public class Arguments {
     private String loggerPath;
 
     @Parameter(names = {"-t", "--timeout-in-seconds"}, validateWith = ApplicationTimeoutValidator.class,
-               description = "Application timeout in seconds. This parameter specifies max time which application"
-                       + " will wait until a timeout exception will be thrown. Default value is 60. (15 - INT.MAX)")
-    private Integer applicationTimeout = 60;
+               description = "Lighty modules timeout in seconds. Timeout exception is thrown when lighty module fails "
+                       + "to start within the specified time. Default value is 30. (range: 15 - Integer.MAX_VALUE)")
+    private Integer applicationTimeout = 30;
 
     public String getConfigPath() {
         return configPath;
@@ -54,7 +54,7 @@ public class Arguments {
             }
             if (intValue < 15) {
                 throw new ParameterException("Provided application timeout " + value
-                        + " is not in range (15 - INT.MAX)");
+                        + " is not in range (15 - Integer.MAX_VALUE)");
             }
         }
     }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Arguments.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Arguments.java
@@ -21,12 +21,21 @@ public class Arguments {
             + " (If absent, will look on classpath for it")
     private String loggerPath;
 
+    @Parameter(names = {"-t", "--timeout-in-seconds"}, description = "Application timeout in seconds. "
+            + "This parameter specifies max time which application will wait until a timeout exception will be thrown. "
+            + "Default value is 60. (15 - INT.MAX)")
+    private Integer applicationTimeout = 60;
+
     public String getConfigPath() {
         return configPath;
     }
 
     public String getLoggerPath() {
         return loggerPath;
+    }
+
+    public Integer getApplicationTimeout() {
+        return applicationTimeout;
     }
 
 }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Arguments.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Arguments.java
@@ -25,8 +25,8 @@ public class Arguments {
 
     @Parameter(names = {"-t", "--timeout-in-seconds"}, validateWith = ModuleTimeoutValidator.class,
                description = "Lighty modules timeout in seconds. Timeout exception is thrown when lighty module fails "
-                       + "to start within the specified time. Default value is 30. (range: 15 - Integer.MAX_VALUE)")
-    private Integer moduleTimeout = 30;
+                       + "to start within the specified time. Default value is 60. (range: 15 - Integer.MAX_VALUE)")
+    private Integer moduleTimeout = 60;
 
     public String getConfigPath() {
         return configPath;

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Arguments.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Arguments.java
@@ -44,8 +44,14 @@ public class Arguments {
     public static final class ApplicationTimeoutValidator implements IParameterValidator {
 
         @Override
-        public void validate(String name, String value) throws ParameterException {
-            int intValue = Integer.parseInt(value);
+        public void validate(final String name, final String value) throws ParameterException {
+            final int intValue;
+            try {
+                intValue = Integer.parseInt(value);
+            } catch (NumberFormatException e) {
+                throw new ParameterException("Expected number after parameter \"-t\", \"--timeout-in-seconds\". "
+                        + "Provided: " + value, e);
+            }
             if (intValue < 15) {
                 throw new ParameterException("Provided application timeout " + value
                         + " is not in range (15 - INT.MAX)");

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Arguments.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Arguments.java
@@ -7,7 +7,9 @@
  */
 package io.lighty.applications.rnc.app;
 
+import com.beust.jcommander.IParameterValidator;
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,9 +23,9 @@ public class Arguments {
             + " (If absent, will look on classpath for it")
     private String loggerPath;
 
-    @Parameter(names = {"-t", "--timeout-in-seconds"}, description = "Application timeout in seconds. "
-            + "This parameter specifies max time which application will wait until a timeout exception will be thrown. "
-            + "Default value is 60. (15 - INT.MAX)")
+    @Parameter(names = {"-t", "--timeout-in-seconds"}, validateWith = ApplicationTimeoutValidator.class,
+               description = "Application timeout in seconds. This parameter specifies max time which application"
+                       + " will wait until a timeout exception will be thrown. Default value is 60. (15 - INT.MAX)")
     private Integer applicationTimeout = 60;
 
     public String getConfigPath() {
@@ -36,6 +38,19 @@ public class Arguments {
 
     public Integer getApplicationTimeout() {
         return applicationTimeout;
+    }
+
+
+    public static final class ApplicationTimeoutValidator implements IParameterValidator {
+
+        @Override
+        public void validate(String name, String value) throws ParameterException {
+            int intValue = Integer.parseInt(value);
+            if (intValue < 15) {
+                throw new ParameterException("Provided application timeout " + value
+                        + " is not in range (15 - INT.MAX)");
+            }
+        }
     }
 
 }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Arguments.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Arguments.java
@@ -23,10 +23,10 @@ public class Arguments {
             + " (If absent, will look on classpath for it")
     private String loggerPath;
 
-    @Parameter(names = {"-t", "--timeout-in-seconds"}, validateWith = ApplicationTimeoutValidator.class,
+    @Parameter(names = {"-t", "--timeout-in-seconds"}, validateWith = ModuleTimeoutValidator.class,
                description = "Lighty modules timeout in seconds. Timeout exception is thrown when lighty module fails "
                        + "to start within the specified time. Default value is 30. (range: 15 - Integer.MAX_VALUE)")
-    private Integer applicationTimeout = 30;
+    private Integer moduleTimeout = 30;
 
     public String getConfigPath() {
         return configPath;
@@ -36,13 +36,11 @@ public class Arguments {
         return loggerPath;
     }
 
-    public Integer getApplicationTimeout() {
-        return applicationTimeout;
+    public Integer getModuleTimeout() {
+        return moduleTimeout;
     }
 
-
-    public static final class ApplicationTimeoutValidator implements IParameterValidator {
-
+    public static final class ModuleTimeoutValidator implements IParameterValidator {
         @Override
         public void validate(final String name, final String value) throws ParameterException {
             final int intValue;
@@ -58,5 +56,4 @@ public class Arguments {
             }
         }
     }
-
 }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Arguments.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Arguments.java
@@ -51,8 +51,8 @@ public class Arguments {
                         + "Provided: " + value, e);
             }
             if (intValue < 15) {
-                throw new ParameterException("Provided application timeout " + value
-                        + " is not in range (15 - Integer.MAX_VALUE)");
+                throw new ParameterException("Provided module timeout value: [" + value
+                        + "] is not in range (15 - Integer.MAX_VALUE)");
             }
         }
     }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Main.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Main.java
@@ -79,18 +79,11 @@ public class Main {
                 .addObject(arguments)
                 .build()
                 .parse(args);
-
+        lightyModuleTimeout = arguments.getApplicationTimeout();
         if (arguments.getLoggerPath() != null) {
             LOG.debug("Argument for custom logging settings path is present: {} ", arguments.getLoggerPath());
             PropertyConfigurator.configure(arguments.getLoggerPath());
             LOG.info("Custom logger properties loaded successfully");
-        }
-        lightyModuleTimeout = arguments.getApplicationTimeout();
-        if (lightyModuleTimeout < 15) {
-            final Integer defaultValue = new Arguments().getApplicationTimeout();
-            LOG.info("Provided application timeout [{}] is not in range (15 - INT.MAX). Using default value [{}]",
-                    lightyModuleTimeout, defaultValue);
-            lightyModuleTimeout = defaultValue;
         }
         try {
             MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Main.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Main.java
@@ -44,7 +44,6 @@ public class Main {
             = "Exception was thrown while shutting down RNC lighty.io application!";
 
     private AbstractLightyModule rncLightyModule;
-    private Integer lightyModuleTimeout;
 
     // Using args is safe as we need only a configuration file location here
     @SuppressWarnings("squid:S4823")
@@ -76,7 +75,6 @@ public class Main {
                 .addObject(arguments)
                 .build()
                 .parse(args);
-        lightyModuleTimeout = arguments.getApplicationTimeout();
         if (arguments.getLoggerPath() != null) {
             LOG.debug("Argument for custom logging settings path is present: {} ", arguments.getLoggerPath());
             PropertyConfigurator.configure(arguments.getLoggerPath());
@@ -107,7 +105,7 @@ public class Main {
                 rncModuleConfig.getControllerConfig().getSchemaServiceConfig().getModels());
         LOG.info("Loaded YANG modules: {}", arrayNode);
 
-        rncLightyModule = createRncLightyModule(rncModuleConfig);
+        rncLightyModule = createRncLightyModule(rncModuleConfig, arguments.getApplicationTimeout());
         try {
             Boolean hasStarted = rncLightyModule.start().get();
             if (hasStarted) {
@@ -125,7 +123,8 @@ public class Main {
         }
     }
 
-    public RncLightyModule createRncLightyModule(final RncLightyModuleConfiguration rncModuleConfig) {
+    public RncLightyModule createRncLightyModule(final RncLightyModuleConfiguration rncModuleConfig,
+            final Integer lightyModuleTimeout) {
         return new RncLightyModule(rncModuleConfig, lightyModuleTimeout);
     }
 

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Main.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Main.java
@@ -23,8 +23,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Enumeration;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import javax.management.InstanceAlreadyExistsException;
 import javax.management.MBeanRegistrationException;
 import javax.management.MBeanServer;
@@ -41,7 +39,6 @@ import org.slf4j.LoggerFactory;
 public class Main {
 
     private static final Logger LOG = LoggerFactory.getLogger(Main.class);
-    private static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.SECONDS;
     private static final String UNABLE_TO_START_APPLICATION = "Unable to start RNC lighty.io application!";
     private static final String UNABLE_TO_STOP_APPLICATION
             = "Exception was thrown while shutting down RNC lighty.io application!";
@@ -112,7 +109,7 @@ public class Main {
 
         rncLightyModule = createRncLightyModule(rncModuleConfig);
         try {
-            Boolean hasStarted = rncLightyModule.start().get(lightyModuleTimeout, DEFAULT_TIME_UNIT);
+            Boolean hasStarted = rncLightyModule.start().get();
             if (hasStarted) {
                 LOG.info("Registering ShutdownHook to gracefully shutdown application");
                 registerShutdownHook(rncLightyModule);
@@ -120,7 +117,7 @@ public class Main {
             } else {
                 throw new RncLightyAppStartException(UNABLE_TO_START_APPLICATION);
             }
-        } catch (ExecutionException | TimeoutException e) {
+        } catch (ExecutionException e) {
             throw new RncLightyAppStartException(UNABLE_TO_START_APPLICATION, e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -142,9 +139,9 @@ public class Main {
         if (module != null) {
             try {
                 LOG.info("ShutdownHook triggered. Shutting down RNC lighty.io application...");
-                module.shutdown().get(lightyModuleTimeout, DEFAULT_TIME_UNIT);
+                module.shutdown().get();
                 LOG.info("RNC lighty.io application was shut down!");
-            } catch (ExecutionException | TimeoutException e) {
+            } catch (ExecutionException e) {
                 LOG.error(UNABLE_TO_STOP_APPLICATION, e);
             } catch (InterruptedException e) {
                 LOG.error(UNABLE_TO_STOP_APPLICATION, e);

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Main.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Main.java
@@ -110,7 +110,7 @@ public class Main {
                 rncModuleConfig.getControllerConfig().getSchemaServiceConfig().getModels());
         LOG.info("Loaded YANG modules: {}", arrayNode);
 
-        rncLightyModule = createRncLightyModule(rncModuleConfig).setRncModuleTimeout(lightyModuleTimeout);
+        rncLightyModule = createRncLightyModule(rncModuleConfig);
         try {
             Boolean hasStarted = rncLightyModule.start().get(lightyModuleTimeout, DEFAULT_TIME_UNIT);
             if (hasStarted) {
@@ -129,7 +129,7 @@ public class Main {
     }
 
     public RncLightyModule createRncLightyModule(final RncLightyModuleConfiguration rncModuleConfig) {
-        return new RncLightyModule(rncModuleConfig);
+        return new RncLightyModule(rncModuleConfig, lightyModuleTimeout);
     }
 
     private void registerShutdownHook(final AbstractLightyModule application) {

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Main.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Main.java
@@ -93,7 +93,7 @@ public class Main {
         LOG.info("Loaded YANG modules: {}", arrayNode);
 
         final RncLightyModule rncLightyModule
-                = createRncLightyModule(rncModuleConfig, arguments.getApplicationTimeout());
+                = createRncLightyModule(rncModuleConfig, arguments.getModuleTimeout());
         // Initialize RNC modules
         if (rncLightyModule.initModules()) {
             LOG.info("Registering ShutdownHook to gracefully shutdown application");

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/test/java/io/lighty/applications/rnc/app/MainTest.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/test/java/io/lighty/applications/rnc/app/MainTest.java
@@ -25,7 +25,6 @@ public class MainTest {
     public void testStartWithDefaultConfiguration() throws RncLightyAppStartException {
         Main app = spy(new Main());
         RncLightyModule lighty = mock(RncLightyModule.class);
-        doReturn(lighty).when(lighty).setRncModuleTimeout(any());
         doReturn(Futures.immediateFuture(true)).when(lighty).start();
         doReturn(Futures.immediateFuture(true)).when(lighty).shutdown();
         doReturn(lighty).when(app).createRncLightyModule(any());
@@ -36,7 +35,6 @@ public class MainTest {
     public void testStartWithConfigFile() throws RncLightyAppStartException {
         Main app = spy(new Main());
         RncLightyModule lighty = mock(RncLightyModule.class);
-        doReturn(lighty).when(lighty).setRncModuleTimeout(any());
         doReturn(Futures.immediateFuture(true)).when(lighty).start();
         doReturn(Futures.immediateFuture(true)).when(lighty).shutdown();
         doReturn(lighty).when(app).createRncLightyModule(any());

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/test/java/io/lighty/applications/rnc/app/MainTest.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/test/java/io/lighty/applications/rnc/app/MainTest.java
@@ -16,7 +16,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import com.beust.jcommander.ParameterException;
-import com.google.common.util.concurrent.Futures;
 import io.lighty.applications.rnc.module.RncLightyModule;
 import io.lighty.applications.rnc.module.exception.RncLightyAppStartException;
 import org.testng.Assert;
@@ -28,8 +27,8 @@ public class MainTest {
     public void testStartWithDefaultConfiguration() throws RncLightyAppStartException {
         Main app = spy(new Main());
         RncLightyModule lighty = mock(RncLightyModule.class);
-        doReturn(Futures.immediateFuture(true)).when(lighty).start();
-        doReturn(Futures.immediateFuture(true)).when(lighty).shutdown();
+        doReturn(true).when(lighty).initModules();
+        doReturn(true).when(lighty).close();
         doReturn(lighty).when(app).createRncLightyModule(any(), eq(30));
         app.start(new String[] {});
     }
@@ -38,8 +37,8 @@ public class MainTest {
     public void testStartWithConfigFile() throws RncLightyAppStartException {
         Main app = spy(new Main());
         RncLightyModule lighty = mock(RncLightyModule.class);
-        doReturn(Futures.immediateFuture(true)).when(lighty).start();
-        doReturn(Futures.immediateFuture(true)).when(lighty).shutdown();
+        doReturn(true).when(lighty).initModules();
+        doReturn(true).when(lighty).close();
         doReturn(lighty).when(app).createRncLightyModule(any(), eq(90));
         app.start(new String[] {"-c","src/main/resources/configuration.json", "-t", "90"});
     }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/test/java/io/lighty/applications/rnc/app/MainTest.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/test/java/io/lighty/applications/rnc/app/MainTest.java
@@ -16,12 +16,13 @@ import static org.mockito.Mockito.verify;
 
 import com.google.common.util.concurrent.Futures;
 import io.lighty.applications.rnc.module.RncLightyModule;
+import io.lighty.applications.rnc.module.exception.RncLightyAppStartException;
 import org.testng.annotations.Test;
 
 public class MainTest {
 
     @Test
-    public void testStartWithDefaultConfiguration() {
+    public void testStartWithDefaultConfiguration() throws RncLightyAppStartException {
         Main app = spy(new Main());
         RncLightyModule lighty = mock(RncLightyModule.class);
         doReturn(lighty).when(lighty).setRncModuleTimeout(any());
@@ -32,7 +33,7 @@ public class MainTest {
     }
 
     @Test
-    public void testStartWithConfigFile() {
+    public void testStartWithConfigFile() throws RncLightyAppStartException {
         Main app = spy(new Main());
         RncLightyModule lighty = mock(RncLightyModule.class);
         doReturn(lighty).when(lighty).setRncModuleTimeout(any());
@@ -43,7 +44,7 @@ public class MainTest {
     }
 
     @Test
-    public void testStartWithConfigFileNoSuchFile() {
+    public void testStartWithConfigFileNoSuchFile() throws RncLightyAppStartException {
         Main app = spy(new Main());
         verify(app, never()).createRncLightyModule(any());
         app.start(new String[] {"-c","no_config.json"});

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/test/java/io/lighty/applications/rnc/app/MainTest.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/test/java/io/lighty/applications/rnc/app/MainTest.java
@@ -29,7 +29,7 @@ public class MainTest {
         RncLightyModule lighty = mock(RncLightyModule.class);
         doReturn(true).when(lighty).initModules();
         doReturn(true).when(lighty).close();
-        doReturn(lighty).when(app).createRncLightyModule(any(), eq(30));
+        doReturn(lighty).when(app).createRncLightyModule(any(), eq(60));
         app.start(new String[] {});
     }
 
@@ -46,14 +46,14 @@ public class MainTest {
     @Test
     public void testStartWithConfigFileNoSuchFile() throws RncLightyAppStartException {
         Main app = spy(new Main());
-        verify(app, never()).createRncLightyModule(any(), eq(30));
+        verify(app, never()).createRncLightyModule(any(), eq(60));
         app.start(new String[] {"-c","no_config.json"});
     }
 
     @Test
     public void testStartWithWrongTimeOut() {
         final Main app = spy(new Main());
-        verify(app, never()).createRncLightyModule(any(), eq(30));
+        verify(app, never()).createRncLightyModule(any(), eq(60));
         Assert.assertThrows(ParameterException.class, () -> app.start(new String[] {"-t", "WRONG_TIME_OUT"}));
     }
 }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/test/java/io/lighty/applications/rnc/app/MainTest.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/test/java/io/lighty/applications/rnc/app/MainTest.java
@@ -8,15 +8,18 @@
 package io.lighty.applications.rnc.app;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
+import com.beust.jcommander.ParameterException;
 import com.google.common.util.concurrent.Futures;
 import io.lighty.applications.rnc.module.RncLightyModule;
 import io.lighty.applications.rnc.module.exception.RncLightyAppStartException;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class MainTest {
@@ -27,7 +30,7 @@ public class MainTest {
         RncLightyModule lighty = mock(RncLightyModule.class);
         doReturn(Futures.immediateFuture(true)).when(lighty).start();
         doReturn(Futures.immediateFuture(true)).when(lighty).shutdown();
-        doReturn(lighty).when(app).createRncLightyModule(any());
+        doReturn(lighty).when(app).createRncLightyModule(any(), eq(30));
         app.start(new String[] {});
     }
 
@@ -37,14 +40,21 @@ public class MainTest {
         RncLightyModule lighty = mock(RncLightyModule.class);
         doReturn(Futures.immediateFuture(true)).when(lighty).start();
         doReturn(Futures.immediateFuture(true)).when(lighty).shutdown();
-        doReturn(lighty).when(app).createRncLightyModule(any());
-        app.start(new String[] {"-c","src/main/resources/configuration.json"});
+        doReturn(lighty).when(app).createRncLightyModule(any(), eq(90));
+        app.start(new String[] {"-c","src/main/resources/configuration.json", "-t", "90"});
     }
 
     @Test
     public void testStartWithConfigFileNoSuchFile() throws RncLightyAppStartException {
         Main app = spy(new Main());
-        verify(app, never()).createRncLightyModule(any());
+        verify(app, never()).createRncLightyModule(any(), eq(30));
         app.start(new String[] {"-c","no_config.json"});
+    }
+
+    @Test
+    public void testStartWithWrongTimeOut() {
+        final Main app = spy(new Main());
+        verify(app, never()).createRncLightyModule(any(), eq(30));
+        Assert.assertThrows(ParameterException.class, () -> app.start(new String[] {"-t", "WRONG_TIME_OUT"}));
     }
 }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/test/java/io/lighty/applications/rnc/app/MainTest.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/test/java/io/lighty/applications/rnc/app/MainTest.java
@@ -17,14 +17,13 @@ import static org.mockito.Mockito.verify;
 
 import com.beust.jcommander.ParameterException;
 import io.lighty.applications.rnc.module.RncLightyModule;
-import io.lighty.applications.rnc.module.exception.RncLightyAppStartException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class MainTest {
 
     @Test
-    public void testStartWithDefaultConfiguration() throws RncLightyAppStartException {
+    public void testStartWithDefaultConfiguration() {
         Main app = spy(new Main());
         RncLightyModule lighty = mock(RncLightyModule.class);
         doReturn(true).when(lighty).initModules();
@@ -34,7 +33,7 @@ public class MainTest {
     }
 
     @Test
-    public void testStartWithConfigFile() throws RncLightyAppStartException {
+    public void testStartWithConfigFile() {
         Main app = spy(new Main());
         RncLightyModule lighty = mock(RncLightyModule.class);
         doReturn(true).when(lighty).initModules();
@@ -44,7 +43,7 @@ public class MainTest {
     }
 
     @Test
-    public void testStartWithConfigFileNoSuchFile() throws RncLightyAppStartException {
+    public void testStartWithConfigFileNoSuchFile() {
         Main app = spy(new Main());
         verify(app, never()).createRncLightyModule(any(), eq(60));
         app.start(new String[] {"-c","no_config.json"});

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/test/java/io/lighty/applications/rnc/app/MainTest.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/test/java/io/lighty/applications/rnc/app/MainTest.java
@@ -24,6 +24,7 @@ public class MainTest {
     public void testStartWithDefaultConfiguration() {
         Main app = spy(new Main());
         RncLightyModule lighty = mock(RncLightyModule.class);
+        doReturn(lighty).when(lighty).setRncModuleTimeout(any());
         doReturn(Futures.immediateFuture(true)).when(lighty).start();
         doReturn(Futures.immediateFuture(true)).when(lighty).shutdown();
         doReturn(lighty).when(app).createRncLightyModule(any());
@@ -34,6 +35,7 @@ public class MainTest {
     public void testStartWithConfigFile() {
         Main app = spy(new Main());
         RncLightyModule lighty = mock(RncLightyModule.class);
+        doReturn(lighty).when(lighty).setRncModuleTimeout(any());
         doReturn(Futures.immediateFuture(true)).when(lighty).start();
         doReturn(Futures.immediateFuture(true)).when(lighty).shutdown();
         doReturn(lighty).when(app).createRncLightyModule(any());

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/test/java/io/lighty/applications/rnc/app/MainTest.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/test/java/io/lighty/applications/rnc/app/MainTest.java
@@ -14,10 +14,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertThrows;
 
 import com.beust.jcommander.ParameterException;
 import io.lighty.applications.rnc.module.RncLightyModule;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class MainTest {
@@ -45,14 +45,14 @@ public class MainTest {
     @Test
     public void testStartWithConfigFileNoSuchFile() {
         Main app = spy(new Main());
-        verify(app, never()).createRncLightyModule(any(), eq(60));
         app.start(new String[] {"-c","no_config.json"});
+        verify(app, never()).createRncLightyModule(any(), eq(60));
     }
 
     @Test
     public void testStartWithWrongTimeOut() {
         final Main app = spy(new Main());
+        assertThrows(ParameterException.class, () -> app.start(new String[] {"-t", "WRONG_TIME_OUT"}));
         verify(app, never()).createRncLightyModule(any(), eq(60));
-        Assert.assertThrows(ParameterException.class, () -> app.start(new String[] {"-t", "WRONG_TIME_OUT"}));
     }
 }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/RncLightyModule.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/RncLightyModule.java
@@ -41,11 +41,11 @@ import org.slf4j.LoggerFactory;
 public class RncLightyModule extends AbstractLightyModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(RncLightyModule.class);
-    private static final long DEFAULT_LIGHTY_MODULE_TIMEOUT = 60;
     private static final TimeUnit DEFAULT_LIGHTY_MODULE_TIME_UNIT = TimeUnit.SECONDS;
 
     private final RncLightyModuleConfiguration rncModuleConfig;
 
+    private Integer lightyModuleTimeout = 60;
     private LightyController lightyController;
     private CommunityRestConf lightyRestconf;
     private NetconfSBPlugin lightyNetconf;
@@ -56,6 +56,11 @@ public class RncLightyModule extends AbstractLightyModule {
         LOG.info("Creating instance of RNC lighty.io module...");
         this.rncModuleConfig = rncModuleConfig;
         LOG.info("Instance of RNC lighty.io module created!");
+    }
+
+    public RncLightyModule setRncModuleTimeout(final Integer rncModuleTimeout) {
+        this.lightyModuleTimeout = rncModuleTimeout;
+        return this;
     }
 
     @Override
@@ -137,7 +142,7 @@ public class RncLightyModule extends AbstractLightyModule {
         try {
             LOG.info("Initializing lighty.io module ({})...", lightyModule.getClass());
             boolean startSuccess = lightyModule.start()
-                    .get(DEFAULT_LIGHTY_MODULE_TIMEOUT, DEFAULT_LIGHTY_MODULE_TIME_UNIT);
+                    .get(lightyModuleTimeout, DEFAULT_LIGHTY_MODULE_TIME_UNIT);
             if (startSuccess) {
                 LOG.info("lighty.io module ({}) initialized successfully!", lightyModule.getClass());
             } else {
@@ -192,7 +197,7 @@ public class RncLightyModule extends AbstractLightyModule {
         try {
             LOG.info("Stopping lighty.io module ({})...", lightyModule.getClass());
             boolean stopSuccess =
-                    lightyModule.shutdown().get(DEFAULT_LIGHTY_MODULE_TIMEOUT, DEFAULT_LIGHTY_MODULE_TIME_UNIT);
+                    lightyModule.shutdown().get(lightyModuleTimeout, DEFAULT_LIGHTY_MODULE_TIME_UNIT);
             if (stopSuccess) {
                 LOG.info("lighty.io module ({}) stopped successfully!", lightyModule.getClass());
                 return true;

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/RncLightyModule.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/RncLightyModule.java
@@ -45,22 +45,18 @@ public class RncLightyModule extends AbstractLightyModule {
 
     private final RncLightyModuleConfiguration rncModuleConfig;
 
-    private Integer lightyModuleTimeout = 60;
+    private final int lightyModuleTimeout;
     private LightyController lightyController;
     private CommunityRestConf lightyRestconf;
     private NetconfSBPlugin lightyNetconf;
     private AAALighty aaaLighty;
     private LightyServerBuilder jettyServerBuilder;
 
-    public RncLightyModule(RncLightyModuleConfiguration rncModuleConfig) {
+    public RncLightyModule(final RncLightyModuleConfiguration rncModuleConfig, final int lightyModuleTimeout) {
         LOG.info("Creating instance of RNC lighty.io module...");
         this.rncModuleConfig = rncModuleConfig;
+        this.lightyModuleTimeout = lightyModuleTimeout;
         LOG.info("Instance of RNC lighty.io module created!");
-    }
-
-    public RncLightyModule setRncModuleTimeout(final Integer rncModuleTimeout) {
-        this.lightyModuleTimeout = rncModuleTimeout;
-        return this;
     }
 
     @Override

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/RncLightyModule.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/RncLightyModule.java
@@ -14,7 +14,6 @@ import io.lighty.applications.rnc.module.config.RncLightyModuleConfiguration;
 import io.lighty.applications.rnc.module.config.RncRestConfConfiguration;
 import io.lighty.applications.rnc.module.config.util.RncRestConfConfigUtils;
 import io.lighty.applications.rnc.module.exception.RncLightyAppStartException;
-import io.lighty.core.controller.api.AbstractLightyModule;
 import io.lighty.core.controller.api.LightyController;
 import io.lighty.core.controller.api.LightyModule;
 import io.lighty.core.controller.api.LightyServices;
@@ -38,7 +37,7 @@ import org.opendaylight.mdsal.binding.api.DataBroker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class RncLightyModule extends AbstractLightyModule {
+public class RncLightyModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(RncLightyModule.class);
     private static final TimeUnit DEFAULT_LIGHTY_MODULE_TIME_UNIT = TimeUnit.SECONDS;
@@ -59,8 +58,7 @@ public class RncLightyModule extends AbstractLightyModule {
         LOG.info("Instance of RNC lighty.io module created!");
     }
 
-    @Override
-    protected boolean initProcedure() {
+    public boolean initModules() {
         LOG.info("Initializing RNC lighty.io module...");
         try {
             this.lightyController = initController(this.rncModuleConfig.getControllerConfig());
@@ -157,8 +155,7 @@ public class RncLightyModule extends AbstractLightyModule {
         }
     }
 
-    @Override
-    protected boolean stopProcedure() {
+    public boolean close() {
         LOG.info("Stopping RNC lighty.io application...");
         boolean success = true;
 

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/java/io/lighty/applications/rnc/module/RncLightyModuleSmokeTest.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/java/io/lighty/applications/rnc/module/RncLightyModuleSmokeTest.java
@@ -20,13 +20,13 @@ import java.util.concurrent.TimeoutException;
 import org.testng.annotations.Test;
 
 public class RncLightyModuleSmokeTest {
-    private static final long MODULE_TIMEOUT = 60;
+    private static final int MODULE_TIMEOUT = 60;
     private static final TimeUnit MODULE_TIME_UNIT = TimeUnit.SECONDS;
 
     @Test
     public void rncLightyModuleSmokeTest()
             throws ConfigurationException, InterruptedException, ExecutionException, TimeoutException {
-        RncLightyModule rncModule = new RncLightyModule(RncLightyModuleConfigUtils.loadDefaultConfig());
+        RncLightyModule rncModule = new RncLightyModule(RncLightyModuleConfigUtils.loadDefaultConfig(), MODULE_TIMEOUT);
         rncModule.start().get(MODULE_TIMEOUT, MODULE_TIME_UNIT);
         rncModule.shutdown().get(MODULE_TIMEOUT, MODULE_TIME_UNIT);
     }
@@ -36,7 +36,7 @@ public class RncLightyModuleSmokeTest {
             ConfigurationException {
         final RncLightyModuleConfiguration config = spy(RncLightyModuleConfigUtils.loadDefaultConfig());
         when(config.getControllerConfig()).thenReturn(null);
-        RncLightyModule rncModule = new RncLightyModule(config);
+        RncLightyModule rncModule = new RncLightyModule(config, MODULE_TIMEOUT);
         final Boolean isStarted = rncModule.start().get(MODULE_TIMEOUT, MODULE_TIME_UNIT);
 
         assertFalse(isStarted);

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/java/io/lighty/applications/rnc/module/RncLightyModuleSmokeTest.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/java/io/lighty/applications/rnc/module/RncLightyModuleSmokeTest.java
@@ -21,7 +21,8 @@ public class RncLightyModuleSmokeTest {
 
     @Test
     public void rncLightyModuleSmokeTest() throws ConfigurationException {
-        RncLightyModule rncModule = new RncLightyModule(RncLightyModuleConfigUtils.loadDefaultConfig(), MODULE_TIMEOUT);
+        final RncLightyModule rncModule = new RncLightyModule(RncLightyModuleConfigUtils.loadDefaultConfig(),
+                MODULE_TIMEOUT);
         rncModule.initModules();
         rncModule.close();
     }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/java/io/lighty/applications/rnc/module/RncLightyModuleSmokeTest.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/java/io/lighty/applications/rnc/module/RncLightyModuleSmokeTest.java
@@ -14,30 +14,24 @@ import static org.testng.Assert.assertFalse;
 import io.lighty.applications.rnc.module.config.RncLightyModuleConfigUtils;
 import io.lighty.applications.rnc.module.config.RncLightyModuleConfiguration;
 import io.lighty.core.controller.impl.config.ConfigurationException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import org.testng.annotations.Test;
 
 public class RncLightyModuleSmokeTest {
     private static final int MODULE_TIMEOUT = 60;
-    private static final TimeUnit MODULE_TIME_UNIT = TimeUnit.SECONDS;
 
     @Test
-    public void rncLightyModuleSmokeTest()
-            throws ConfigurationException, InterruptedException, ExecutionException, TimeoutException {
+    public void rncLightyModuleSmokeTest() throws ConfigurationException {
         RncLightyModule rncModule = new RncLightyModule(RncLightyModuleConfigUtils.loadDefaultConfig(), MODULE_TIMEOUT);
-        rncModule.start().get(MODULE_TIMEOUT, MODULE_TIME_UNIT);
-        rncModule.shutdown().get(MODULE_TIMEOUT, MODULE_TIME_UNIT);
+        rncModule.initModules();
+        rncModule.close();
     }
 
     @Test
-    public void rncLightyModuleStartFailed() throws InterruptedException, ExecutionException, TimeoutException,
-            ConfigurationException {
+    public void rncLightyModuleStartFailed() throws ConfigurationException {
         final RncLightyModuleConfiguration config = spy(RncLightyModuleConfigUtils.loadDefaultConfig());
         when(config.getControllerConfig()).thenReturn(null);
         RncLightyModule rncModule = new RncLightyModule(config, MODULE_TIMEOUT);
-        final Boolean isStarted = rncModule.start().get(MODULE_TIMEOUT, MODULE_TIME_UNIT);
+        final Boolean isStarted = rncModule.initModules();
 
         assertFalse(isStarted);
     }

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/AbstractLightyModule.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/AbstractLightyModule.java
@@ -116,8 +116,8 @@ public abstract class AbstractLightyModule implements LightyModule {
         return this.executorService.submit(() -> {
             synchronized (this) {
                 LOG.debug("Starting initialization of LightyModule {}", this.getClass().getSimpleName());
-                boolean initResult = initProcedure();
                 this.running = true;
+                boolean initResult = initProcedure();
                 LOG.info("LightyModule {} started.", this.getClass().getSimpleName());
                 return initResult;
             }

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
@@ -398,6 +398,15 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
         if (this.timer != null) {
             this.timer.stop();
         }
+        if (this.threadPool != null && this.threadPool.getExecutor() != null) {
+            this.threadPool.getExecutor().shutdown();
+        }
+        if (this.scheduledThreadPool != null && this.scheduledThreadPool.getExecutor() != null) {
+            this.scheduledThreadPool.getExecutor().shutdown();
+        }
+        if (this.clusterSingletonServiceProvider != null) {
+            this.clusterSingletonServiceProvider.close();
+        }
         if (this.bindingDOMEntityOwnershipServiceAdapter != null) {
             this.bindingDOMEntityOwnershipServiceAdapter.close();
         }
@@ -408,6 +417,9 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
                 LOG.error("Closing akka AkkaEntityOwnershipService failed!", e);
                 stopSuccessful = false;
             }
+        }
+        if (this.listenableFutureExecutor != null) {
+            this.listenableFutureExecutor.shutdown();
         }
         if (this.operDatastore != null) {
             this.operDatastore.close();

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiITBase.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiITBase.java
@@ -16,7 +16,6 @@ import static io.lighty.modules.gnmi.test.gnmi.rcgnmi.GnmiITBase.GeneralConstant
 
 import gnmi.Gnmi;
 import io.lighty.applications.rcgnmi.app.RCgNMIApp;
-import io.lighty.applications.rcgnmi.module.RcGnmiAppException;
 import io.lighty.modules.gnmi.simulatordevice.config.GnmiSimulatorConfiguration;
 import io.lighty.modules.gnmi.simulatordevice.impl.SimulatedGnmiDevice;
 import io.lighty.modules.gnmi.simulatordevice.utils.GnmiSimulatorConfUtils;
@@ -62,7 +61,7 @@ public abstract class GnmiITBase {
     protected static HttpClient httpClient;
 
     @BeforeAll
-    public static void setup() throws RcGnmiAppException {
+    public static void setup() {
         httpClientExecutor = Executors.newSingleThreadExecutor();
         httpClient = HttpClient.newBuilder().executor(httpClientExecutor).build();
 

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiITBase.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiITBase.java
@@ -16,6 +16,7 @@ import static io.lighty.modules.gnmi.test.gnmi.rcgnmi.GnmiITBase.GeneralConstant
 
 import gnmi.Gnmi;
 import io.lighty.applications.rcgnmi.app.RCgNMIApp;
+import io.lighty.applications.rcgnmi.module.RcGnmiAppException;
 import io.lighty.modules.gnmi.simulatordevice.config.GnmiSimulatorConfiguration;
 import io.lighty.modules.gnmi.simulatordevice.impl.SimulatedGnmiDevice;
 import io.lighty.modules.gnmi.simulatordevice.utils.GnmiSimulatorConfUtils;
@@ -61,7 +62,7 @@ public abstract class GnmiITBase {
     protected static HttpClient httpClient;
 
     @BeforeAll
-    public static void setup() {
+    public static void setup() throws RcGnmiAppException {
         httpClientExecutor = Executors.newSingleThreadExecutor();
         httpClient = HttpClient.newBuilder().executor(httpClientExecutor).build();
 


### PR DESCRIPTION
This PR is a fix for requested changes in #885 and is triggered by issue #881 
- Add option to increase time-out for lighty apps.
- Fix closing lighty modules, if initProcedure() fails and throw exception.
- Close resources in RcGNMI and RNC app when application fails.
- Close resources in lighty.core