### PR TITLE
Set Alpine version inside docker to 3.15.0 - master

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/src/main/docker/Dockerfile
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.15.0
 
 RUN apk add openjdk11-jre
 

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/src/main/docker/Dockerfile
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.15.0
 
 RUN apk add openjdk11-jre
 


### PR DESCRIPTION
Not specified version for alpine OS could cause not replicable build.