### PR TITLE
Fix reported Snkyk issues - master

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/src/main/docker/Dockerfile
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/src/main/docker/Dockerfile
@@ -3,6 +3,15 @@ FROM alpine:latest
 RUN apk add openjdk11-jre
 
 WORKDIR /lighty-rcgnmi
+
+# Create new user 'rcgnmi-user' with uid 1000 and group 2000
+RUN addgroup -S 2000
+RUN adduser -S -D -h /lighty-rcgnmi rcgnmi-user 2000 --uid 1000
+# Move ownership of /lighty-rcgnmi folder to rcgnmi-user
+RUN chown -R rcgnmi-user:2000 /lighty-rcgnmi
+# Switch to rcgnmi-user
+USER rcgnmi-user
+
 COPY LICENSE ${lighty.app.name} entrypoint.sh ./
 
 EXPOSE 8888

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/src/main/docker/Dockerfile
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/src/main/docker/Dockerfile
@@ -4,13 +4,14 @@ RUN apk add openjdk11-jre
 
 WORKDIR /lighty-rcgnmi
 
-# Create new user 'rcgnmi-user' with uid 1000 and group 2000
-RUN addgroup -S 2000
-RUN adduser -S -D -h /lighty-rcgnmi rcgnmi-user 2000 --uid 1000
-# Move ownership of /lighty-rcgnmi folder to rcgnmi-user
-RUN chown -R rcgnmi-user:2000 /lighty-rcgnmi
-# Switch to rcgnmi-user
-USER rcgnmi-user
+# Create new user 'rcgnmi' with UID 1000
+# https://wiki.alpinelinux.org/wiki/Setting_up_a_new_user
+# https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md
+RUN addgroup --system rcgnmi && adduser --system --ingroup rcgnmi --uid 1000 rcgnmi
+# Move ownership of /lighty-rcgnmi folder to rcgnmi user
+RUN chown -R rcgnmi:rcgnmi /lighty-rcgnmi
+# Switch to rcgnmi user
+USER rcgnmi
 
 COPY LICENSE ${lighty.app.name} entrypoint.sh ./
 

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/src/main/docker/Dockerfile
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/src/main/docker/Dockerfile
@@ -1,4 +1,6 @@
-FROM openjdk:11-jre-slim
+FROM alpine:latest
+
+RUN apk add openjdk11-jre
 
 WORKDIR /lighty-rcgnmi
 COPY LICENSE ${lighty.app.name} entrypoint.sh ./

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/deployment.yaml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
               mountPath: {{ .Values.lighty.workdir }}/{{ .Values.lighty.configDirectoryName }}
           {{- if .Values.deploymentSecurity.useContainerSecurity }}
           securityContext:
-            allowPrivilegeEscalation: true
+            allowPrivilegeEscalation: false
             runAsUser: {{ .Values.deploymentSecurity.runAsUser }}
             capabilities:
               drop:

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/deployment.yaml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/deployment.yaml
@@ -14,11 +14,9 @@ spec:
       labels:
         {{- include "lighty-rcgnmi-app-helm.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if .Values.deploymentSecurity.usePodSecurity }}
       securityContext:
         runAsNonRoot: true
         runAsUser: {{ .Values.deploymentSecurity.runAsUser }}
-      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.name }}:{{ .Values.image.version }}"
@@ -28,14 +26,12 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: {{ .Values.lighty.workdir }}/{{ .Values.lighty.configDirectoryName }}
-          {{- if .Values.deploymentSecurity.useContainerSecurity }}
           securityContext:
             allowPrivilegeEscalation: false
             runAsUser: {{ .Values.deploymentSecurity.runAsUser }}
             capabilities:
               drop:
                 - all
-          {{- end }}
           env:
             - name: HOSTNAME
               valueFrom:

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/deployment.yaml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/deployment.yaml
@@ -14,6 +14,11 @@ spec:
       labels:
         {{- include "lighty-rcgnmi-app-helm.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.deploymentSecurity.usePodSecurity }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: {{ .Values.deploymentSecurity.runAsUser }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.name }}:{{ .Values.image.version }}"
@@ -23,6 +28,15 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: {{ .Values.lighty.workdir }}/{{ .Values.lighty.configDirectoryName }}
+          {{- if .Values.deploymentSecurity.useContainerSecurity }}
+          securityContext:
+            allowPrivilegeEscalation: true
+            runAsUser: {{ .Values.deploymentSecurity.runAsUser }}
+            capabilities:
+              drop:
+                - all
+              add: {{ .Values.deploymentSecurity.useCapabilities }}
+          {{- end }}
           env:
             - name: HOSTNAME
               valueFrom:

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/deployment.yaml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/deployment.yaml
@@ -35,7 +35,6 @@ spec:
             capabilities:
               drop:
                 - all
-              add: {{ .Values.deploymentSecurity.useCapabilities }}
           {{- end }}
           env:
             - name: HOSTNAME

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/values.yaml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/values.yaml
@@ -60,8 +60,6 @@ ingress:
   managementHost: "management.lighty.io"
 
 deploymentSecurity:
-  usePodSecurity: true
-  useContainerSecurity: true
   # User with UID 1000 is set in RcGNMI docker image
   runAsUser: 1000
 

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/values.yaml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/values.yaml
@@ -64,8 +64,6 @@ deploymentSecurity:
   useContainerSecurity: true
   # User with UID 1000 is set in RcGNMI docker image
   runAsUser: 1000
-  # Description for possible capabilities https://github.com/torvalds/linux/blob/master/include/uapi/linux/capability.h
-  useCapabilities: ["NET_BIND_SERVICE"]
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/values.yaml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/values.yaml
@@ -59,6 +59,14 @@ ingress:
   exposeManagement: false
   managementHost: "management.lighty.io"
 
+deploymentSecurity:
+  usePodSecurity: true
+  useContainerSecurity: true
+  # User with UID 1000 is set in RcGNMI docker image
+  runAsUser: 1000
+  # Description for possible capabilities https://github.com/torvalds/linux/blob/master/include/uapi/linux/capability.h
+  useCapabilities: ["NET_BIND_SERVICE"]
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/src/main/docker/Dockerfile
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/src/main/docker/Dockerfile
@@ -3,6 +3,15 @@ FROM alpine:latest
 RUN apk add openjdk11-jre
 
 WORKDIR /lighty-rnc
+
+# Create new user 'rnc-user' with uid 1000 and group 2000
+RUN addgroup -S 2000
+RUN adduser -S -D -h /lighty-rnc rnc-user 2000 --uid 1000
+# Move ownership of /lighty-rnc folder to rnc-user
+RUN chown -R rnc-user:2000 /lighty-rnc
+# Switch to rnc-user
+USER rnc-user
+
 COPY LICENSE ${lighty.app.name} entrypoint.sh ./
 
 EXPOSE 8888

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/src/main/docker/Dockerfile
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/src/main/docker/Dockerfile
@@ -4,13 +4,14 @@ RUN apk add openjdk11-jre
 
 WORKDIR /lighty-rnc
 
-# Create new user 'rnc-user' with uid 1000 and group 2000
-RUN addgroup -S 2000
-RUN adduser -S -D -h /lighty-rnc rnc-user 2000 --uid 1000
-# Move ownership of /lighty-rnc folder to rnc-user
-RUN chown -R rnc-user:2000 /lighty-rnc
-# Switch to rnc-user
-USER rnc-user
+# Create new user 'rnc' with UID 1000
+# https://wiki.alpinelinux.org/wiki/Setting_up_a_new_user
+# https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md
+RUN addgroup --system rnc && adduser --system --ingroup rnc --uid 1000 rnc
+# Move ownership of /lighty-rnc folder to rnc user
+RUN chown -R rnc:rnc /lighty-rnc
+# Switch to rnc user
+USER rnc
 
 COPY LICENSE ${lighty.app.name} entrypoint.sh ./
 

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/src/main/docker/Dockerfile
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/src/main/docker/Dockerfile
@@ -1,4 +1,6 @@
-FROM openjdk:11-jre-slim
+FROM alpine:latest
+
+RUN apk add openjdk11-jre
 
 WORKDIR /lighty-rnc
 COPY LICENSE ${lighty.app.name} entrypoint.sh ./

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/deployment.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/deployment.yaml
@@ -14,11 +14,9 @@ spec:
       labels:
         {{- include "lighty-rnc-app-helm.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if .Values.deploymentSecurity.usePodSecurity }}
       securityContext:
         runAsNonRoot: true
         runAsUser: {{ .Values.deploymentSecurity.runAsUser }}
-      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.name }}:{{ .Values.image.version }}"
@@ -30,14 +28,12 @@ spec:
               mountPath: {{ .Values.lighty.workdir }}/{{ .Values.lighty.configDirectoryName }}
             - name: secrets-volume
               mountPath: {{ .Values.lighty.workdir }}/{{ .Values.lighty.restconf.keyStoreDirectory }}
-          {{- if .Values.deploymentSecurity.useContainerSecurity }}
           securityContext:
             allowPrivilegeEscalation: false
             runAsUser: {{ .Values.deploymentSecurity.runAsUser }}
             capabilities:
               drop:
                 - all
-          {{- end }}
           env:
             - name: HOSTNAME
               valueFrom:

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/deployment.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
               mountPath: {{ .Values.lighty.workdir }}/{{ .Values.lighty.restconf.keyStoreDirectory }}
           {{- if .Values.deploymentSecurity.useContainerSecurity }}
           securityContext:
-            allowPrivilegeEscalation: true
+            allowPrivilegeEscalation: false
             runAsUser: {{ .Values.deploymentSecurity.runAsUser }}
             capabilities:
               drop:

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/deployment.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/deployment.yaml
@@ -37,7 +37,6 @@ spec:
             capabilities:
               drop:
                 - all
-              add: {{ .Values.deploymentSecurity.useCapabilities }}
           {{- end }}
           env:
             - name: HOSTNAME

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/deployment.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/deployment.yaml
@@ -14,6 +14,11 @@ spec:
       labels:
         {{- include "lighty-rnc-app-helm.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.deploymentSecurity.usePodSecurity }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: {{ .Values.deploymentSecurity.runAsUser }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.name }}:{{ .Values.image.version }}"
@@ -25,6 +30,15 @@ spec:
               mountPath: {{ .Values.lighty.workdir }}/{{ .Values.lighty.configDirectoryName }}
             - name: secrets-volume
               mountPath: {{ .Values.lighty.workdir }}/{{ .Values.lighty.restconf.keyStoreDirectory }}
+          {{- if .Values.deploymentSecurity.useContainerSecurity }}
+          securityContext:
+            allowPrivilegeEscalation: true
+            runAsUser: {{ .Values.deploymentSecurity.runAsUser }}
+            capabilities:
+              drop:
+                - all
+              add: {{ .Values.deploymentSecurity.useCapabilities }}
+          {{- end }}
           env:
             - name: HOSTNAME
               valueFrom:

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/values.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/values.yaml
@@ -70,8 +70,6 @@ ingress:
   managementHost: "management.lighty.io"
 
 deploymentSecurity:
-  usePodSecurity: true
-  useContainerSecurity: true
   # User with UID 1000 is set in RNC docker image
   runAsUser: 1000
 

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/values.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/values.yaml
@@ -69,6 +69,14 @@ ingress:
   exposeManagement: false
   managementHost: "management.lighty.io"
 
+deploymentSecurity:
+  usePodSecurity: true
+  useContainerSecurity: true
+  # User with UID 1000 is set in RNC docker image
+  runAsUser: 1000
+  # Description for possible capabilities https://github.com/torvalds/linux/blob/master/include/uapi/linux/capability.h
+  useCapabilities: ["NET_BIND_SERVICE"]
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/values.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/values.yaml
@@ -74,8 +74,6 @@ deploymentSecurity:
   useContainerSecurity: true
   # User with UID 1000 is set in RNC docker image
   runAsUser: 1000
-  # Description for possible capabilities https://github.com/torvalds/linux/blob/master/include/uapi/linux/capability.h
-  useCapabilities: ["NET_BIND_SERVICE"]
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
@@ -22,8 +22,8 @@
     <version>16.0.0-SNAPSHOT</version>
 
     <properties>
-        <protobuf.version>3.11.3</protobuf.version>
-        <grpc.version>1.27.0</grpc.version>
+        <protobuf.version>3.19.3</protobuf.version>
+        <grpc.version>1.44.0</grpc.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Bump versions in lighty-gnmi-proto
 protobuf 3.11.3 -> 3.19.3
 grpc 1.27.0 -> 1.44.0

Use Alpine instead of Debian in docker container
 openjdk:11-jre-slim use Debian OS which has known vulnerabilities
https://security-tracker.debian.org/tracker/CVE-2022-23218
https://security-tracker.debian.org/tracker/CVE-2022-23219
https://security-tracker.debian.org/tracker/CVE-2021-33574
https://security-tracker.debian.org/tracker/CVE-2020-16156
https://security-tracker.debian.org/tracker/CVE-2021-33560

 Hence, we changed it to Alpine Linux and install JRE inside docker.
Before docker size with openjdk:11-jre-slim:
   - RNC 15.1.0    : 352 MB
   - RcGNMI 15.1.0 : 337 MB

Size of docker images with Alpine:
   - RNC 15.1.0    : 311 MB
   - RcGNMI 15.1.0 : 296 MB
   
Fix lighty applications helm-charts vulnerability:
https://snyk.io/security-rules/SNYK-CC-K8S-6
https://snyk.io/security-rules/SNYK-CC-K8S-9
https://snyk.io/security-rules/SNYK-CC-K8S-10