### PR TITLE
Fix lighty spring boot log4j vulnerabilities - master

### DIFF
--- a/lighty-core/lighty-controller-spring-di/pom.xml
+++ b/lighty-core/lighty-controller-spring-di/pom.xml
@@ -51,6 +51,10 @@
 
         <dependency>
             <groupId>io.lighty.resources</groupId>
+            <artifactId>log4j-properties</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.lighty.resources</groupId>
             <artifactId>singlenode-configuration</artifactId>
             <scope>test</scope>
         </dependency>
@@ -64,12 +68,6 @@
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-log4j</artifactId>
-            <version>1.3.8.RELEASE</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/lighty-core/lighty-controller-spring-di/pom.xml
+++ b/lighty-core/lighty-controller-spring-di/pom.xml
@@ -50,6 +50,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.lighty.resources</groupId>
+            <artifactId>singlenode-configuration</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
             <scope>test</scope>

--- a/lighty-core/lighty-controller-spring-di/src/test/java/io/lighty/core/controller/spring/LightyCoreSpringConfigurationTest.java
+++ b/lighty-core/lighty-controller-spring-di/src/test/java/io/lighty/core/controller/spring/LightyCoreSpringConfigurationTest.java
@@ -8,6 +8,8 @@
 
 package io.lighty.core.controller.spring;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import com.google.common.util.concurrent.ListenableFuture;
 import io.lighty.core.controller.api.LightyController;
 import io.lighty.core.controller.api.LightyModuleRegistryService;
@@ -19,6 +21,7 @@ import io.netty.util.Timer;
 import io.netty.util.concurrent.EventExecutor;
 import java.util.Collections;
 import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
 import org.opendaylight.controller.cluster.ActorSystemProvider;
 import org.opendaylight.controller.cluster.datastore.DistributedDataStoreInterface;
 import org.opendaylight.controller.config.threadpool.ScheduledThreadPool;
@@ -51,9 +54,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 
 /**
  * Initializes Spring Boot application and check whether all the lighty.io beans has been correctly autowired.
@@ -63,7 +64,7 @@ import org.testng.annotations.Test;
  * can not create ApplicationContext properly.
  */
 @SpringBootTest
-public class LightyCoreSpringConfigurationTest extends AbstractTestNGSpringContextTests {
+public class LightyCoreSpringConfigurationTest extends AbstractJUnit4SpringContextTests {
 
     private static final Logger LOG = LoggerFactory.getLogger(LightyCoreSpringConfigurationTest.class);
 
@@ -171,40 +172,40 @@ public class LightyCoreSpringConfigurationTest extends AbstractTestNGSpringConte
     Timer timerTestProperty;
 
     @Test
-    void testLightyBeansExists() {
-        Assert.assertNotNull(lightyControllerTestProperty);
-        Assert.assertNotNull(lightyModuleRegistryServiceTestProperty);
-        Assert.assertNotNull(diagStatusServiceTestProperty);
-        Assert.assertNotNull(actorSystemProviderTestProperty);
-        Assert.assertNotNull(effectiveModelContextProvider);
-        Assert.assertNotNull(domSchemaServiceTestProperty);
-        Assert.assertNotNull(domYangTextSourceProviderTestProperty);
-        Assert.assertNotNull(domMountPointServiceTestProperty);
-        Assert.assertNotNull(domNotificationPublishServiceTestProperty);
-        Assert.assertNotNull(domNotificationServiceTestProperty);
-        Assert.assertNotNull(domNotificationSubscriptionListenerRegistryTestProperty);
-        Assert.assertNotNull(configDatastoreTestProperty);
-        Assert.assertNotNull(operationalDatastoreTestProperty);
-        Assert.assertNotNull(clusteredDOMDataBrokerTestProperty);
-        Assert.assertNotNull(domRpcServiceTestProperty);
-        Assert.assertNotNull(domRpcProviderServiceTestProperty);
-        Assert.assertNotNull(bindingNormalizedNodeSerializerTestProperty);
-        Assert.assertNotNull(bindingCodecTreeFactoryTestProperty);
-        Assert.assertNotNull(domEntityOwnershipServiceTestProperty);
-        Assert.assertNotNull(entityOwnershipServiceTestProperty);
-        Assert.assertNotNull(clusterAdminRPCServiceTestProperty);
-        Assert.assertNotNull(clusterSingletonServiceProviderTestProperty);
-        Assert.assertNotNull(rpcProviderRegistryTestProperty);
-        Assert.assertNotNull(bindingMountPointServiceTestProperty);
-        Assert.assertNotNull(notificationServiceTestProperty);
-        Assert.assertNotNull(bindingNotificationPublishServiceTestProperty);
-        Assert.assertNotNull(bindingDataBrokerTestProperty);
-        Assert.assertNotNull(eventExecutorTestProperty);
-        Assert.assertNotNull(bossGroupTestProperty);
-        Assert.assertNotNull(workerGroupTestProperty);
-        Assert.assertNotNull(threadPoolTestProperty);
-        Assert.assertNotNull(scheduledThreadPoolTestProperty);
-        Assert.assertNotNull(timerTestProperty);
+    public void testLightyBeansExists() {
+        assertNotNull(lightyControllerTestProperty);
+        assertNotNull(lightyModuleRegistryServiceTestProperty);
+        assertNotNull(diagStatusServiceTestProperty);
+        assertNotNull(actorSystemProviderTestProperty);
+        assertNotNull(effectiveModelContextProvider);
+        assertNotNull(domSchemaServiceTestProperty);
+        assertNotNull(domYangTextSourceProviderTestProperty);
+        assertNotNull(domMountPointServiceTestProperty);
+        assertNotNull(domNotificationPublishServiceTestProperty);
+        assertNotNull(domNotificationServiceTestProperty);
+        assertNotNull(domNotificationSubscriptionListenerRegistryTestProperty);
+        assertNotNull(configDatastoreTestProperty);
+        assertNotNull(operationalDatastoreTestProperty);
+        assertNotNull(clusteredDOMDataBrokerTestProperty);
+        assertNotNull(domRpcServiceTestProperty);
+        assertNotNull(domRpcProviderServiceTestProperty);
+        assertNotNull(bindingNormalizedNodeSerializerTestProperty);
+        assertNotNull(bindingCodecTreeFactoryTestProperty);
+        assertNotNull(domEntityOwnershipServiceTestProperty);
+        assertNotNull(entityOwnershipServiceTestProperty);
+        assertNotNull(clusterAdminRPCServiceTestProperty);
+        assertNotNull(clusterSingletonServiceProviderTestProperty);
+        assertNotNull(rpcProviderRegistryTestProperty);
+        assertNotNull(bindingMountPointServiceTestProperty);
+        assertNotNull(notificationServiceTestProperty);
+        assertNotNull(bindingNotificationPublishServiceTestProperty);
+        assertNotNull(bindingDataBrokerTestProperty);
+        assertNotNull(eventExecutorTestProperty);
+        assertNotNull(bossGroupTestProperty);
+        assertNotNull(workerGroupTestProperty);
+        assertNotNull(threadPoolTestProperty);
+        assertNotNull(scheduledThreadPoolTestProperty);
+        assertNotNull(timerTestProperty);
     }
 
     @TestConfiguration

--- a/lighty-examples/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/lighty-controller-springboot-netconf/pom.xml
@@ -43,6 +43,27 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- TODO: Remove log4j overriding when spring-boot will be bumped to 2.5.8 or higher -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-to-slf4j</artifactId>
+                <version>2.17.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>2.17.1</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.2.10</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>1.2.10</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
- Remove spring-boot-starter-log4j dependency from  lighty-controller-spring-di which brings old log4j dependencies.
- Override Logback and Log4j dependencies inside lighty-controller-springboot application 