### PR TITLE
Upgrading lift configuration to remove problematic tooling

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -1,4 +1,4 @@
 build = "maven"
 jdk11 = true
 summaryComments = true
-tools = ["open source vulnerabilities", "infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]
+tools = ["infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]

--- a/.lift.toml
+++ b/.lift.toml
@@ -1,4 +1,4 @@
 build = "maven"
 jdk11 = true
 summaryComments = true
-tools = ["infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]
+tools = ["open source vulnerabilities", "infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]

--- a/.lift.toml
+++ b/.lift.toml
@@ -1,3 +1,4 @@
 build = "maven"
 jdk11 = true
 summaryComments = true
+tools = ["infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]


### PR DESCRIPTION
There are a couple of tools in Lift that are waiting for bug fixes, but many of the other tools are successful. This update disables the problematic tooling until the fix becomes available.