### PR TITLE
Prepare release 15.2.0

### DIFF
--- a/.github/workflows/lighty-rcgnmi-app/tests-lighty-rcgnmi-app.sh
+++ b/.github/workflows/lighty-rcgnmi-app/tests-lighty-rcgnmi-app.sh
@@ -44,7 +44,7 @@ ls -1 yangs
 #Run simulator for testing purpose
 printLine
 echo -e "-- Starting gNMI simulator device --\n"
-java -jar ${GITHUB_WORKSPACE}/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/target/lighty-gnmi-device-simulator-15.1.1-SNAPSHOT.jar -c ./simulator/example_config.json > /dev/null 2>&1 &
+java -jar ${GITHUB_WORKSPACE}/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/target/lighty-gnmi-device-simulator-15.2.0.jar -c ./simulator/example_config.json > /dev/null 2>&1 &
 
 
 #Add yangs into controller through REST rpc

--- a/.github/workflows/lighty-rnc-app/simulator/Dockerfile
+++ b/.github/workflows/lighty-rnc-app/simulator/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git as clone
 WORKDIR /netconf-simulator
-RUN git clone https://github.com/PANTHEONtech/lighty-netconf-simulator.git -b 14.2.0
+RUN git clone https://github.com/PANTHEONtech/lighty-netconf-simulator.git -b 15.1.0
 
 FROM maven:3.8-jdk-11-slim as build
 WORKDIR /lighty-netconf-simulator
@@ -13,4 +13,4 @@ COPY --from=build /lighty-netconf-simulator/examples/devices/lighty-network-topo
 
 EXPOSE 17380
 
-ENTRYPOINT ["java", "-jar", "/lighty-netconf-simulator/target/lighty-network-topology-device-14.2.0.jar"]
+ENTRYPOINT ["java", "-jar", "/lighty-netconf-simulator/target/lighty-network-topology-device-15.1.0.jar"]

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>io.lighty.applications.rcgnmi</groupId>
     <artifactId>lighty-rcgnmi-app-docker</artifactId>
-    <version>15.1.1-SNAPSHOT</version>
+    <version>15.2.0</version>
 
     <properties>
         <image.name>lighty-rcgnmi</image.name>

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.applications.rnc</groupId>
     <artifactId>lighty-rnc-app-docker</artifactId>
-    <version>15.1.1-SNAPSHOT</version>
+    <version>15.2.0</version>
 
     <properties>
         <image.name>lighty-rnc</image.name>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -46,15 +46,6 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <!-- Bundle parent brings dependency management for artifacts used by Akka: (scala, typesafe, aeron.. ).
-                This artifact dependency management was removed from odl-parent in Aluminium release. -->
-                <groupId>org.opendaylight.controller</groupId>
-                <artifactId>bundle-parent</artifactId>
-                <version>4.0.10</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.opendaylight.infrautils</groupId>
                 <artifactId>infrautils-artifacts</artifactId>
                 <version>2.0.13</version>
@@ -98,6 +89,11 @@
                 <groupId>com.google.inject</groupId>
                 <artifactId>guice</artifactId>
                 <version>4.2.3</version>
+            </dependency>
+            <dependency>
+                <groupId>com.typesafe</groupId>
+                <artifactId>config</artifactId>
+                <version>1.4.2</version>
             </dependency>
             <dependency>
                 <groupId>org.testng</groupId>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -258,8 +258,8 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>15.2.0</tag>
+    </scm>
     <developers>
         <developer>
             <id>rovarga</id>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
-                <version>9.0.8</version>
+                <version>9.0.13</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -34,14 +34,14 @@
             <dependency>
                 <groupId>org.opendaylight.aaa</groupId>
                 <artifactId>aaa-artifacts</artifactId>
-                <version>0.14.7</version>
+                <version>0.14.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>controller-artifacts</artifactId>
-                <version>4.0.7</version>
+                <version>4.0.10</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -50,35 +50,35 @@
                 This artifact dependency management was removed from odl-parent in Aluminium release. -->
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>bundle-parent</artifactId>
-                <version>4.0.7</version>
+                <version>4.0.10</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.infrautils</groupId>
                 <artifactId>infrautils-artifacts</artifactId>
-                <version>2.0.8</version>
+                <version>2.0.13</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.mdsal</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>8.0.7</version>
+                <version>8.0.12</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>netconf-artifacts</artifactId>
-                <version>2.0.11</version>
+                <version>2.0.14</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yangtools-artifacts</artifactId>
-                <version>7.0.9</version>
+                <version>7.0.14</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -34,7 +34,7 @@
             <dependency>
                 <groupId>org.opendaylight.aaa</groupId>
                 <artifactId>aaa-artifacts</artifactId>
-                <version>0.14.9</version>
+                <version>0.14.10</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -54,12 +54,12 @@
             <plugin>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yang-maven-plugin</artifactId>
-                <version>7.0.9</version>
+                <version>7.0.14</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.opendaylight.mdsal</groupId>
                         <artifactId>mdsal-binding-java-api-generator</artifactId>
-                        <version>8.0.7</version>
+                        <version>8.0.12</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/lighty-core/lighty-bom/pom.xml
+++ b/lighty-core/lighty-bom/pom.xml
@@ -266,8 +266,8 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>15.2.0</tag>
+    </scm>
     <developers>
         <developer>
             <id>rovarga</id>

--- a/lighty-core/lighty-controller/README.md
+++ b/lighty-core/lighty-controller/README.md
@@ -17,7 +17,7 @@ To use Lighty controller in your project:
   <dependency>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-controller</artifactId>
-    <version>15.1.1-SNAPSHOT</version>
+    <version>15.2.0</version>
   </dependency>
 ```
 

--- a/lighty-core/lighty-minimal-parent/pom.xml
+++ b/lighty-core/lighty-minimal-parent/pom.xml
@@ -103,8 +103,8 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>15.2.0</tag>
+    </scm>
     <developers>
         <developer>
             <id>rovarga</id>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -174,7 +174,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>9.0.8</version>
+                            <version>9.0.13</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -191,7 +191,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>spotbugs</artifactId>
-                            <version>9.0.8</version>
+                            <version>9.0.13</version>
                         </dependency>
                         <dependency>
                             <!-- The SpotBugs Maven plugin uses SLF4J 1.8 beta 2 -->

--- a/lighty-examples/README.md
+++ b/lighty-examples/README.md
@@ -15,7 +15,7 @@ ODL core services represent MD-SAL layer, controller, DataStore, global schema c
    <dependency>
       <groupId>io.lighty.core.parents</groupId>
       <artifactId>lighty-dependency-artifacts</artifactId>
-      <version>15.1.1-SNAPSHOT</version>
+      <version>15.2.0</version>
       <type>pom</type>
       <scope>import</scope>
    </dependency>

--- a/lighty-examples/lighty-community-restconf-actions-app/src/main/java/io/lighty/examples/controllers/actions/binding/ServerResetRegistrationUtil.java
+++ b/lighty-examples/lighty-community-restconf-actions-app/src/main/java/io/lighty/examples/controllers/actions/binding/ServerResetRegistrationUtil.java
@@ -9,6 +9,7 @@ package io.lighty.examples.controllers.actions.binding;
 
 import io.lighty.core.controller.api.LightyController;
 import java.util.Set;
+import org.opendaylight.mdsal.binding.api.ActionSpec;
 import org.opendaylight.mdsal.common.api.LogicalDatastoreType;
 import org.opendaylight.yang.gen.v1.urn.example.data.center.rev180807.Server;
 import org.opendaylight.yang.gen.v1.urn.example.data.center.rev180807.ServerKey;
@@ -32,7 +33,8 @@ public final class ServerResetRegistrationUtil {
         final var actionProviderService = lightyController.getServices().getActionProviderService();
         final var validNode =
                 InstanceIdentifier.builder(Server.class, new ServerKey("server-earth")).build();
-        return actionProviderService.registerImplementation(Reset.class, new ServerResetActionImpl(),
+        final var actionSpec = ActionSpec.builder(Server.class).build(Reset.class);
+        return actionProviderService.registerImplementation(actionSpec, new ServerResetActionImpl(),
                 LogicalDatastoreType.OPERATIONAL, Set.of(validNode));
     }
 }

--- a/lighty-examples/lighty-community-restconf-netconf-app/README.md
+++ b/lighty-examples/lighty-community-restconf-netconf-app/README.md
@@ -21,12 +21,12 @@ build the project: ```mvn clean install```
 ### Start this demo example
 * build the project using ```mvn clean install```
 * go to target directory ```cd lighty-examples/lighty-community-restconf-netconf-app/target``` 
-* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-15.1.1-SNAPSHOT-bin.zip```
-* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-15.1.1-SNAPSHOT```
-* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-15.1.1-SNAPSHOT.jar``` 
+* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-15.2.0-bin.zip```
+* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-15.2.0```
+* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-15.2.0.jar``` 
 
 ### Test example application
-Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-15.1.1-SNAPSHOT.jar``` 
+Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-15.2.0.jar``` 
 RESTCONF web interface is available at URL ```http://localhost:8888/restconf/*```
 
 ##### URLs to start with
@@ -43,7 +43,7 @@ URLs for Swagger (choose RESTCONF [draft18](https://tools.ietf.org/html/draft-ie
 
 ### Use custom config files
 There are two separated config files: for NETCONF SBP single node and for cluster.
-`java -jar lighty-community-restconf-netconf-app-15.1.1-SNAPSHOT.jar /path/to/singleNodeConfig.json`
+`java -jar lighty-community-restconf-netconf-app-15.2.0.jar /path/to/singleNodeConfig.json`
 
 Example configuration for single node is [here](src/main/assembly/resources/sampleConfigSingleNode.json)
 

--- a/lighty-examples/lighty-controller-springboot-netconf/README.md
+++ b/lighty-examples/lighty-controller-springboot-netconf/README.md
@@ -46,7 +46,7 @@ mvn spring-boot:run
 or
 
 ```
-java -jar target/lighty-controller-springboot-15.1.1-SNAPSHOT.jar
+java -jar target/lighty-controller-springboot-15.2.0.jar
 ```
 
 or in any IDE, run main in 

--- a/lighty-examples/lighty-gnmi-community-restconf-app/README.md
+++ b/lighty-examples/lighty-gnmi-community-restconf-app/README.md
@@ -14,7 +14,7 @@ This application starts:
 * [Lighty.io Controller](../../lighty-core/lighty-controller) with modules:
   * [lighty.io RESTCONF module](../../lighty-modules/lighty-restconf-nb-community)
   * [lighty.io gNMI module](../../lighty-modules/lighty-gnmi/lighty-gnmi-sb)
-* [lighty.io gNMI device simulator](https://github.com/PANTHEONtech/lighty/tree/14.2.0/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator)
+* [lighty.io gNMI device simulator](https://github.com/PANTHEONtech/lighty/tree/15.2.0/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator)
 
 ![lighty.io gNMI / RESTCONF architecture](docs/lighty-gnmi-restconf-architecture.png)
 
@@ -42,22 +42,22 @@ cd lighty-examples/lighty-gnmi-community-restconf-app
 ### Start RCgNMI controller app
 Unzip lighty-rcgnmi-app to current location
 ```
-unzip ../../lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/target/lighty-rcgnmi-app-15.1.1-SNAPSHOT-bin.zip
+unzip ../../lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/target/lighty-rcgnmi-app-15.2.0-bin.zip
 ```
 Start application with pre-prepared configuration [example_config.json](example_config.json).
 ```
-java -jar lighty-rcgnmi-app-15.1.1-SNAPSHOT/lighty-rcgnmi-app-15.1.1-SNAPSHOT.jar -c example_config.json
+java -jar lighty-rcgnmi-app-15.2.0/lighty-rcgnmi-app-15.2.0.jar -c example_config.json
 ```
 
 ### Start lighty.io gNMI device simulator
 Unzip gNMI simulator app to current folder.
 ```
-unzip ../../lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/target/lighty-gnmi-device-simulator-15.1.1-SNAPSHOT-bin.zip
+unzip ../../lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/target/lighty-gnmi-device-simulator-15.2.0-bin.zip
 ```
 
 Start the application with pre-prepared configuration [simulator_config.json](simulator/simulator_config.json)
 ```
-java -jar lighty-gnmi-device-simulator-15.1.1-SNAPSHOT/lighty-gnmi-device-simulator-15.1.1-SNAPSHOT.jar  -c simulator/simulator_config.json 
+java -jar lighty-gnmi-device-simulator-15.2.0/lighty-gnmi-device-simulator-15.2.0.jar  -c simulator/simulator_config.json 
 ```
 
 ### Add client certificates to lighty.io gNMI keystore

--- a/lighty-models/README.md
+++ b/lighty-models/README.md
@@ -56,7 +56,7 @@ my-model/pom.xml
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>15.1.1-SNAPSHOT</version>
+        <version>15.2.0</version>
         <relativePath/>
     </parent>
 

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/README.md
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/README.md
@@ -8,7 +8,7 @@ This simulator provides gNMI device driven by gNMI proto files, with datastore d
    <dependency>
       <groupId>io.lighty.modules.gnmi</groupId>
       <artifactId>lighty-gnmi-device-simulator</artifactId>
-      <version>15.1.1-SNAPSHOT</version>
+      <version>15.2.0</version>
    </dependency>
 ```
 

--- a/lighty-modules/lighty-netconf-sb/README.md
+++ b/lighty-modules/lighty-netconf-sb/README.md
@@ -42,7 +42,7 @@ To use NETCONF in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-netconf-sb</artifactId>
-    <version>15.1.1-SNAPSHOT</version>
+    <version>15.2.0</version>
   </dependency>  
 ```
 2. Initialize and start an instance of NETCONF SBP in your code:

--- a/lighty-modules/lighty-restconf-nb-community/README.md
+++ b/lighty-modules/lighty-restconf-nb-community/README.md
@@ -12,7 +12,7 @@ To use RESTCONF in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-restconf-nb-community</artifactId>
-    <version>15.1.1-SNAPSHOT</version>
+    <version>15.2.0</version>
   </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-        <tag>HEAD</tag>
+        <tag>15.2.0</tag>
     </scm>
     <developers>
         <developer>


### PR DESCRIPTION
Update upstream dependencies to Phosphorus SR2 release versions:

- odlparent - 9.0.13
- aaa - 0.14.10
- controller - 4.0.10
- infrautils - 2.0.13
- mdsal - 8.0.12
- netconf - 2.0.14
- yangtools - 7.0.14

Release notes:

- Add base lift configuration
- Add option to Load yang models from class path inside gNMI SB
- Workaround fix for Openconfig regex pattern matching problem
- Upgrade and unify usage of lighty-codecs-util
- Removed unused dependencies 
- Update copyrights in opensourced repositories 
- Upgrading lift configuration to remove problematic tooling
- Replace slf4j-log4j12 with slf4j-reload4j
- Fix reported Snkyk issues
- Fix lighty-controller-spring-di test
- Set Alpine version inside docker to 3.15.0
- Fix closing lighty apps and add option to increase time-out
- Uncomment tests for restconf/operations after fix in upstream

ODL fixes:
- Leaf Node cannot be deleted inside NETCONF device via RESTCONF (https://jira.opendaylight.org/browse/NETCONF-833)


Signed-off-by: Peter Suna <peter.suna@pantheon.tech>