### PR TITLE
Upgrading lift configuration to remove problematic tooling (cherry-pick #906)

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -1,4 +1,4 @@
 build = "maven"
 jdk11 = true
 summaryComments = true
-tools = ["open source vulnerabilities", "infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]
+tools = ["infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]

--- a/.lift.toml
+++ b/.lift.toml
@@ -1,4 +1,4 @@
 build = "maven"
 jdk11 = true
 summaryComments = true
-tools = ["infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]
+tools = ["open source vulnerabilities", "infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]

--- a/.lift.toml
+++ b/.lift.toml
@@ -1,3 +1,4 @@
 build = "maven"
 jdk11 = true
 summaryComments = true
+tools = ["infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]


### PR DESCRIPTION
Cherry-picks #906, but with `signed-off-by` added to commit messages

There are a couple of tools in Lift that are waiting for bug fixes, but many of the other tools are successful. This update disables the problematic tooling until the fix becomes available.