### PR TITLE
Replace slf4j-log4j12 with slf4j-reload4j (cherry-pick #914) + Resolve rest of logging vulnerabilities

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -1,0 +1,4 @@
+build = "maven"
+jdk11 = true
+summaryComments = true
+tools = ["infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]

--- a/.lift.toml
+++ b/.lift.toml
@@ -1,4 +1,4 @@
 build = "maven"
 jdk11 = true
 summaryComments = true
-tools = ["open source vulnerabilities", "infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]
+tools = ["infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]

--- a/.lift.toml
+++ b/.lift.toml
@@ -1,4 +1,4 @@
 build = "maven"
 jdk11 = true
 summaryComments = true
-tools = ["infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]
+tools = ["open source vulnerabilities", "infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/pom.xml
@@ -28,27 +28,7 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>io.lighty.resources</groupId>
-            <artifactId>singlenode-configuration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.lighty.resources</groupId>
-            <artifactId>start-script</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.lighty.resources</groupId>
-            <artifactId>controller-application-assembly</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.lighty.core</groupId>
-            <artifactId>lighty-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.lighty.modules</groupId>
-            <artifactId>lighty-restconf-nb-community</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>io.lighty.applications.rcgnmi</groupId>
             <artifactId>lighty-rcgnmi-app-module</artifactId>

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/pom.xml
@@ -28,7 +28,6 @@
     </properties>
 
     <dependencies>
-
         <dependency>
             <groupId>io.lighty.applications.rcgnmi</groupId>
             <artifactId>lighty-rcgnmi-app-module</artifactId>

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/pom.xml
@@ -33,11 +33,6 @@
             <artifactId>lighty-rnc-module</artifactId>
             <version>${project.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>io.lighty.resources</groupId>
-            <artifactId>singlenode-configuration</artifactId>
-        </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -106,8 +106,13 @@
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
-                <version>1.7.30</version>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.35</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-reload4j</artifactId>
+                <version>1.7.35</version>
             </dependency>
             <dependency>
                 <groupId>com.google.inject</groupId>

--- a/lighty-core/lighty-clustering/pom.xml
+++ b/lighty-core/lighty-clustering/pom.xml
@@ -36,7 +36,6 @@
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-cluster-admin-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-distributed-eos</artifactId>

--- a/lighty-core/lighty-clustering/pom.xml
+++ b/lighty-core/lighty-clustering/pom.xml
@@ -23,14 +23,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
@@ -38,32 +30,13 @@
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
 
         <!--ODL dependencies-->
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>yang-binding</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-cluster-admin-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.opendaylight.controller</groupId>
-            <artifactId>sal-distributed-datastore</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-singleton-common-api</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-distributed-eos</artifactId>

--- a/lighty-core/lighty-codecs-util/pom.xml
+++ b/lighty-core/lighty-codecs-util/pom.xml
@@ -40,10 +40,7 @@
             <groupId>org.opendaylight.netconf</groupId>
             <artifactId>netconf-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-codec-xml</artifactId>
@@ -51,10 +48,6 @@
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-codec-gson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.netconf</groupId>
-            <artifactId>restconf-common</artifactId>
         </dependency>
         <dependency>
             <groupId>io.lighty.models.test</groupId>
@@ -68,25 +61,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
 
         <!-- Test scoped dependencies -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.netconf</groupId>
-            <artifactId>ietf-netconf</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.netconf</groupId>
-            <artifactId>ietf-restconf</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/lighty-core/lighty-codecs-util/pom.xml
+++ b/lighty-core/lighty-codecs-util/pom.xml
@@ -40,7 +40,6 @@
             <groupId>org.opendaylight.netconf</groupId>
             <artifactId>netconf-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-codec-xml</artifactId>

--- a/lighty-core/lighty-codecs/pom.xml
+++ b/lighty-core/lighty-codecs/pom.xml
@@ -73,7 +73,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
         </dependency>
 
         <dependency>

--- a/lighty-core/lighty-common/pom.xml
+++ b/lighty-core/lighty-common/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
         </dependency>
 
         <!--Tests-->

--- a/lighty-core/lighty-controller-spring-di/pom.xml
+++ b/lighty-core/lighty-controller-spring-di/pom.xml
@@ -75,7 +75,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
 </project>

--- a/lighty-core/lighty-controller-spring-di/pom.xml
+++ b/lighty-core/lighty-controller-spring-di/pom.xml
@@ -48,7 +48,11 @@
             <artifactId>javax.annotation-api</artifactId>
             <version>1.3.2</version>
         </dependency>
-
+        <dependency>
+            <groupId>io.lighty.resources</groupId>
+            <artifactId>singlenode-configuration</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
@@ -71,11 +75,7 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.lighty.resources</groupId>
-            <artifactId>singlenode-configuration</artifactId>
-            <scope>test</scope>
-        </dependency>
+
     </dependencies>
 
 </project>

--- a/lighty-core/lighty-controller-spring-di/pom.xml
+++ b/lighty-core/lighty-controller-spring-di/pom.xml
@@ -49,6 +49,18 @@
             <version>1.3.2</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-reload4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.lighty.resources</groupId>
+            <artifactId>log4j-properties</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.lighty.resources</groupId>
             <artifactId>singlenode-configuration</artifactId>
             <scope>test</scope>
@@ -63,12 +75,6 @@
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-log4j</artifactId>
-            <version>1.3.8.RELEASE</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/lighty-core/lighty-controller/pom.xml
+++ b/lighty-core/lighty-controller/pom.xml
@@ -28,10 +28,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.lighty.core</groupId>
             <artifactId>lighty-common</artifactId>
         </dependency>
@@ -71,10 +67,7 @@
             <artifactId>metrics-api</artifactId>
         </dependency>
         <!--odl-yangtools-common-->
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>util</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>concepts</artifactId>
@@ -93,18 +86,12 @@
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-parser-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-parser-impl</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-model-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-model-util</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-util</artifactId>
@@ -113,30 +100,11 @@
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.antlr</groupId>
-            <artifactId>antlr4-runtime</artifactId>
-        </dependency>
         <!--odl-yangtools-yang-data-->
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-data-codec-gson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-impl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-data-codec-xml</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>stax2-api</artifactId>
         </dependency>
         <!--odl-mdsal-binding-base-->
         <dependency>
@@ -147,51 +115,10 @@
             <groupId>org.opendaylight.mdsal.model</groupId>
             <artifactId>yang-ext</artifactId>
         </dependency>
-        <!--odl-mdsal-binding-runtime-->
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-generator-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-generator-impl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-runtime-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-runtime-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.javassist</groupId>
-            <artifactId>javassist</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-generator-util</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-dom-codec</artifactId>
-        </dependency>
         <!--odl-mdsal-binding-api-->
         <dependency>
             <groupId>org.opendaylight.mdsal</groupId>
             <artifactId>mdsal-binding-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal.model</groupId>
-            <artifactId>general-entity</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-util</artifactId>
         </dependency>
         <!--odl-mdsal-dom-api-->
         <dependency>
@@ -213,14 +140,6 @@
             <artifactId>iana-if-type</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.opendaylight.mdsal.binding.model.ietf</groupId>
-            <artifactId>rfc6991</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal.binding.model.ietf</groupId>
-            <artifactId>rfc7223</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.opendaylight.mdsal.model</groupId>
             <artifactId>opendaylight-l2-types</artifactId>
         </dependency>
@@ -228,33 +147,7 @@
             <groupId>org.opendaylight.mdsal.model</groupId>
             <artifactId>ietf-topology</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal.model</groupId>
-            <artifactId>ietf-type-util</artifactId>
-        </dependency>
-        <!--odl-lmax-3-->
-        <dependency>
-            <groupId>com.lmax</groupId>
-            <artifactId>disruptor</artifactId>
-        </dependency>
-        <!--odl-mdsal-dom-broker-->
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-dom-broker</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-dom-inmemory-datastore</artifactId>
-        </dependency>
-        <!--odl-mdsal-eos-common-->
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-eos-common-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-eos-common-spi</artifactId>
-        </dependency>
+
         <!--odl-mdsal-eos-dom-->
         <dependency>
             <groupId>org.opendaylight.mdsal</groupId>
@@ -269,49 +162,15 @@
             <groupId>org.opendaylight.mdsal</groupId>
             <artifactId>mdsal-eos-binding-adapter</artifactId>
         </dependency>
-        <!--odl-mdsal-singleton-common-->
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-singleton-common-api</artifactId>
-        </dependency>
         <!--odl-mdsal-singleton-dom-->
         <dependency>
             <groupId>org.opendaylight.mdsal</groupId>
             <artifactId>mdsal-singleton-dom-impl</artifactId>
         </dependency>
-        <!--odl-akka-scala-2.12-->
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-reflect</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-java8-compat_2.13</artifactId>
-        </dependency>
         <!--odl-akka-system-->
-        <dependency>
-            <groupId>org.opendaylight.controller</groupId>
-            <artifactId>repackaged-akka</artifactId>
-        </dependency>
         <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.reactivestreams</groupId>
-            <artifactId>reactive-streams</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.typesafe</groupId>
-            <artifactId>ssl-config-core_2.13</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-parser-combinators_2.13</artifactId>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -322,22 +181,6 @@
             <artifactId>netty-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-buffer</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>threadpool-config-api</artifactId>
         </dependency>
@@ -345,47 +188,11 @@
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>threadpool-config-impl</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.aeron</groupId>
-            <artifactId>aeron-driver</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.aeron</groupId>
-            <artifactId>aeron-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.agrona</groupId>
-            <artifactId>agrona</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.fusesource.leveldbjni</groupId>
-            <artifactId>leveldbjni-all</artifactId>
-        </dependency>
 
         <!-- controller - akka-segmented-journal dependencies -->
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-akka-segmented-journal</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.esotericsoftware</groupId>
-            <artifactId>kryo</artifactId>
-            <version>4.0.2</version>
-        </dependency>
-        <dependency>
-            <groupId>com.esotericsoftware</groupId>
-            <artifactId>minlog</artifactId>
-            <version>1.3.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.esotericsoftware</groupId>
-            <artifactId>reflectasm</artifactId>
-            <version>1.11.8</version>
-        </dependency>
-        <dependency>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm</artifactId>
-            <version>5.2</version>
         </dependency>
 
         <!--odl-mdsal-remoterpc-connector-->
@@ -393,26 +200,10 @@
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-remoterpc-connector</artifactId>
         </dependency>
-        <!--odl-mdsal-distributed-datastore-->
-        <dependency>
-            <groupId>org.opendaylight.controller</groupId>
-            <artifactId>cds-access-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.controller</groupId>
-            <artifactId>cds-access-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.controller</groupId>
-            <artifactId>cds-dom-api</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-distributed-datastore</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.controller</groupId>
-            <artifactId>sal-distributed-eos</artifactId>
         </dependency>
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
@@ -421,11 +212,6 @@
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-cluster-admin-impl</artifactId>
-        </dependency>
-        <!--NOT in mdsal-broker feature, but required for its actor-system-provider-service.yang-->
-        <dependency>
-            <groupId>org.opendaylight.controller</groupId>
-            <artifactId>sal-clustering-commons</artifactId>
         </dependency>
 
         <dependency>

--- a/lighty-core/lighty-controller/pom.xml
+++ b/lighty-core/lighty-controller/pom.xml
@@ -39,7 +39,6 @@
             <groupId>io.lighty.core</groupId>
             <artifactId>lighty-codecs</artifactId>
         </dependency>
-        <!--ODL-->
         <!--odl-guava-22-->
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -67,7 +66,6 @@
             <artifactId>metrics-api</artifactId>
         </dependency>
         <!--odl-yangtools-common-->
-
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>concepts</artifactId>
@@ -86,12 +84,10 @@
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-parser-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-model-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-util</artifactId>
@@ -101,7 +97,6 @@
             <artifactId>yang-data-api</artifactId>
         </dependency>
         <!--odl-yangtools-yang-data-->
-
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-impl</artifactId>
@@ -147,7 +142,6 @@
             <groupId>org.opendaylight.mdsal.model</groupId>
             <artifactId>ietf-topology</artifactId>
         </dependency>
-
         <!--odl-mdsal-eos-dom-->
         <dependency>
             <groupId>org.opendaylight.mdsal</groupId>
@@ -188,19 +182,16 @@
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>threadpool-config-impl</artifactId>
         </dependency>
-
         <!-- controller - akka-segmented-journal dependencies -->
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-akka-segmented-journal</artifactId>
         </dependency>
-
         <!--odl-mdsal-remoterpc-connector-->
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-remoterpc-connector</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-distributed-datastore</artifactId>
@@ -213,7 +204,6 @@
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-cluster-admin-impl</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>

--- a/lighty-examples/lighty-community-aaa-restconf-app/pom.xml
+++ b/lighty-examples/lighty-community-aaa-restconf-app/pom.xml
@@ -38,30 +38,6 @@
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-restconf-nb-community</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.lighty.resources</groupId>
-            <artifactId>singlenode-configuration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlets</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-server</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/lighty-examples/lighty-community-restconf-actions-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-actions-app/pom.xml
@@ -33,15 +33,15 @@
         </dependency>
         <dependency>
             <groupId>io.lighty.modules</groupId>
+            <artifactId>lighty-restconf-nb-community</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-swagger</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.lighty.modules</groupId>
-            <artifactId>lighty-restconf-nb-community</artifactId>
         </dependency>
         <dependency>
             <groupId>io.lighty.models.test</groupId>

--- a/lighty-examples/lighty-community-restconf-actions-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-actions-app/pom.xml
@@ -33,10 +33,6 @@
         </dependency>
         <dependency>
             <groupId>io.lighty.modules</groupId>
-            <artifactId>lighty-restconf-nb-community</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-swagger</artifactId>
         </dependency>
         <dependency>

--- a/lighty-examples/lighty-community-restconf-actions-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-actions-app/pom.xml
@@ -34,7 +34,6 @@
         <dependency>
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-swagger</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/lighty-examples/lighty-community-restconf-actions-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-actions-app/pom.xml
@@ -34,10 +34,15 @@
         <dependency>
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-swagger</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.lighty.modules</groupId>
+            <artifactId>lighty-restconf-nb-community</artifactId>
         </dependency>
         <dependency>
             <groupId>io.lighty.models.test</groupId>

--- a/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
@@ -34,11 +34,11 @@
         </dependency>
         <dependency>
             <groupId>io.lighty.modules</groupId>
-            <artifactId>lighty-swagger</artifactId>
+            <artifactId>lighty-restconf-nb-community</artifactId>
         </dependency>
         <dependency>
             <groupId>io.lighty.modules</groupId>
-            <artifactId>lighty-restconf-nb-community</artifactId>
+            <artifactId>lighty-swagger</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
@@ -34,10 +34,6 @@
         </dependency>
         <dependency>
             <groupId>io.lighty.modules</groupId>
-            <artifactId>lighty-restconf-nb-community</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-swagger</artifactId>
         </dependency>
         <dependency>

--- a/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
@@ -35,7 +35,6 @@
         <dependency>
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-swagger</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.lighty.modules</groupId>

--- a/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
@@ -35,6 +35,11 @@
         <dependency>
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-swagger</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.lighty.modules</groupId>
+            <artifactId>lighty-restconf-nb-community</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/lighty-examples/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/lighty-controller-springboot-netconf/pom.xml
@@ -43,6 +43,27 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- TODO: Remove log4j overriding when spring-boot will be bumped to 2.5.8 or higher -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-to-slf4j</artifactId>
+                <version>2.17.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>2.17.1</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.2.10</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>1.2.10</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/lighty-models/lighty-gnmi-models/lighty-gnmi-force-capabilities/pom.xml
+++ b/lighty-models/lighty-gnmi-models/lighty-gnmi-force-capabilities/pom.xml
@@ -27,10 +27,6 @@
             <artifactId>ietf-topology</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.opendaylight.mdsal.binding.model.ietf</groupId>
-            <artifactId>rfc6991-ietf-inet-types</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.opendaylight.mdsal.model</groupId>
             <artifactId>yang-ext</artifactId>
         </dependency>

--- a/lighty-modules/integration-tests-aaa/pom.xml
+++ b/lighty-modules/integration-tests-aaa/pom.xml
@@ -38,100 +38,15 @@
     </build>
 
     <dependencies>
-        <!-- opendaylight dependencies -->
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-model-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-data-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-data-codec-gson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-dom-codec</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-generator-impl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal.model</groupId>
-            <artifactId>ietf-topology</artifactId>
-        </dependency>
-
         <!--Tests-->
-        <dependency>
-            <groupId>io.lighty.modules</groupId>
-            <artifactId>lighty-restconf-nb-community</artifactId>
-        </dependency>
         <dependency>
             <groupId>io.lighty.kit.examples.controllers</groupId>
             <artifactId>lighty-community-aaa-restconf-app</artifactId>
             <version>${project.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlets</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-server</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>osgi.cmpn</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/lighty-modules/integration-tests-aaa/pom.xml
+++ b/lighty-modules/integration-tests-aaa/pom.xml
@@ -43,10 +43,12 @@
             <groupId>io.lighty.kit.examples.controllers</groupId>
             <artifactId>lighty-community-aaa-restconf-app</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-client</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/lighty-modules/lighty-aaa-aggregator/lighty-aaa/pom.xml
+++ b/lighty-modules/lighty-aaa-aggregator/lighty-aaa/pom.xml
@@ -42,12 +42,7 @@
             <groupId>org.opendaylight.aaa</groupId>
             <artifactId>aaa-encrypt-service-impl</artifactId>
         </dependency>
-        <dependency>
-            <!-- Required only for 3rd-party libraries (especially commons-beanutils), that expect to call the commons
-                 logging APIs -->
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-        </dependency>
+
 
         <!-- Jersey + Jetty for RESTCONF -->
         <dependency>
@@ -60,16 +55,9 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlets</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-server</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet-core</artifactId>
@@ -78,25 +66,13 @@
             <groupId>org.glassfish.jersey.inject</groupId>
             <artifactId>jersey-hk2</artifactId>
         </dependency>
-        <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
         <!--Tests-->
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.lighty.resources</groupId>
-            <artifactId>singlenode-configuration</artifactId>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/lighty-modules/lighty-aaa-aggregator/lighty-aaa/pom.xml
+++ b/lighty-modules/lighty-aaa-aggregator/lighty-aaa/pom.xml
@@ -43,7 +43,6 @@
             <artifactId>aaa-encrypt-service-impl</artifactId>
         </dependency>
 
-
         <!-- Jersey + Jetty for RESTCONF -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -57,7 +56,6 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlets</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet-core</artifactId>
@@ -72,7 +70,6 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-commons/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-commons/pom.xml
@@ -26,10 +26,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-codec-gson</artifactId>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-commons/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-commons/pom.xml
@@ -26,7 +26,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-codec-gson</artifactId>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-connector/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-connector/pom.xml
@@ -37,13 +37,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <scope>compile</scope>
         </dependency>
-
     </dependencies>
 
 </project>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-connector/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-connector/pom.xml
@@ -33,45 +33,17 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-generator-impl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-runtime-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-dom-codec-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-dom-codec</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-data-codec-gson</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-            <scope>compile</scope>
-        </dependency>
+
     </dependencies>
 
 </project>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/pom.xml
@@ -51,7 +51,6 @@
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/pom.xml
@@ -31,10 +31,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.opendaylight.mdsal</groupId>
             <artifactId>mdsal-dom-inmemory-datastore</artifactId>
         </dependency>
@@ -49,43 +45,16 @@
         <!--odl-yangtools-yang-parser-->
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-parser-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-parser-impl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-model-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-model-util</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-data-util</artifactId>
         </dependency>
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.antlr</groupId>
-            <artifactId>antlr4-runtime</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/pom.xml
@@ -27,10 +27,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.lighty.core</groupId>
             <artifactId>lighty-controller</artifactId>
         </dependency>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/pom.xml
@@ -41,7 +41,6 @@
             <artifactId>lighty-gnmi-device-simulator</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>io.lighty.applications.rcgnmi</groupId>
             <artifactId>lighty-rcgnmi-app</artifactId>

--- a/lighty-modules/lighty-jetty-server/pom.xml
+++ b/lighty-modules/lighty-jetty-server/pom.xml
@@ -27,24 +27,8 @@
             <artifactId>jetty-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlets</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.aaa.web</groupId>
-            <artifactId>web-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.opendaylight.aaa.web</groupId>

--- a/lighty-modules/lighty-netconf-sb/pom.xml
+++ b/lighty-modules/lighty-netconf-sb/pom.xml
@@ -35,10 +35,6 @@
         </dependency>
         <dependency>
             <groupId>org.opendaylight.netconf</groupId>
-            <artifactId>netconf-topology</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.netconf</groupId>
             <artifactId>netconf-topology-impl</artifactId>
         </dependency>
         <dependency>
@@ -63,15 +59,7 @@
         </dependency>
         <dependency>
             <groupId>org.opendaylight.netconf</groupId>
-            <artifactId>mdsal-netconf-yang-library</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.netconf</groupId>
             <artifactId>ietf-netconf-nmda</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.netconf</groupId>
-            <artifactId>ietf-netconf-with-defaults</artifactId>
         </dependency>
         <dependency>
             <groupId>org.opendaylight.aaa</groupId>
@@ -82,19 +70,6 @@
             <artifactId>sal-netconf-connector</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
@@ -102,10 +77,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
         </dependency>
         <dependency>
             <groupId>io.lighty.resources</groupId>

--- a/lighty-modules/lighty-restconf-nb-community/pom.xml
+++ b/lighty-modules/lighty-restconf-nb-community/pom.xml
@@ -31,7 +31,6 @@
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-jetty-server</artifactId>
         </dependency>
-        
         <dependency>
             <groupId>org.opendaylight.netconf</groupId>
             <artifactId>restconf-nb-bierman02</artifactId>

--- a/lighty-modules/lighty-restconf-nb-community/pom.xml
+++ b/lighty-modules/lighty-restconf-nb-community/pom.xml
@@ -43,30 +43,6 @@
 
         <!-- Jersey + Jetty for RESTCONF -->
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlets</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-server</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet-core</artifactId>
         </dependency>

--- a/lighty-modules/lighty-swagger/pom.xml
+++ b/lighty-modules/lighty-swagger/pom.xml
@@ -25,20 +25,22 @@
         <dependency>
             <groupId>io.lighty.core</groupId>
             <artifactId>lighty-controller</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-jetty-server</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-restconf-nb-community</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.opendaylight.netconf</groupId>
             <artifactId>sal-rest-docgen</artifactId>
         </dependency>
-
         <dependency>
             <groupId>io.lighty.resources</groupId>
             <artifactId>singlenode-configuration</artifactId>


### PR DESCRIPTION
Cherry-pick #914

- Remove spring-boot-starter-log4j from lighty-spring-di module and bump log4j and Logback in spring boot application.
- Switch slf4j-log4j12 to slf4j-reload4j in lighty-codecs


This PR contains also PR #919 and #916