### PR TITLE
Prepare release 14.4.0

### DIFF
--- a/.github/workflows/lighty-rcgnmi-app/tests-lighty-rcgnmi-app.sh
+++ b/.github/workflows/lighty-rcgnmi-app/tests-lighty-rcgnmi-app.sh
@@ -44,7 +44,7 @@ ls -1 yangs
 #Run simulator for testing purpose
 printLine
 echo -e "-- Starting gNMI simulator device --\n"
-java -jar ${GITHUB_WORKSPACE}/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/target/lighty-gnmi-device-simulator-14.3.1-SNAPSHOT.jar -c ./simulator/example_config.json > /dev/null 2>&1 &
+java -jar ${GITHUB_WORKSPACE}/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/target/lighty-gnmi-device-simulator-14.4.0.jar -c ./simulator/example_config.json > /dev/null 2>&1 &
 
 #Add yangs into controller through REST rpc
 ./add_yangs_via_rpc.sh

--- a/.github/workflows/lighty-rnc-app/simulator/Dockerfile
+++ b/.github/workflows/lighty-rnc-app/simulator/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git as clone
 WORKDIR /netconf-simulator
-RUN git clone https://github.com/PANTHEONtech/lighty-netconf-simulator.git -b 14.2.0
+RUN git clone https://github.com/PANTHEONtech/lighty-netconf-simulator.git -b 14.3.0
 
 FROM maven:3.8-jdk-11-slim as build
 WORKDIR /lighty-netconf-simulator
@@ -13,4 +13,4 @@ COPY --from=build /lighty-netconf-simulator/examples/devices/lighty-network-topo
 
 EXPOSE 17380
 
-ENTRYPOINT ["java", "-jar", "/lighty-netconf-simulator/target/lighty-network-topology-device-14.2.0.jar"]
+ENTRYPOINT ["java", "-jar", "/lighty-netconf-simulator/target/lighty-network-topology-device-14.3.0.jar"]

--- a/.lift.toml
+++ b/.lift.toml
@@ -1,0 +1,4 @@
+build = "maven"
+jdk11 = true
+summaryComments = true
+tools = ["infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]

--- a/.lift.toml
+++ b/.lift.toml
@@ -1,4 +1,4 @@
 build = "maven"
 jdk11 = true
 summaryComments = true
-tools = ["open source vulnerabilities", "infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]
+tools = ["infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]

--- a/.lift.toml
+++ b/.lift.toml
@@ -1,4 +1,4 @@
 build = "maven"
 jdk11 = true
 summaryComments = true
-tools = ["infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]
+tools = ["open source vulnerabilities", "infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>io.lighty.applications.rcgnmi</groupId>
     <artifactId>lighty-rcgnmi-app-docker</artifactId>
-    <version>14.3.1-SNAPSHOT</version>
+    <version>14.4.0</version>
 
     <properties>
         <image.name>lighty-rcgnmi</image.name>

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/pom.xml
@@ -28,27 +28,7 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>io.lighty.resources</groupId>
-            <artifactId>singlenode-configuration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.lighty.resources</groupId>
-            <artifactId>start-script</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.lighty.resources</groupId>
-            <artifactId>controller-application-assembly</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.lighty.core</groupId>
-            <artifactId>lighty-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.lighty.modules</groupId>
-            <artifactId>lighty-restconf-nb-community</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>io.lighty.applications.rcgnmi</groupId>
             <artifactId>lighty-rcgnmi-app-module</artifactId>

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/pom.xml
@@ -28,7 +28,6 @@
     </properties>
 
     <dependencies>
-
         <dependency>
             <groupId>io.lighty.applications.rcgnmi</groupId>
             <artifactId>lighty-rcgnmi-app-module</artifactId>

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.applications.rnc</groupId>
     <artifactId>lighty-rnc-app-docker</artifactId>
-    <version>14.3.1-SNAPSHOT</version>
+    <version>14.4.0</version>
 
     <properties>
         <image.name>lighty-rnc</image.name>

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/pom.xml
@@ -33,11 +33,6 @@
             <artifactId>lighty-rnc-module</artifactId>
             <version>${project.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>io.lighty.resources</groupId>
-            <artifactId>singlenode-configuration</artifactId>
-        </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -106,8 +106,13 @@
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
-                <version>1.7.30</version>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.35</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-reload4j</artifactId>
+                <version>1.7.35</version>
             </dependency>
             <dependency>
                 <groupId>com.google.inject</groupId>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -280,7 +280,7 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-        <tag>HEAD</tag>
+        <tag>14.4.0</tag>
     </scm>
     <developers>
         <developer>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
-                <version>8.1.4</version>
+                <version>8.1.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -34,14 +34,14 @@
             <dependency>
                 <groupId>org.opendaylight.aaa</groupId>
                 <artifactId>aaa-artifacts</artifactId>
-                <version>0.13.7</version>
+                <version>0.13.11</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>controller-artifacts</artifactId>
-                <version>3.0.12</version>
+                <version>3.0.16</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -50,35 +50,35 @@
                 This artifact dependency management was removed from odl-parent in Aluminium release. -->
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>bundle-parent</artifactId>
-                <version>3.0.12</version>
+                <version>3.0.16</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.infrautils</groupId>
                 <artifactId>infrautils-artifacts</artifactId>
-                <version>1.9.10</version>
+                <version>1.9.15</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.mdsal</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>7.0.10</version>
+                <version>7.0.14</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>netconf-artifacts</artifactId>
-                <version>1.13.5</version>
+                <version>1.13.8</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yangtools-artifacts</artifactId>
-                <version>6.0.8</version>
+                <version>6.0.12</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -86,14 +86,14 @@
             <dependency>
                 <groupId>org.opendaylight.openflowplugin</groupId>
                 <artifactId>openflowplugin-artifacts</artifactId>
-                <version>0.12.3</version>
+                <version>0.12.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.serviceutils</groupId>
                 <artifactId>serviceutils-artifacts</artifactId>
-                <version>0.7.3</version>
+                <version>0.7.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -54,12 +54,12 @@
             <plugin>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yang-maven-plugin</artifactId>
-                <version>6.0.8</version>
+                <version>6.0.12</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.opendaylight.mdsal</groupId>
                         <artifactId>maven-sal-api-gen-plugin</artifactId>
-                        <version>7.0.10</version>
+                        <version>7.0.14</version>
                         <type>jar</type>
                     </dependency>
                 </dependencies>

--- a/lighty-core/lighty-bom/pom.xml
+++ b/lighty-core/lighty-bom/pom.xml
@@ -264,7 +264,7 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-        <tag>HEAD</tag>
+        <tag>14.4.0</tag>
     </scm>
     <developers>
         <developer>

--- a/lighty-core/lighty-clustering/pom.xml
+++ b/lighty-core/lighty-clustering/pom.xml
@@ -36,7 +36,6 @@
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-cluster-admin-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-distributed-eos</artifactId>

--- a/lighty-core/lighty-clustering/pom.xml
+++ b/lighty-core/lighty-clustering/pom.xml
@@ -23,14 +23,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
@@ -38,32 +30,13 @@
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
 
         <!--ODL dependencies-->
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>yang-binding</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-cluster-admin-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.opendaylight.controller</groupId>
-            <artifactId>sal-distributed-datastore</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-singleton-common-api</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-distributed-eos</artifactId>

--- a/lighty-core/lighty-codecs-util/pom.xml
+++ b/lighty-core/lighty-codecs-util/pom.xml
@@ -40,10 +40,7 @@
             <groupId>org.opendaylight.netconf</groupId>
             <artifactId>netconf-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-codec-xml</artifactId>
@@ -51,10 +48,6 @@
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-codec-gson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.netconf</groupId>
-            <artifactId>restconf-common</artifactId>
         </dependency>
         <dependency>
             <groupId>io.lighty.models.test</groupId>
@@ -68,25 +61,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
 
         <!-- Test scoped dependencies -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.netconf</groupId>
-            <artifactId>ietf-netconf</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.netconf</groupId>
-            <artifactId>ietf-restconf</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/lighty-core/lighty-codecs-util/pom.xml
+++ b/lighty-core/lighty-codecs-util/pom.xml
@@ -40,7 +40,6 @@
             <groupId>org.opendaylight.netconf</groupId>
             <artifactId>netconf-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-codec-xml</artifactId>

--- a/lighty-core/lighty-codecs/pom.xml
+++ b/lighty-core/lighty-codecs/pom.xml
@@ -73,7 +73,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
         </dependency>
 
         <dependency>

--- a/lighty-core/lighty-common/pom.xml
+++ b/lighty-core/lighty-common/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
         </dependency>
 
         <!--Tests-->

--- a/lighty-core/lighty-controller-spring-di/pom.xml
+++ b/lighty-core/lighty-controller-spring-di/pom.xml
@@ -75,7 +75,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
 </project>

--- a/lighty-core/lighty-controller-spring-di/pom.xml
+++ b/lighty-core/lighty-controller-spring-di/pom.xml
@@ -48,7 +48,11 @@
             <artifactId>javax.annotation-api</artifactId>
             <version>1.3.2</version>
         </dependency>
-
+        <dependency>
+            <groupId>io.lighty.resources</groupId>
+            <artifactId>singlenode-configuration</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
@@ -71,11 +75,7 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.lighty.resources</groupId>
-            <artifactId>singlenode-configuration</artifactId>
-            <scope>test</scope>
-        </dependency>
+
     </dependencies>
 
 </project>

--- a/lighty-core/lighty-controller-spring-di/pom.xml
+++ b/lighty-core/lighty-controller-spring-di/pom.xml
@@ -49,6 +49,18 @@
             <version>1.3.2</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-reload4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.lighty.resources</groupId>
+            <artifactId>log4j-properties</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.lighty.resources</groupId>
             <artifactId>singlenode-configuration</artifactId>
             <scope>test</scope>
@@ -63,12 +75,6 @@
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-log4j</artifactId>
-            <version>1.3.8.RELEASE</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/lighty-core/lighty-controller/README.md
+++ b/lighty-core/lighty-controller/README.md
@@ -17,7 +17,7 @@ To use Lighty controller in your project:
   <dependency>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-controller</artifactId>
-    <version>14.3.0</version>
+    <version>14.4.0</version>
   </dependency>
 ```
 

--- a/lighty-core/lighty-controller/pom.xml
+++ b/lighty-core/lighty-controller/pom.xml
@@ -28,10 +28,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.lighty.core</groupId>
             <artifactId>lighty-common</artifactId>
         </dependency>
@@ -71,10 +67,7 @@
             <artifactId>metrics-api</artifactId>
         </dependency>
         <!--odl-yangtools-common-->
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>util</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>concepts</artifactId>
@@ -93,18 +86,12 @@
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-parser-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-parser-impl</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-model-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-model-util</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-util</artifactId>
@@ -113,30 +100,11 @@
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.antlr</groupId>
-            <artifactId>antlr4-runtime</artifactId>
-        </dependency>
         <!--odl-yangtools-yang-data-->
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-data-codec-gson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-impl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-data-codec-xml</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>stax2-api</artifactId>
         </dependency>
         <!--odl-mdsal-binding-base-->
         <dependency>
@@ -147,51 +115,10 @@
             <groupId>org.opendaylight.mdsal.model</groupId>
             <artifactId>yang-ext</artifactId>
         </dependency>
-        <!--odl-mdsal-binding-runtime-->
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-generator-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-generator-impl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-runtime-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-runtime-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.javassist</groupId>
-            <artifactId>javassist</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-generator-util</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-dom-codec</artifactId>
-        </dependency>
         <!--odl-mdsal-binding-api-->
         <dependency>
             <groupId>org.opendaylight.mdsal</groupId>
             <artifactId>mdsal-binding-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal.model</groupId>
-            <artifactId>general-entity</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-util</artifactId>
         </dependency>
         <!--odl-mdsal-dom-api-->
         <dependency>
@@ -213,14 +140,6 @@
             <artifactId>iana-if-type</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.opendaylight.mdsal.binding.model.ietf</groupId>
-            <artifactId>rfc6991</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal.binding.model.ietf</groupId>
-            <artifactId>rfc7223</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.opendaylight.mdsal.model</groupId>
             <artifactId>opendaylight-l2-types</artifactId>
         </dependency>
@@ -228,33 +147,7 @@
             <groupId>org.opendaylight.mdsal.model</groupId>
             <artifactId>ietf-topology</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal.model</groupId>
-            <artifactId>ietf-type-util</artifactId>
-        </dependency>
-        <!--odl-lmax-3-->
-        <dependency>
-            <groupId>com.lmax</groupId>
-            <artifactId>disruptor</artifactId>
-        </dependency>
-        <!--odl-mdsal-dom-broker-->
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-dom-broker</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-dom-inmemory-datastore</artifactId>
-        </dependency>
-        <!--odl-mdsal-eos-common-->
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-eos-common-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-eos-common-spi</artifactId>
-        </dependency>
+
         <!--odl-mdsal-eos-dom-->
         <dependency>
             <groupId>org.opendaylight.mdsal</groupId>
@@ -269,49 +162,15 @@
             <groupId>org.opendaylight.mdsal</groupId>
             <artifactId>mdsal-eos-binding-adapter</artifactId>
         </dependency>
-        <!--odl-mdsal-singleton-common-->
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-singleton-common-api</artifactId>
-        </dependency>
         <!--odl-mdsal-singleton-dom-->
         <dependency>
             <groupId>org.opendaylight.mdsal</groupId>
             <artifactId>mdsal-singleton-dom-impl</artifactId>
         </dependency>
-        <!--odl-akka-scala-2.12-->
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-reflect</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-java8-compat_2.13</artifactId>
-        </dependency>
         <!--odl-akka-system-->
-        <dependency>
-            <groupId>org.opendaylight.controller</groupId>
-            <artifactId>repackaged-akka</artifactId>
-        </dependency>
         <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.reactivestreams</groupId>
-            <artifactId>reactive-streams</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.typesafe</groupId>
-            <artifactId>ssl-config-core_2.13</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.scala-lang.modules</groupId>
-            <artifactId>scala-parser-combinators_2.13</artifactId>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -322,22 +181,6 @@
             <artifactId>netty-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-buffer</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>threadpool-config-api</artifactId>
         </dependency>
@@ -345,47 +188,11 @@
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>threadpool-config-impl</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.aeron</groupId>
-            <artifactId>aeron-driver</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.aeron</groupId>
-            <artifactId>aeron-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.agrona</groupId>
-            <artifactId>agrona</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.fusesource.leveldbjni</groupId>
-            <artifactId>leveldbjni-all</artifactId>
-        </dependency>
 
         <!-- controller - akka-segmented-journal dependencies -->
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-akka-segmented-journal</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.esotericsoftware</groupId>
-            <artifactId>kryo</artifactId>
-            <version>4.0.2</version>
-        </dependency>
-        <dependency>
-            <groupId>com.esotericsoftware</groupId>
-            <artifactId>minlog</artifactId>
-            <version>1.3.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.esotericsoftware</groupId>
-            <artifactId>reflectasm</artifactId>
-            <version>1.11.8</version>
-        </dependency>
-        <dependency>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm</artifactId>
-            <version>5.2</version>
         </dependency>
 
         <!--odl-mdsal-remoterpc-connector-->
@@ -393,26 +200,10 @@
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-remoterpc-connector</artifactId>
         </dependency>
-        <!--odl-mdsal-distributed-datastore-->
-        <dependency>
-            <groupId>org.opendaylight.controller</groupId>
-            <artifactId>cds-access-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.controller</groupId>
-            <artifactId>cds-access-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.controller</groupId>
-            <artifactId>cds-dom-api</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-distributed-datastore</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.controller</groupId>
-            <artifactId>sal-distributed-eos</artifactId>
         </dependency>
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
@@ -421,11 +212,6 @@
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-cluster-admin-impl</artifactId>
-        </dependency>
-        <!--NOT in mdsal-broker feature, but required for its actor-system-provider-service.yang-->
-        <dependency>
-            <groupId>org.opendaylight.controller</groupId>
-            <artifactId>sal-clustering-commons</artifactId>
         </dependency>
 
         <dependency>

--- a/lighty-core/lighty-controller/pom.xml
+++ b/lighty-core/lighty-controller/pom.xml
@@ -39,7 +39,6 @@
             <groupId>io.lighty.core</groupId>
             <artifactId>lighty-codecs</artifactId>
         </dependency>
-        <!--ODL-->
         <!--odl-guava-22-->
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -67,7 +66,6 @@
             <artifactId>metrics-api</artifactId>
         </dependency>
         <!--odl-yangtools-common-->
-
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>concepts</artifactId>
@@ -86,12 +84,10 @@
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-parser-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-model-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-util</artifactId>
@@ -101,7 +97,6 @@
             <artifactId>yang-data-api</artifactId>
         </dependency>
         <!--odl-yangtools-yang-data-->
-
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-impl</artifactId>
@@ -147,7 +142,6 @@
             <groupId>org.opendaylight.mdsal.model</groupId>
             <artifactId>ietf-topology</artifactId>
         </dependency>
-
         <!--odl-mdsal-eos-dom-->
         <dependency>
             <groupId>org.opendaylight.mdsal</groupId>
@@ -188,19 +182,16 @@
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>threadpool-config-impl</artifactId>
         </dependency>
-
         <!-- controller - akka-segmented-journal dependencies -->
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-akka-segmented-journal</artifactId>
         </dependency>
-
         <!--odl-mdsal-remoterpc-connector-->
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-remoterpc-connector</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-distributed-datastore</artifactId>
@@ -213,7 +204,6 @@
             <groupId>org.opendaylight.controller</groupId>
             <artifactId>sal-cluster-admin-impl</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>

--- a/lighty-core/lighty-minimal-parent/pom.xml
+++ b/lighty-core/lighty-minimal-parent/pom.xml
@@ -103,7 +103,7 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-        <tag>HEAD</tag>
+        <tag>14.4.0</tag>
     </scm>
     <developers>
         <developer>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -174,7 +174,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.1.4</version>
+                            <version>8.1.9</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -191,7 +191,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>spotbugs</artifactId>
-                            <version>8.1.4</version>
+                            <version>8.1.9</version>
                         </dependency>
                         <dependency>
                             <!-- The SpotBugs Maven plugin uses SLF4J 1.8 beta 2 -->

--- a/lighty-examples/README.md
+++ b/lighty-examples/README.md
@@ -17,7 +17,7 @@ ODL core services represent MD-SAL layer, controller, DataStore, global schema c
    <dependency>
       <groupId>io.lighty.core.parents</groupId>
       <artifactId>lighty-dependency-artifacts</artifactId>
-      <version>14.3.1-SNAPSHOT</version>
+      <version>14.4.0</version>
       <type>pom</type>
       <scope>import</scope>
    </dependency>

--- a/lighty-examples/lighty-community-aaa-restconf-app/pom.xml
+++ b/lighty-examples/lighty-community-aaa-restconf-app/pom.xml
@@ -38,30 +38,6 @@
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-restconf-nb-community</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.lighty.resources</groupId>
-            <artifactId>singlenode-configuration</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlets</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-server</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/lighty-examples/lighty-community-netconf-quarkus-app/README.md
+++ b/lighty-examples/lighty-community-netconf-quarkus-app/README.md
@@ -30,7 +30,7 @@ mvn clean compile quarkus:dev
 ## Build package & Run
 ```
 mvn clean package
-java -Xms128m -Xmx128m -XX:MaxMetaspaceSize=128m -jar target/lighty-quarkus-netconf-app-14.3.1-SNAPSHOT-runner.jar
+java -Xms128m -Xmx128m -XX:MaxMetaspaceSize=128m -jar target/lighty-quarkus-netconf-app-14.4.0-runner.jar
 ```
 
 ## Build native image

--- a/lighty-examples/lighty-community-restconf-actions-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-actions-app/pom.xml
@@ -33,15 +33,15 @@
         </dependency>
         <dependency>
             <groupId>io.lighty.modules</groupId>
+            <artifactId>lighty-restconf-nb-community</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-swagger</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.lighty.modules</groupId>
-            <artifactId>lighty-restconf-nb-community</artifactId>
         </dependency>
         <dependency>
             <groupId>io.lighty.models.test</groupId>

--- a/lighty-examples/lighty-community-restconf-actions-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-actions-app/pom.xml
@@ -33,10 +33,6 @@
         </dependency>
         <dependency>
             <groupId>io.lighty.modules</groupId>
-            <artifactId>lighty-restconf-nb-community</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-swagger</artifactId>
         </dependency>
         <dependency>

--- a/lighty-examples/lighty-community-restconf-actions-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-actions-app/pom.xml
@@ -34,7 +34,6 @@
         <dependency>
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-swagger</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/lighty-examples/lighty-community-restconf-actions-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-actions-app/pom.xml
@@ -34,10 +34,15 @@
         <dependency>
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-swagger</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.lighty.modules</groupId>
+            <artifactId>lighty-restconf-nb-community</artifactId>
         </dependency>
         <dependency>
             <groupId>io.lighty.models.test</groupId>

--- a/lighty-examples/lighty-community-restconf-netconf-app/README.md
+++ b/lighty-examples/lighty-community-restconf-netconf-app/README.md
@@ -21,12 +21,12 @@ build the project: ```mvn clean install```
 ### Start this demo example
 * build the project using ```mvn clean install```
 * go to target directory ```cd lighty-examples/lighty-community-restconf-netconf-app/target``` 
-* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-14.3.1-SNAPSHOT-bin.zip```
-* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-14.3.1-SNAPSHOT```
-* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-14.3.1-SNAPSHOT.jar``` 
+* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-14.4.0-bin.zip```
+* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-14.4.0```
+* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-14.4.0.jar``` 
 
 ### Test example application
-Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-14.3.1-SNAPSHOT.jar``` 
+Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-14.4.0.jar``` 
 RESTCONF web interface is available at URL ```http://localhost:8888/restconf/*```
 
 ##### URLs to start with
@@ -43,7 +43,7 @@ URLs for Swagger (choose RESTCONF [draft18](https://tools.ietf.org/html/draft-ie
 
 ### Use custom config files
 There are two separated config files: for NETCONF SBP single node and for cluster.
-`java -jar lighty-community-restconf-netconf-app-14.3.1-SNAPSHOT.jar /path/to/singleNodeConfig.json`
+`java -jar lighty-community-restconf-netconf-app-14.4.0.jar /path/to/singleNodeConfig.json`
 
 Example configuration for single node is [here](src/main/assembly/resources/sampleConfigSingleNode.json)
 

--- a/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
@@ -34,11 +34,11 @@
         </dependency>
         <dependency>
             <groupId>io.lighty.modules</groupId>
-            <artifactId>lighty-swagger</artifactId>
+            <artifactId>lighty-restconf-nb-community</artifactId>
         </dependency>
         <dependency>
             <groupId>io.lighty.modules</groupId>
-            <artifactId>lighty-restconf-nb-community</artifactId>
+            <artifactId>lighty-swagger</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
@@ -34,10 +34,6 @@
         </dependency>
         <dependency>
             <groupId>io.lighty.modules</groupId>
-            <artifactId>lighty-restconf-nb-community</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-swagger</artifactId>
         </dependency>
         <dependency>

--- a/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
@@ -35,7 +35,6 @@
         <dependency>
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-swagger</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.lighty.modules</groupId>

--- a/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
@@ -35,6 +35,11 @@
         <dependency>
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-swagger</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.lighty.modules</groupId>
+            <artifactId>lighty-restconf-nb-community</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/lighty-examples/lighty-community-restconf-ofp-app/Dockerfile
+++ b/lighty-examples/lighty-community-restconf-ofp-app/Dockerfile
@@ -1,16 +1,16 @@
 FROM openjdk:11-jre-slim
 
-COPY ./target/lighty-community-restconf-ofp-app-14.3.1-SNAPSHOT-bin.zip /
+COPY ./target/lighty-community-restconf-ofp-app-14.4.0-bin.zip /
 RUN apt-get update && apt-get install unzip \
-    && unzip /lighty-community-restconf-ofp-app-14.3.1-SNAPSHOT-bin.zip \
-    && rm /lighty-community-restconf-ofp-app-14.3.1-SNAPSHOT-bin.zip
+    && unzip /lighty-community-restconf-ofp-app-14.4.0-bin.zip \
+    && rm /lighty-community-restconf-ofp-app-14.4.0-bin.zip
 
 
 ##libstdc++ is required by leveldbjni-1.8 (Akka dispatcher)
 #Uncaught error from thread [opendaylight-cluster-data-akka.persistence.dispatchers.default-plugin-dispatcher-22]: Could not load library. Reasons: [no leveldbjni64-1.8 in java.library.path, no leveldbjni-1.8 in java.library.path, no leveldbjni in java.library.path, /tmp/libleveldbjni-64-1-3166161234556196376.8: Error loading shared library libstdc++.so.6: No such file or directory (needed by /tmp/libleveldbjni-64-1-3166161234556196376.8)], shutting down JVM since 'akka.jvm-exit-on-fatal-error' is enabled for ActorSystem[opendaylight-cluster-data]
 RUN apt-get install libstdc++6
 
-WORKDIR /lighty-community-restconf-ofp-app-14.3.1-SNAPSHOT
+WORKDIR /lighty-community-restconf-ofp-app-14.4.0
 
 EXPOSE 8888
 EXPOSE 8185
@@ -19,4 +19,4 @@ EXPOSE 6653
 EXPOSE 2550
 EXPOSE 80
 
-CMD java -jar lighty-community-restconf-ofp-app-14.3.1-SNAPSHOT.jar sampleConfigSingleNode.json
+CMD java -jar lighty-community-restconf-ofp-app-14.4.0.jar sampleConfigSingleNode.json

--- a/lighty-examples/lighty-community-restconf-ofp-app/README.md
+++ b/lighty-examples/lighty-community-restconf-ofp-app/README.md
@@ -12,7 +12,7 @@ Build the project using maven command: ```mvn clean install```.
 This will create *.zip* archive in target directory. Extract this archive
 and run *.jar* file using java with command:
 ```
-java -jar lighty-community-restconf-ofp-app-14.3.1-SNAPSHOT.jar
+java -jar lighty-community-restconf-ofp-app-14.4.0.jar
 ```
 
 ### Use custom config files
@@ -24,7 +24,7 @@ after build.
 
 When running application pass path to configuration file as argument:
 ```
-java -jar lighty-community-restconf-ofp-app-14.3.1-SNAPSHOT.jar sampleConfigSingleNode.json
+java -jar lighty-community-restconf-ofp-app-14.4.0.jar sampleConfigSingleNode.json
 ```
 
 ### Building and running Docker Image

--- a/lighty-examples/lighty-controller-springboot-netconf/README.md
+++ b/lighty-examples/lighty-controller-springboot-netconf/README.md
@@ -46,7 +46,7 @@ mvn spring-boot:run
 or
 
 ```
-java -jar target/lighty-controller-springboot-14.3.1-SNAPSHOT.jar
+java -jar target/lighty-controller-springboot-14.4.0.jar
 ```
 
 or in any IDE, run main in 

--- a/lighty-examples/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/lighty-controller-springboot-netconf/pom.xml
@@ -43,6 +43,27 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- TODO: Remove log4j overriding when spring-boot will be bumped to 2.5.8 or higher -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-to-slf4j</artifactId>
+                <version>2.17.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>2.17.1</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.2.10</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>1.2.10</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/lighty-examples/lighty-gnmi-community-restconf-app/README.md
+++ b/lighty-examples/lighty-gnmi-community-restconf-app/README.md
@@ -11,10 +11,10 @@ To communicate with gNMI device it is required to use TLS communication with cer
 authorization.
 
 This application starts:
-* [Lighty.io Controller](https://github.com/PANTHEONtech/lighty/tree/14.3.1-SNAPSHOT/lighty-core/lighty-controller) with modules:
-  * [lighty.io RESTCONF module](https://github.com/PANTHEONtech/lighty/tree/14.3.1-SNAPSHOT/lighty-modules/lighty-restconf-nb-community)
-  * [lighty.io gNMI module](https://github.com/PANTHEONtech/lighty/tree/14.3.1-SNAPSHOT/lighty-modules/lighty-gnmi/lighty-gnmi-sb)
-* [lighty.io gNMI device simulator](https://github.com/PANTHEONtech/lighty/tree/14.3.1-SNAPSHOT/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator)
+* [Lighty.io Controller](https://github.com/PANTHEONtech/lighty/tree/14.4.0/lighty-core/lighty-controller) with modules:
+  * [lighty.io RESTCONF module](https://github.com/PANTHEONtech/lighty/tree/14.4.0/lighty-modules/lighty-restconf-nb-community)
+  * [lighty.io gNMI module](https://github.com/PANTHEONtech/lighty/tree/14.4.0/lighty-modules/lighty-gnmi/lighty-gnmi-sb)
+* [lighty.io gNMI device simulator](https://github.com/PANTHEONtech/lighty/tree/14.4.0/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator)
 
 ![lighty.io gNMI / RESTCONF architecture](docs/lighty-gnmi-restconf-architecture.png)
 
@@ -42,22 +42,22 @@ cd lighty-examples/lighty-gnmi-community-restconf-app
 ### Start RCgNMI controller app
 Unzip lighty-rcgnmi-app to current location
 ```
-unzip ../../lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/target/lighty-rcgnmi-app-14.3.0-bin.zip
+unzip ../../lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/target/lighty-rcgnmi-app-14.4.0-bin.zip
 ```
 Start application with pre-prepared configuration [example_config.json](example_config.json).
 ```
-java -jar lighty-rcgnmi-app-14.3.0/lighty-rcgnmi-app-14.3.0.jar -c example_config.json
+java -jar lighty-rcgnmi-app-14.4.0/lighty-rcgnmi-app-14.4.0.jar -c example_config.json
 ```
 
 ### Start lighty.io gNMI device simulator
 Unzip gNMI simulator app to current folder.
 ```
-unzip ../../lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/target/lighty-gnmi-device-simulator-14.3.0-bin.zip
+unzip ../../lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/target/lighty-gnmi-device-simulator-14.4.0-bin.zip
 ```
 
 Start the application with pre-prepared configuration [simulator_config.json](simulator/simulator_config.json)
 ```
-java -jar lighty-gnmi-device-simulator-14.3.0/lighty-gnmi-device-simulator-14.3.0.jar  -c simulator/simulator_config.json 
+java -jar lighty-gnmi-device-simulator-14.4.0/lighty-gnmi-device-simulator-14.4.0.jar  -c simulator/simulator_config.json 
 ```
 
 ### Add client certificates to lighty.io gNMI keystore

--- a/lighty-models/README.md
+++ b/lighty-models/README.md
@@ -56,7 +56,7 @@ my-model/pom.xml
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>14.3.1-SNAPSHOT</version>
+        <version>14.4.0</version>
         <relativePath/>
     </parent>
 

--- a/lighty-models/lighty-gnmi-models/lighty-gnmi-force-capabilities/pom.xml
+++ b/lighty-models/lighty-gnmi-models/lighty-gnmi-force-capabilities/pom.xml
@@ -27,10 +27,6 @@
             <artifactId>ietf-topology</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.opendaylight.mdsal.binding.model.ietf</groupId>
-            <artifactId>rfc6991-ietf-inet-types</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.opendaylight.mdsal.model</groupId>
             <artifactId>yang-ext</artifactId>
         </dependency>

--- a/lighty-modules/integration-tests-aaa/pom.xml
+++ b/lighty-modules/integration-tests-aaa/pom.xml
@@ -38,100 +38,15 @@
     </build>
 
     <dependencies>
-        <!-- opendaylight dependencies -->
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-model-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-data-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-data-codec-gson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-dom-codec</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-generator-impl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal.model</groupId>
-            <artifactId>ietf-topology</artifactId>
-        </dependency>
-
         <!--Tests-->
-        <dependency>
-            <groupId>io.lighty.modules</groupId>
-            <artifactId>lighty-restconf-nb-community</artifactId>
-        </dependency>
         <dependency>
             <groupId>io.lighty.kit.examples.controllers</groupId>
             <artifactId>lighty-community-aaa-restconf-app</artifactId>
             <version>${project.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlets</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-server</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>osgi.cmpn</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/lighty-modules/integration-tests-aaa/pom.xml
+++ b/lighty-modules/integration-tests-aaa/pom.xml
@@ -43,10 +43,12 @@
             <groupId>io.lighty.kit.examples.controllers</groupId>
             <artifactId>lighty-community-aaa-restconf-app</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-client</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/TopologyPluginsTest.java
+++ b/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/TopologyPluginsTest.java
@@ -23,7 +23,6 @@ import io.lighty.modules.northbound.restconf.community.impl.util.RestConfConfigU
 import io.lighty.modules.southbound.netconf.impl.NetconfTopologyPluginBuilder;
 import io.lighty.modules.southbound.netconf.impl.config.NetconfConfiguration;
 import io.lighty.modules.southbound.netconf.impl.util.NetconfConfigUtils;
-import io.netty.util.concurrent.Future;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -33,6 +32,7 @@ import org.opendaylight.mdsal.binding.api.DataBroker;
 import org.opendaylight.mdsal.binding.api.WriteTransaction;
 import org.opendaylight.mdsal.common.api.LogicalDatastoreType;
 import org.opendaylight.netconf.client.NetconfClientDispatcher;
+import org.opendaylight.netconf.nettyutil.ReconnectFuture;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.inet.types.rev130715.Host;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.inet.types.rev130715.IpAddress;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.inet.types.rev130715.Ipv4Address;
@@ -70,7 +70,7 @@ public class TopologyPluginsTest {
     @Mock
     private NetconfClientDispatcher dispatcher;
     @Mock
-    private Future<Void> initFuture;
+    private ReconnectFuture reconnectFuture;
 
     private static LightyModule startSingleNodeNetconf(final LightyServices services,
                                                        final NetconfClientDispatcher dispatcher)
@@ -85,7 +85,7 @@ public class TopologyPluginsTest {
     public void beforeClass()
             throws ConfigurationException, ExecutionException, InterruptedException, TimeoutException {
         MockitoAnnotations.initMocks(this);
-        when(this.dispatcher.createReconnectingClient(any())).thenReturn(this.initFuture);
+        when(this.dispatcher.createReconnectingClient(any())).thenReturn(this.reconnectFuture);
 
         this.lightyController = LightyTestUtils.startController();
         RestConfConfiguration restConfConfig =

--- a/lighty-modules/lighty-aaa-aggregator/lighty-aaa/pom.xml
+++ b/lighty-modules/lighty-aaa-aggregator/lighty-aaa/pom.xml
@@ -42,12 +42,7 @@
             <groupId>org.opendaylight.aaa</groupId>
             <artifactId>aaa-encrypt-service-impl</artifactId>
         </dependency>
-        <dependency>
-            <!-- Required only for 3rd-party libraries (especially commons-beanutils), that expect to call the commons
-                 logging APIs -->
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-        </dependency>
+
 
         <!-- Jersey + Jetty for RESTCONF -->
         <dependency>
@@ -60,16 +55,9 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlets</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-server</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet-core</artifactId>
@@ -78,25 +66,13 @@
             <groupId>org.glassfish.jersey.inject</groupId>
             <artifactId>jersey-hk2</artifactId>
         </dependency>
-        <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
         <!--Tests-->
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.lighty.resources</groupId>
-            <artifactId>singlenode-configuration</artifactId>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/lighty-modules/lighty-aaa-aggregator/lighty-aaa/pom.xml
+++ b/lighty-modules/lighty-aaa-aggregator/lighty-aaa/pom.xml
@@ -43,7 +43,6 @@
             <artifactId>aaa-encrypt-service-impl</artifactId>
         </dependency>
 
-
         <!-- Jersey + Jetty for RESTCONF -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -57,7 +56,6 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlets</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet-core</artifactId>
@@ -72,7 +70,6 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-commons/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-commons/pom.xml
@@ -26,10 +26,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-codec-gson</artifactId>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-commons/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-commons/pom.xml
@@ -26,7 +26,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-codec-gson</artifactId>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-connector/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-connector/pom.xml
@@ -37,13 +37,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <scope>compile</scope>
         </dependency>
-
     </dependencies>
 
 </project>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-connector/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-connector/pom.xml
@@ -33,45 +33,17 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-generator-impl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-runtime-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-dom-codec-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.mdsal</groupId>
-            <artifactId>mdsal-binding-dom-codec</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-data-codec-gson</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-            <scope>compile</scope>
-        </dependency>
+
     </dependencies>
 
 </project>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/README.md
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/README.md
@@ -8,7 +8,7 @@ This simulator provides gNMI device driven by gNMI proto files, with datastore d
    <dependency>
       <groupId>io.lighty.modules.gnmi</groupId>
       <artifactId>lighty-gnmi-device-simulator</artifactId>
-      <version>14.3.1-SNAPSHOT</version>
+      <version>14.4.0</version>
    </dependency>
 ```
 

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/pom.xml
@@ -51,7 +51,6 @@
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/pom.xml
@@ -31,10 +31,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.opendaylight.mdsal</groupId>
             <artifactId>mdsal-dom-inmemory-datastore</artifactId>
         </dependency>
@@ -49,43 +45,16 @@
         <!--odl-yangtools-yang-parser-->
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-parser-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-parser-impl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-model-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-model-util</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.yangtools</groupId>
-            <artifactId>yang-data-util</artifactId>
         </dependency>
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-data-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.antlr</groupId>
-            <artifactId>antlr4-runtime</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/README.md
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/README.md
@@ -96,7 +96,7 @@ Creating a device connection and CRUD operation, is performed by writing data di
 
 3. Wait until the gNMI device is successfully connected to gNMI-sb. The device is successfully connected, when the status is `NodeState.NodeStatus.READY`.
 
-Device [node-status](https://github.com/PANTHEONtech/lighty/blob/14.2.x/lighty-models/lighty-gnmi-models/lighty-gnmi-topology-model/src/main/yang/gnmi-topology.yang#L140) is available in operational memory, inside data store.
+Device [node-status](https://github.com/PANTHEONtech/lighty/blob/14.4.0/lighty-models/lighty-gnmi-models/lighty-gnmi-topology-model/src/main/yang/gnmi-topology.yang#L140) is available in operational memory, inside data store.
 
 4. Get DOM GnmiDataBroker registered for specific gNMI device. For each successfully registered gNMI device, a new GnmiDataBroker with a device specific schema context is created.
 

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/pom.xml
@@ -27,10 +27,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.lighty.core</groupId>
             <artifactId>lighty-controller</artifactId>
         </dependency>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/pom.xml
@@ -41,7 +41,6 @@
             <artifactId>lighty-gnmi-device-simulator</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>io.lighty.applications.rcgnmi</groupId>
             <artifactId>lighty-rcgnmi-app</artifactId>

--- a/lighty-modules/lighty-jetty-server/pom.xml
+++ b/lighty-modules/lighty-jetty-server/pom.xml
@@ -27,24 +27,8 @@
             <artifactId>jetty-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlets</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.aaa.web</groupId>
-            <artifactId>web-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.opendaylight.aaa.web</groupId>

--- a/lighty-modules/lighty-netconf-sb/README.md
+++ b/lighty-modules/lighty-netconf-sb/README.md
@@ -42,7 +42,7 @@ To use NETCONF in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-netconf-sb</artifactId>
-    <version>14.3.1-SNAPSHOT</version>
+    <version>14.4.0</version>
   </dependency>  
 ```
 2. Initialize and start an instance of NETCONF SBP in your code:

--- a/lighty-modules/lighty-netconf-sb/pom.xml
+++ b/lighty-modules/lighty-netconf-sb/pom.xml
@@ -35,10 +35,6 @@
         </dependency>
         <dependency>
             <groupId>org.opendaylight.netconf</groupId>
-            <artifactId>netconf-topology</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.netconf</groupId>
             <artifactId>netconf-topology-impl</artifactId>
         </dependency>
         <dependency>
@@ -63,15 +59,7 @@
         </dependency>
         <dependency>
             <groupId>org.opendaylight.netconf</groupId>
-            <artifactId>mdsal-netconf-yang-library</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.netconf</groupId>
             <artifactId>ietf-netconf-nmda</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.opendaylight.netconf</groupId>
-            <artifactId>ietf-netconf-with-defaults</artifactId>
         </dependency>
         <dependency>
             <groupId>org.opendaylight.aaa</groupId>
@@ -82,19 +70,6 @@
             <artifactId>sal-netconf-connector</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
@@ -102,10 +77,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
         </dependency>
         <dependency>
             <groupId>io.lighty.resources</groupId>

--- a/lighty-modules/lighty-openflow-sb/README.md
+++ b/lighty-modules/lighty-openflow-sb/README.md
@@ -10,7 +10,7 @@ is Lighty's version of openflow plugin.
 <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-openflow-sb</artifactId>
-    <version>14.3.1-SNAPSHOT</version>
+    <version>14.4.0</version>
 </dependency>
 ```
 

--- a/lighty-modules/lighty-restconf-nb-community/README.md
+++ b/lighty-modules/lighty-restconf-nb-community/README.md
@@ -12,7 +12,7 @@ To use RESTCONF in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-restconf-nb-community</artifactId>
-    <version>14.3.1-SNAPSHOT</version>
+    <version>14.4.0</version>
   </dependency>
 ```
 

--- a/lighty-modules/lighty-restconf-nb-community/pom.xml
+++ b/lighty-modules/lighty-restconf-nb-community/pom.xml
@@ -31,7 +31,6 @@
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-jetty-server</artifactId>
         </dependency>
-        
         <dependency>
             <groupId>org.opendaylight.netconf</groupId>
             <artifactId>restconf-nb-bierman02</artifactId>

--- a/lighty-modules/lighty-restconf-nb-community/pom.xml
+++ b/lighty-modules/lighty-restconf-nb-community/pom.xml
@@ -43,30 +43,6 @@
 
         <!-- Jersey + Jetty for RESTCONF -->
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlets</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-server</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet-core</artifactId>
         </dependency>

--- a/lighty-modules/lighty-swagger/pom.xml
+++ b/lighty-modules/lighty-swagger/pom.xml
@@ -25,20 +25,22 @@
         <dependency>
             <groupId>io.lighty.core</groupId>
             <artifactId>lighty-controller</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-jetty-server</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-restconf-nb-community</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.opendaylight.netconf</groupId>
             <artifactId>sal-rest-docgen</artifactId>
         </dependency>
-
         <dependency>
             <groupId>io.lighty.resources</groupId>
             <artifactId>singlenode-configuration</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-        <tag>HEAD</tag>
+        <tag>14.4.0</tag>
     </scm>
     <developers>
         <developer>


### PR DESCRIPTION
Update upstream dependencies to Silicon SR4 release versions:

-  odlparent - 8.1.9
-  aaa - 0.13.11
-  controller - 3.0.16
-  infrautils - 1.9.15
-  mdsal - 7.0.14
-  netconf - 1.13.8
-  yangtools - 6.0.12
-  openflowplugin - 0.12.4
-  serviceutils - 0.7.4

This PR contains also PR #919, #916 and #917