### PR TITLE
Bump OpenDaylight netconf to 2.0.11 & fix logs bug

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -71,7 +71,7 @@
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>netconf-artifacts</artifactId>
-                <version>2.0.9</version>
+                <version>2.0.11</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Netconf ODL dependency currently in version 2.0.9 triggers the ODL bug
NETCONF-835, making part of logs unreadable (hexadecimal log messages).
Netconf version >=2.0.11 have fixed this bug and shoud be preferred.

Bug: #888
Signed-off-by: guillaume.lambert <guillaume.lambert@orange.com>