### PR TITLE
Lift config update

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -1,4 +1,4 @@
 build = "maven"
 jdkVersion = "11"
 summaryComments = true
-disableTools = ["bill of materials", "open source vulnerabilities"]
+

--- a/.lift.toml
+++ b/.lift.toml
@@ -1,4 +1,4 @@
 build = "maven"
 jdkVersion = "11"
 summaryComments = true
-tools = ["infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]
+disableTools = ["bill of materials", "open source vulnerabilities"]

--- a/.lift.toml
+++ b/.lift.toml
@@ -1,4 +1,4 @@
 build = "maven"
-jdk11 = true
+jdkVersion = "11"
 summaryComments = true
 tools = ["infer", "findsecbugs", "errorprone", "cobra", "gosec", "shellcheck", "semgrep"]


### PR DESCRIPTION
Replace deprecated `jdk11` field by `jdkVersion`
and enable all the Sonatype Lift tools, as they were already fixed and now works without failing.