### PR TITLE
Add mTLS and swagger support via configuration capability

### DIFF
--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/example-config/configuration.json
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/example-config/configuration.json
@@ -77,9 +77,13 @@
         "restconfServletContextPath":"/restconf",
         "jsonRestconfServiceType": "DRAFT_18",
         "useHttps": false,
+        "needClientAuth": false,
         "keyStorePassword":"8pgETwat",
         "keyStoreType":"JKS",
-        "keyStoreFilePath":"keystore/lightyio.jks"
+        "keyStoreFilePath":"keystore/lightyio.jks",
+        "trustKeyStorePassword":"8pgETwat",
+        "trustKeyStoreFilePath":"keystore/lightyio.jks",
+        "enableSwagger": false        
     },
     "netconf-northbound":{
         "connectionTimeout":20000,

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/configmaps.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/configmaps.yaml
@@ -84,9 +84,13 @@ data:
             "restconfServletContextPath":{{ .Values.lighty.restconf.restconfPath | quote}},
             "jsonRestconfServiceType": "DRAFT_18",
             "useHttps": {{ .Values.lighty.restconf.useHttps }},
+            "needClientAuth": {{ .Values.lighty.restconf.needClientAuth }},
             "keyStorePassword":{{ .Values.lighty.restconf.keyStorePassword | quote }},
             "keyStoreType":{{ .Values.lighty.restconf.keyStoreType | quote }},
-            "keyStoreFilePath":"{{ .Values.lighty.restconf.keyStoreDirectory }}/{{ .Values.lighty.restconf.keyStoreFileName }}"
+            "keyStoreFilePath":"{{ .Values.lighty.restconf.keyStoreDirectory }}/{{ .Values.lighty.restconf.keyStoreFileName }}",
+            "trustKeyStorePassword":{{ .Values.lighty.restconf.trustKeyStorePassword | quote }},
+            "trustKeyStoreFilePath":"{{ .Values.lighty.restconf.trustKeyStoreDirectory }}/{{ .Values.lighty.restconf.trustKeyStoreFileName }}",
+            "enableSwagger": {{ .Values.lighty.restconf.enableSwagger }}
         },
         "netconf-northbound":{
             "connectionTimeout":20000,

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/values.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/values.yaml
@@ -23,10 +23,15 @@ lighty:
     restconfPort: 8888
     restconfPath: "/restconf"
     useHttps: false
+    needClientAuth: false
     keyStorePassword: "8pgETwat"
     keyStoreType: "JKS"
     keyStoreDirectory: "keystore"
     keyStoreFileName: "lightyio.jks"
+    trustKeyStorePassword: "8pgETwat"
+    trustKeyStoreDirectory: "keystore"
+    trustKeyStoreFileName: "lightyio.jks"
+    enableSwagger: false
 
   jmx:
     # Port on which JMX server in image is listening, should be same as defined in dockerfile

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/pom.xml
@@ -41,6 +41,10 @@
             <groupId>org.eclipse.jetty.http2</groupId>
             <artifactId>http2-server</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.lighty.modules</groupId>
+            <artifactId>lighty-swagger</artifactId>
+        </dependency>        
 
         <dependency>
             <groupId>io.lighty.resources</groupId>

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/RncLightyModule.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/RncLightyModule.java
@@ -80,7 +80,9 @@ public class RncLightyModule {
             }
 
             if (rncModuleConfig.getRestconfConfig().isEnableSwagger()) {
-                this.swagger = initSwaggerLighty(this.rncModuleConfig.getRestconfConfig(), this.jettyServerBuilder, this.lightyController.getServices());
+                this.swagger = initSwaggerLighty(this.rncModuleConfig.getRestconfConfig(),
+                                                this.jettyServerBuilder,
+                                                this.lightyController.getServices());
                 startAndWaitLightyModule(this.swagger);
             }
 
@@ -139,9 +141,11 @@ public class RncLightyModule {
             this.jettyServerBuilder);
     }
 
-    private SwaggerLighty initSwaggerLighty(RncRestConfConfiguration config, LightyServerBuilder jettyServerBuilder, LightyServices services) {
+    private SwaggerLighty initSwaggerLighty(RncRestConfConfiguration config,
+                                            LightyServerBuilder jettySrvBuilder,
+                                            LightyServices services) {
         final RncRestConfConfiguration confConf = RncRestConfConfigUtils.getRestConfConfiguration(config, services);
-        return new SwaggerLighty(confConf, jettyServerBuilder, services);
+        return new SwaggerLighty(confConf, jettySrvBuilder, services);
     }
 
     private void startAndWaitLightyModule(LightyModule lightyModule) throws RncLightyAppStartException {
@@ -171,7 +175,7 @@ public class RncLightyModule {
         LOG.info("Stopping RNC lighty.io application...");
         boolean success = true;
 
-        if (rncModuleConfig.getRestconfConfig().isEnableSwagger() 
+        if (rncModuleConfig.getRestconfConfig().isEnableSwagger()
                 && this.swagger != null && !stopAndWaitLightyModule(this.swagger)) {
             success = false;
         }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/RncLightyModule.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/RncLightyModule.java
@@ -81,8 +81,8 @@ public class RncLightyModule {
 
             if (rncModuleConfig.getRestconfConfig().isEnableSwagger()) {
                 this.swagger = initSwaggerLighty(this.rncModuleConfig.getRestconfConfig(),
-                                                this.jettyServerBuilder,
-                                                this.lightyController.getServices());
+                                                 this.jettyServerBuilder,
+                                                 this.lightyController.getServices());
                 startAndWaitLightyModule(this.swagger);
             }
 
@@ -142,10 +142,10 @@ public class RncLightyModule {
     }
 
     private SwaggerLighty initSwaggerLighty(RncRestConfConfiguration config,
-                                            LightyServerBuilder jettySrvBuilder,
+                                            LightyServerBuilder serverBuilder,
                                             LightyServices services) {
         final RncRestConfConfiguration confConf = RncRestConfConfigUtils.getRestConfConfiguration(config, services);
-        return new SwaggerLighty(confConf, jettySrvBuilder, services);
+        return new SwaggerLighty(confConf, serverBuilder, services);
     }
 
     private void startAndWaitLightyModule(LightyModule lightyModule) throws RncLightyAppStartException {

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/RncLightyModule.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/RncLightyModule.java
@@ -27,6 +27,7 @@ import io.lighty.modules.southbound.netconf.impl.NetconfTopologyPluginBuilder;
 import io.lighty.modules.southbound.netconf.impl.config.NetconfConfiguration;
 import io.lighty.modules.southbound.netconf.impl.util.NetconfConfigUtils;
 import io.lighty.server.LightyServerBuilder;
+import io.lighty.swagger.SwaggerLighty;
 import java.net.InetSocketAddress;
 import java.security.Security;
 import java.util.concurrent.ExecutionException;
@@ -50,6 +51,7 @@ public class RncLightyModule {
     private NetconfSBPlugin lightyNetconf;
     private AAALighty aaaLighty;
     private LightyServerBuilder jettyServerBuilder;
+    private SwaggerLighty swagger;
 
     public RncLightyModule(final RncLightyModuleConfiguration rncModuleConfig, final int lightyModuleTimeout) {
         LOG.info("Creating instance of RNC lighty.io module...");
@@ -75,6 +77,11 @@ public class RncLightyModule {
             if (rncModuleConfig.getAaaConfig().isEnableAAA()) {
                 this.aaaLighty = initAAA(this.rncModuleConfig.getAaaConfig(), this.lightyController.getServices());
                 startAndWaitLightyModule(this.aaaLighty);
+            }
+
+            if (rncModuleConfig.getRestconfConfig().isEnableSwagger()) {
+                this.swagger = initSwaggerLighty(this.rncModuleConfig.getRestconfConfig(), this.jettyServerBuilder, this.lightyController.getServices());
+                startAndWaitLightyModule(this.swagger);
             }
 
             lightyRestconf.startServer();
@@ -132,6 +139,11 @@ public class RncLightyModule {
             this.jettyServerBuilder);
     }
 
+    private SwaggerLighty initSwaggerLighty(RncRestConfConfiguration config, LightyServerBuilder jettyServerBuilder, LightyServices services) {
+        final RncRestConfConfiguration confConf = RncRestConfConfigUtils.getRestConfConfiguration(config, services);
+        return new SwaggerLighty(confConf, jettyServerBuilder, services);
+    }
+
     private void startAndWaitLightyModule(LightyModule lightyModule) throws RncLightyAppStartException {
         try {
             LOG.info("Initializing lighty.io module ({})...", lightyModule.getClass());
@@ -158,6 +170,11 @@ public class RncLightyModule {
     public boolean close() {
         LOG.info("Stopping RNC lighty.io application...");
         boolean success = true;
+
+        if (rncModuleConfig.getRestconfConfig().isEnableSwagger() 
+                && this.swagger != null && !stopAndWaitLightyModule(this.swagger)) {
+            success = false;
+        }
 
         if (this.rncModuleConfig.getAaaConfig().isEnableAAA()
                 && this.aaaLighty != null && !stopAndWaitLightyModule(this.aaaLighty)) {

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/RncRestConfConfiguration.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/RncRestConfConfiguration.java
@@ -115,6 +115,6 @@ public class RncRestConfConfiguration extends RestConfConfiguration {
     }
 
     public void setEnableSwagger(boolean enableSwagger) {
-       this.enableSwagger = enableSwagger;
-    }    
+        this.enableSwagger = enableSwagger;
+    }
 }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/RncRestConfConfiguration.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/RncRestConfConfiguration.java
@@ -20,7 +20,11 @@ public class RncRestConfConfiguration extends RestConfConfiguration {
     private String keyStorePassword = "8pgETwat";
     private String keyStoreType = "JKS";
     private String keyStoreFilePath = "keystore/lightyio.jks";
+    private String trustKeyStorePassword = "8pgETwat";
+    private String trustKeyStoreFilePath = "keystore/lightyio.jks";
     private boolean useHttps = false;
+    private boolean needClientAuth = false;
+    private boolean enableSwagger = false;
 
     public RncRestConfConfiguration() {
         super();
@@ -33,7 +37,12 @@ public class RncRestConfConfiguration extends RestConfConfiguration {
         this.keyStorePassword = rncRestConfConfiguration.getKeyStorePassword();
         this.keyStoreType = rncRestConfConfiguration.getKeyStoreType();
         this.keyStoreFilePath = rncRestConfConfiguration.getKeyStoreFilePath();
+        this.trustKeyStorePassword = rncRestConfConfiguration.getTrustKeyStorePassword();
+        this.trustKeyStoreFilePath = rncRestConfConfiguration.getTrustKeyStoreFilePath();
         this.useHttps = rncRestConfConfiguration.isUseHttps();
+        this.needClientAuth = rncRestConfConfiguration.isNeedClientAuth();
+        this.enableSwagger = rncRestConfConfiguration.isEnableSwagger();
+
         setSecurityConfig(rncRestConfConfiguration.getSecurityConfig());
     }
 
@@ -69,6 +78,22 @@ public class RncRestConfConfiguration extends RestConfConfiguration {
         this.keyStoreFilePath = keyStoreFilePath;
     }
 
+    public String getTrustKeyStorePassword() {
+        return trustKeyStorePassword;
+    }
+
+    public void setTrustKeyStorePassword(String trustKeyStorePassword) {
+        this.trustKeyStorePassword = trustKeyStorePassword;
+    }
+
+    public String getTrustKeyStoreFilePath() {
+        return trustKeyStoreFilePath;
+    }
+
+    public void setTrustKeyStoreFilePath(String trustKeyStoreFilePath) {
+        this.trustKeyStoreFilePath = trustKeyStoreFilePath;
+    }
+
     public boolean isUseHttps() {
         return useHttps;
     }
@@ -76,4 +101,20 @@ public class RncRestConfConfiguration extends RestConfConfiguration {
     public void setUseHttps(boolean useHttps) {
         this.useHttps = useHttps;
     }
+
+    public boolean isNeedClientAuth() {
+        return needClientAuth;
+    }
+
+    public void setNeedClientAuth(boolean needClientAuth) {
+        this.needClientAuth = needClientAuth;
+    }
+
+    public boolean isEnableSwagger() {
+        return enableSwagger;
+    }
+
+    public void setEnableSwagger(boolean enableSwagger) {
+       this.enableSwagger = enableSwagger;
+    }    
 }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/SecurityConfig.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/SecurityConfig.java
@@ -20,9 +20,8 @@ public class SecurityConfig {
     private final SslContextFactory sslContextFactory;
     private final boolean isNeedClientAuth;
 
-    public SecurityConfig(final KeyStore keyStore, final String password,
-                        final KeyStore trustKeyStore, final String trustPassword,
-                        final boolean isNeedClientAuth) {
+    public SecurityConfig(final KeyStore keyStore, final String password, final KeyStore trustKeyStore,
+                          final String trustPassword, final boolean isNeedClientAuth) {
         this.keyStore = keyStore;
         this.password = password;
         this.trustKeyStore = trustKeyStore;

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/SecurityConfig.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/SecurityConfig.java
@@ -14,22 +14,30 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 public class SecurityConfig {
     private final KeyStore keyStore;
+    private final KeyStore trustKeyStore;
     private final String password;
+    private final String trustPassword;
     private final SslContextFactory sslContextFactory;
+    private final boolean isNeedClientAuth;
 
-    public SecurityConfig(final KeyStore keyStore, final String password) {
+    public SecurityConfig(final KeyStore keyStore, final String password, final KeyStore trustKeyStore, final String trustPassword, final boolean isNeedClientAuth) {
         this.keyStore = keyStore;
         this.password = password;
+        this.trustKeyStore = trustKeyStore;
+        this.trustPassword = trustPassword;
+        this.isNeedClientAuth = isNeedClientAuth;
         sslContextFactory = new SslContextFactory.Server();
         initFactoryCtx();
     }
 
     private void initFactoryCtx() {
-        sslContextFactory.setTrustStore(keyStore);
-        sslContextFactory.setTrustStorePassword(password);
+        sslContextFactory.setTrustStore(trustKeyStore);
+        sslContextFactory.setTrustStorePassword(trustPassword);
         sslContextFactory.setKeyStore(keyStore);
         sslContextFactory.setKeyStorePassword(password);
         sslContextFactory.setCipherComparator(HTTP2Cipher.COMPARATOR);
+        if(isNeedClientAuth == true)
+            sslContextFactory.setNeedClientAuth(true);
     }
 
     public SslConnectionFactory getSslConnectionFactory(final String protocol) {

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/SecurityConfig.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/SecurityConfig.java
@@ -20,7 +20,9 @@ public class SecurityConfig {
     private final SslContextFactory sslContextFactory;
     private final boolean isNeedClientAuth;
 
-    public SecurityConfig(final KeyStore keyStore, final String password, final KeyStore trustKeyStore, final String trustPassword, final boolean isNeedClientAuth) {
+    public SecurityConfig(final KeyStore keyStore, final String password, 
+                        final KeyStore trustKeyStore, final String trustPassword, 
+                        final boolean isNeedClientAuth) {
         this.keyStore = keyStore;
         this.password = password;
         this.trustKeyStore = trustKeyStore;
@@ -36,8 +38,9 @@ public class SecurityConfig {
         sslContextFactory.setKeyStore(keyStore);
         sslContextFactory.setKeyStorePassword(password);
         sslContextFactory.setCipherComparator(HTTP2Cipher.COMPARATOR);
-        if(isNeedClientAuth == true)
+        if (isNeedClientAuth == true) {
             sslContextFactory.setNeedClientAuth(true);
+        }
     }
 
     public SslConnectionFactory getSslConnectionFactory(final String protocol) {

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/SecurityConfig.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/SecurityConfig.java
@@ -20,8 +20,8 @@ public class SecurityConfig {
     private final SslContextFactory sslContextFactory;
     private final boolean isNeedClientAuth;
 
-    public SecurityConfig(final KeyStore keyStore, final String password, 
-                        final KeyStore trustKeyStore, final String trustPassword, 
+    public SecurityConfig(final KeyStore keyStore, final String password,
+                        final KeyStore trustKeyStore, final String trustPassword,
                         final boolean isNeedClientAuth) {
         this.keyStore = keyStore;
         this.password = password;

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/util/RncRestConfConfigUtils.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/util/RncRestConfConfigUtils.java
@@ -107,8 +107,8 @@ public final class RncRestConfConfigUtils {
             trustKeyStore.load(trustKsFile.get(), config.getTrustKeyStorePassword().toCharArray());
 
             return new SecurityConfig(keyStore, config.getKeyStorePassword(),
-                                    trustKeyStore, config.getTrustKeyStorePassword(),
-                                    config.isNeedClientAuth());
+                                      trustKeyStore, config.getTrustKeyStorePassword(),
+                                      config.isNeedClientAuth());
         } catch (IOException | NoSuchAlgorithmException | CertificateException | KeyStoreException e) {
             throw new ConfigurationException("Unable to create KeyStore configuration", e);
         }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/util/RncRestConfConfigUtils.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/util/RncRestConfConfigUtils.java
@@ -106,8 +106,8 @@ public final class RncRestConfConfigUtils {
             keyStore.load(ksFile.get(), config.getKeyStorePassword().toCharArray());
             trustKeyStore.load(trustKsFile.get(), config.getTrustKeyStorePassword().toCharArray());
 
-            return new SecurityConfig(keyStore, config.getKeyStorePassword(), 
-                                    trustKeyStore, config.getTrustKeyStorePassword(), 
+            return new SecurityConfig(keyStore, config.getKeyStorePassword(),
+                                    trustKeyStore, config.getTrustKeyStorePassword(),
                                     config.isNeedClientAuth());
         } catch (IOException | NoSuchAlgorithmException | CertificateException | KeyStoreException e) {
             throw new ConfigurationException("Unable to create KeyStore configuration", e);

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/util/RncRestConfConfigUtils.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/util/RncRestConfConfigUtils.java
@@ -99,14 +99,16 @@ public final class RncRestConfConfigUtils {
             final Optional<InputStream> trustKsFile = readKeyStoreFile(config.getTrustKeyStoreFilePath());
 
             if (trustKsFile.isEmpty()) {
-                throw new ConfigurationException("Unable to create TrustKeyStore configuration: KeyStore file was not found"
+                throw new ConfigurationException("Unable to create TrustKeyStore config: KeyStore file was not found"
                         + " on path: " + config.getTrustKeyStoreFilePath());
             }
 
             keyStore.load(ksFile.get(), config.getKeyStorePassword().toCharArray());
             trustKeyStore.load(trustKsFile.get(), config.getTrustKeyStorePassword().toCharArray());
 
-            return new SecurityConfig(keyStore, config.getKeyStorePassword(), trustKeyStore, config.getTrustKeyStorePassword(), config.isNeedClientAuth());
+            return new SecurityConfig(keyStore, config.getKeyStorePassword(), 
+                                    trustKeyStore, config.getTrustKeyStorePassword(), 
+                                    config.isNeedClientAuth());
         } catch (IOException | NoSuchAlgorithmException | CertificateException | KeyStoreException e) {
             throw new ConfigurationException("Unable to create KeyStore configuration", e);
         }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/util/RncRestConfConfigUtils.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/util/RncRestConfConfigUtils.java
@@ -92,8 +92,21 @@ public final class RncRestConfConfigUtils {
                         + " on path: " + config.getKeyStoreFilePath());
             }
 
+            final KeyStore.PasswordProtection trustPassProtection =
+                    new KeyStore.PasswordProtection(config.getTrustKeyStorePassword().toCharArray());
+            final KeyStore trustKeyStore =
+                    KeyStore.Builder.newInstance(config.getKeyStoreType(), null, trustPassProtection).getKeyStore();
+            final Optional<InputStream> trustKsFile = readKeyStoreFile(config.getTrustKeyStoreFilePath());
+
+            if (trustKsFile.isEmpty()) {
+                throw new ConfigurationException("Unable to create TrustKeyStore configuration: KeyStore file was not found"
+                        + " on path: " + config.getTrustKeyStoreFilePath());
+            }
+
             keyStore.load(ksFile.get(), config.getKeyStorePassword().toCharArray());
-            return new SecurityConfig(keyStore, config.getKeyStorePassword());
+            trustKeyStore.load(trustKsFile.get(), config.getTrustKeyStorePassword().toCharArray());
+
+            return new SecurityConfig(keyStore, config.getKeyStorePassword(), trustKeyStore, config.getTrustKeyStorePassword(), config.isNeedClientAuth());
         } catch (IOException | NoSuchAlgorithmException | CertificateException | KeyStoreException e) {
             throw new ConfigurationException("Unable to create KeyStore configuration", e);
         }


### PR DESCRIPTION
This PR aims to provide support for mTLS and swagger support for lighty-rnc-app. Both can be configured from configuration.json. By default mTLS and swagger is disabled.