### PR TITLE
Provide module shards Config to Controller instead of tmp file

### DIFF
--- a/lighty-core/lighty-clustering/pom.xml
+++ b/lighty-core/lighty-clustering/pom.xml
@@ -38,6 +38,10 @@
         </dependency>
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
+            <artifactId>sal-distributed-datastore</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opendaylight.controller</groupId>
             <artifactId>eos-dom-akka</artifactId>
         </dependency>
         <dependency>

--- a/lighty-core/lighty-clustering/src/main/java/io/lighty/core/cluster/ClusteringHandler.java
+++ b/lighty-core/lighty-clustering/src/main/java/io/lighty/core/cluster/ClusteringHandler.java
@@ -7,6 +7,7 @@
  */
 package io.lighty.core.cluster;
 
+import com.typesafe.config.Config;
 import java.util.Optional;
 import org.eclipse.jdt.annotation.NonNull;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.controller.md.sal.cluster.admin.rev151013.ClusterAdminService;
@@ -17,5 +18,5 @@ public interface ClusteringHandler {
 
     void start(@NonNull ClusterAdminService clusterAdminRPCService);
 
-    Optional<String> getModuleConfig();
+    Optional<Config> getModuleShardsConfig();
 }

--- a/lighty-core/lighty-clustering/src/main/java/io/lighty/core/cluster/config/ClusteringConfigUtils.java
+++ b/lighty-core/lighty-clustering/src/main/java/io/lighty/core/cluster/config/ClusteringConfigUtils.java
@@ -12,7 +12,6 @@ import java.util.List;
 
 public final class ClusteringConfigUtils {
 
-    public static final String MODULE_SHARDS_TMP_PATH = "/tmp/module-shards.conf";
     public static final String AKKA_DISCOVERY_METHOD_PATH = "akka.discovery.method";
     public static final String K8S_DISCOVERY_API_NAME = "kubernetes-api";
 


### PR DESCRIPTION
Provide custom moduleShardsConfig in controller instead of storing
moduleShardsConfig in tmp file: "/tmp/module-shards.conf".
This file was later read in initializing class ConfigurationImpl.