### PR TITLE
Replace slf4j-log4j12 with slf4j-reload4j (cherry-pick  #914)

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -91,8 +91,13 @@
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
-                <version>1.7.30</version>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.35</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-reload4j</artifactId>
+                <version>1.7.35</version>
             </dependency>
             <dependency>
                 <groupId>com.google.inject</groupId>

--- a/lighty-core/lighty-common/pom.xml
+++ b/lighty-core/lighty-common/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
         </dependency>
 
         <!--Tests-->


### PR DESCRIPTION
Cherry-pick  #914

reload4j is a fork of no more maintained log4j 1.2.17 with security
fixes and it is available in recent versions of slf4j.

Update slf4j to 1.7.35 and use slf4j-reload4j artifact providing
reload4j version 1.2.18.3.

For now we cannot move to the slf4j version 1.7.36 providing reload4j
version 1.2.19 because we still use JMX which has been removed from
reload4j:
https://github.com/qos-ch/reload4j/commit/409bc000e6d110b1ab3d2b60fe51c1560e3a1cd1

When at place specify also the version of slf4j-api to override its
upstream version.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit 822df50cfc3f0b1cbcdfa055bc9726daa4f89f2a)