### PR TITLE
Support multiple top elements in initial data

### DIFF
--- a/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/util/FileToDatastoreUtilsTest.java
+++ b/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/util/FileToDatastoreUtilsTest.java
@@ -22,6 +22,8 @@ import org.opendaylight.mdsal.binding.api.DataBroker;
 import org.opendaylight.mdsal.binding.api.ReadTransaction;
 import org.opendaylight.mdsal.common.api.LogicalDatastoreType;
 import org.opendaylight.yang.gen.v1.http.pantheon.tech.ns.test.models.rev180119.$YangModuleInfoImpl;
+import org.opendaylight.yang.gen.v1.http.pantheon.tech.ns.test.models.rev180119.SampleList;
+import org.opendaylight.yang.gen.v1.http.pantheon.tech.ns.test.models.rev180119.SampleListKey;
 import org.opendaylight.yang.gen.v1.http.pantheon.tech.ns.test.models.rev180119.TopLevelContainer;
 import org.opendaylight.yang.gen.v1.http.pantheon.tech.ns.test.models.rev180119.container.group.SampleContainer;
 import org.opendaylight.yangtools.yang.binding.DataObject;
@@ -37,8 +39,14 @@ public class FileToDatastoreUtilsTest {
     private static final String OVERRIDE_CONTAINER_PATH = "/data/container-value-2.xml";
     private static final String OVERRIDE_VALUE_JSON_PATH = "/data/leaf-value-3.json";
     private static final String OVERRIDE_VALUE_XML_PATH = "/data/leaf-value-4.xml";
+    private static final String MULTIPLE_TOP_JSON_PATH = "/data/multiple-top-element.json";
+    private static final String MULTIPLE_TOP_XML_PATH = "/data/multiple-top-element.xml";
     private static final InstanceIdentifier<TopLevelContainer> TOP_LEVEL_CONTAINER_IID
             = InstanceIdentifier.create(TopLevelContainer.class);
+    private static final InstanceIdentifier<SampleList> SAMPLE_LIST_ID1_IID
+            = InstanceIdentifier.builder(SampleList.class, new SampleListKey("ID1")).build();
+    private static final InstanceIdentifier<SampleList> SAMPLE_LIST_ID2_IID
+            = InstanceIdentifier.builder(SampleList.class, new SampleListKey("ID2")).build();
 
     private static final YangInstanceIdentifier ROOT_YII = YangInstanceIdentifier.empty();
     private static final YangInstanceIdentifier INNER_VALUE_YII = YangInstanceIdentifier.create(
@@ -87,6 +95,29 @@ public class FileToDatastoreUtilsTest {
         importFile(OVERRIDE_VALUE_XML_PATH, INNER_VALUE_YII, ImportFileFormat.XML);
         topLevelContainer = readDataFromDatastore(TOP_LEVEL_CONTAINER_IID);
         assertEquals(topLevelContainer.getSampleContainer().getValue().intValue(), 4);
+    }
+
+    @Test
+    public void testMultipleTopElement() throws Exception {
+        // Import multiple top element in JSON file, Expected value 5, ID1 value 1, ID2 value 2
+        importFile(MULTIPLE_TOP_JSON_PATH, ROOT_YII, ImportFileFormat.JSON);
+        TopLevelContainer topLevelContainer = readDataFromDatastore(TOP_LEVEL_CONTAINER_IID);
+        assertEquals(topLevelContainer.getSampleContainer().getValue().intValue(), 5);
+
+        SampleList sampleListId1 = readDataFromDatastore(SAMPLE_LIST_ID1_IID);
+        assertEquals(sampleListId1.getValue().intValue(), 1);
+        SampleList sampleListId2 = readDataFromDatastore(SAMPLE_LIST_ID2_IID);
+        assertEquals(sampleListId2.getValue().intValue(), 2);
+
+        // Import multiple top element in XML file, Expected value 6, ID1 value 3, ID2 value 4
+        importFile(MULTIPLE_TOP_XML_PATH, ROOT_YII, ImportFileFormat.XML);
+        topLevelContainer = readDataFromDatastore(TOP_LEVEL_CONTAINER_IID);
+        assertEquals(topLevelContainer.getSampleContainer().getValue().intValue(), 6);
+
+        sampleListId1 = readDataFromDatastore(SAMPLE_LIST_ID1_IID);
+        assertEquals(sampleListId1.getValue().intValue(), 3);
+        sampleListId2 = readDataFromDatastore(SAMPLE_LIST_ID2_IID);
+        assertEquals(sampleListId2.getValue().intValue(), 4);
     }
 
     private <T extends DataObject> T readDataFromDatastore(final InstanceIdentifier<T> instanceIdentifier)

--- a/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/util/FileToDatastoreUtilsTest.java
+++ b/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/util/FileToDatastoreUtilsTest.java
@@ -11,17 +11,13 @@ package io.lighty.core.controller.util;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-import io.lighty.codecs.util.exception.DeserializationException;
 import io.lighty.core.controller.api.LightyController;
-import io.lighty.core.controller.api.LightyServices;
 import io.lighty.core.controller.impl.LightyControllerBuilder;
 import io.lighty.core.controller.impl.util.ControllerConfigUtils;
 import io.lighty.core.controller.impl.util.FileToDatastoreUtils;
-import java.io.IOException;
+import io.lighty.core.controller.impl.util.FileToDatastoreUtils.ImportFileFormat;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import org.opendaylight.mdsal.binding.api.DataBroker;
 import org.opendaylight.mdsal.binding.api.ReadTransaction;
 import org.opendaylight.mdsal.common.api.LogicalDatastoreType;
@@ -31,6 +27,8 @@ import org.opendaylight.yang.gen.v1.http.pantheon.tech.ns.test.models.rev180119.
 import org.opendaylight.yangtools.yang.binding.DataObject;
 import org.opendaylight.yangtools.yang.binding.InstanceIdentifier;
 import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class FileToDatastoreUtilsTest {
@@ -39,6 +37,8 @@ public class FileToDatastoreUtilsTest {
     private static final String OVERRIDE_CONTAINER_PATH = "/data/container-value-2.xml";
     private static final String OVERRIDE_VALUE_JSON_PATH = "/data/leaf-value-3.json";
     private static final String OVERRIDE_VALUE_XML_PATH = "/data/leaf-value-4.xml";
+    private static final InstanceIdentifier<TopLevelContainer> TOP_LEVEL_CONTAINER_IID
+            = InstanceIdentifier.create(TopLevelContainer.class);
 
     private static final YangInstanceIdentifier ROOT_YII = YangInstanceIdentifier.empty();
     private static final YangInstanceIdentifier INNER_VALUE_YII = YangInstanceIdentifier.create(
@@ -49,72 +49,62 @@ public class FileToDatastoreUtilsTest {
     private static final long TIMEOUT_MILLIS = 20_000;
 
     private LightyController lightyController;
+    private DataBroker dataBroker;
 
-    @Test
-    public void testTopLevelNode() throws Exception {
+    @BeforeClass
+    public void startUp() throws Exception {
         lightyController = new LightyControllerBuilder()
                 .from(ControllerConfigUtils.getDefaultSingleNodeConfiguration(
                         Set.of($YangModuleInfoImpl.getInstance())))
                 .build();
         assertTrue(lightyController.start().get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
+        dataBroker = lightyController.getServices().getBindingDataBroker();
+    }
 
-        // Import first JSON file, new top level container, expecting value = 1
-        importFile(lightyController.getServices(), INITIAL_CONTAINER_PATH, ROOT_YII,
-                FileToDatastoreUtils.ImportFileFormat.JSON);
-        //Retrieve data from datastore
-        TopLevelContainer topLevelContainer = readDataFromDatastore(
-                TopLevelContainer.class, lightyController.getServices().getBindingDataBroker());
-        assertEquals(topLevelContainer.getSampleContainer().getValue().intValue(), 1);
-
-
-        //Import second file, overrides whole top level container, expecting value = 2
-        importFile(lightyController.getServices(), OVERRIDE_CONTAINER_PATH, ROOT_YII,
-                FileToDatastoreUtils.ImportFileFormat.XML);
-        //Retrieve data from datastore
-        topLevelContainer = readDataFromDatastore(
-                TopLevelContainer.class, lightyController.getServices().getBindingDataBroker());
-        assertEquals(topLevelContainer.getSampleContainer().getValue().intValue(), 2);
-
-        // Import third file, overrides only inner leaf, expecting value = 3
-        importFile(lightyController.getServices(), OVERRIDE_VALUE_JSON_PATH,
-                INNER_VALUE_YII, FileToDatastoreUtils.ImportFileFormat.JSON);
-        //Retrieve data from datastore
-        topLevelContainer = readDataFromDatastore(
-                TopLevelContainer.class, lightyController.getServices().getBindingDataBroker());
-        assertEquals(topLevelContainer.getSampleContainer().getValue().intValue(), 3);
-
-        // Import fourth file, overrides only inner leaf, expecting value = 4
-        importFile(lightyController.getServices(), OVERRIDE_VALUE_XML_PATH,
-                INNER_VALUE_YII, FileToDatastoreUtils.ImportFileFormat.XML);
-        //Retrieve data from datastore
-        topLevelContainer = readDataFromDatastore(
-                TopLevelContainer.class, lightyController.getServices().getBindingDataBroker());
-        assertEquals(topLevelContainer.getSampleContainer().getValue().intValue(), 4);
-
+    @AfterClass
+    public void tearDown() throws Exception {
         assertTrue(lightyController.shutdown().get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
     }
 
+    @Test
+    public void testTopLevelNode() throws Exception {
+        // Import first JSON file, new top level container, expecting value = 1
+        importFile(INITIAL_CONTAINER_PATH, ROOT_YII, ImportFileFormat.JSON);
+        TopLevelContainer topLevelContainer = readDataFromDatastore(TOP_LEVEL_CONTAINER_IID);
+        assertEquals(topLevelContainer.getSampleContainer().getValue().intValue(), 1);
 
-    private static <T extends DataObject> T readDataFromDatastore(final Class<T> clazz, final DataBroker dataBroker)
-            throws InterruptedException, ExecutionException, TimeoutException {
+        //Import second file, overrides whole top level container, expecting value = 2
+        importFile(OVERRIDE_CONTAINER_PATH, ROOT_YII, ImportFileFormat.XML);
+        topLevelContainer = readDataFromDatastore(TOP_LEVEL_CONTAINER_IID);
+        assertEquals(topLevelContainer.getSampleContainer().getValue().intValue(), 2);
+
+        // Import third file, overrides only inner leaf, expecting value = 3
+        importFile(OVERRIDE_VALUE_JSON_PATH, INNER_VALUE_YII, ImportFileFormat.JSON);
+        topLevelContainer = readDataFromDatastore(TOP_LEVEL_CONTAINER_IID);
+        assertEquals(topLevelContainer.getSampleContainer().getValue().intValue(), 3);
+
+        // Import fourth file, overrides only inner leaf, expecting value = 4
+        importFile(OVERRIDE_VALUE_XML_PATH, INNER_VALUE_YII, ImportFileFormat.XML);
+        topLevelContainer = readDataFromDatastore(TOP_LEVEL_CONTAINER_IID);
+        assertEquals(topLevelContainer.getSampleContainer().getValue().intValue(), 4);
+    }
+
+    private <T extends DataObject> T readDataFromDatastore(final InstanceIdentifier<T> instanceIdentifier)
+            throws Exception {
         try (ReadTransaction readTransaction = dataBroker.newReadOnlyTransaction()) {
-            return readTransaction.read(LogicalDatastoreType.CONFIGURATION,
-                    InstanceIdentifier.create(clazz))
+            return readTransaction.read(LogicalDatastoreType.CONFIGURATION, instanceIdentifier)
                     .get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS).orElseThrow();
         }
     }
 
-    private static void importFile(final LightyServices services, final String path, final YangInstanceIdentifier yii,
-            final FileToDatastoreUtils.ImportFileFormat format)
-            throws InterruptedException, ExecutionException, DeserializationException, TimeoutException, IOException {
-        FileToDatastoreUtils.importConfigDataFile(
-                FileToDatastoreUtils.class.getResourceAsStream(path),
+    private void importFile(final String path, final YangInstanceIdentifier yii, final ImportFileFormat format)
+            throws Exception {
+        FileToDatastoreUtils.importConfigDataFile(FileToDatastoreUtils.class.getResourceAsStream(path),
                 yii,
                 format,
-                services.getEffectiveModelContextProvider().getEffectiveModelContext(),
-                services.getClusteredDOMDataBroker(),
+                lightyController.getServices().getEffectiveModelContextProvider().getEffectiveModelContext(),
+                lightyController.getServices().getClusteredDOMDataBroker(),
                 true);
     }
-
 
 }

--- a/lighty-core/lighty-controller/src/test/resources/data/multiple-top-element.json
+++ b/lighty-core/lighty-controller/src/test/resources/data/multiple-top-element.json
@@ -1,0 +1,18 @@
+{
+  "test-models:top-level-container": {
+    "sample-container": {
+      "name": "name",
+      "value": 5
+    }
+  },
+  "test-models:sample-list": [
+    {
+      "name": "ID1",
+      "value": 1
+    },
+    {
+      "name": "ID2",
+      "value": 2
+    }
+  ]
+}

--- a/lighty-core/lighty-controller/src/test/resources/data/multiple-top-element.xml
+++ b/lighty-core/lighty-controller/src/test/resources/data/multiple-top-element.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (c) 2022 PANTHEON.tech s.r.o. All Rights Reserved.
+  ~
+  ~ This program and the accompanying materials are made available under the
+  ~ terms of the Eclipse Public License v1.0 which accompanies this distribution,
+  ~ and is available at https://www.eclipse.org/legal/epl-v10.html
+  -->
+
+<data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <top-level-container xmlns="http://pantheon.tech/ns/test-models">
+        <sample-container>
+            <name>name</name>
+            <value>6</value>
+        </sample-container>
+    </top-level-container>
+    <sample-list xmlns="http://pantheon.tech/ns/test-models">
+        <name>ID1</name>
+        <value>3</value>
+    </sample-list>
+    <sample-list xmlns="http://pantheon.tech/ns/test-models">
+        <name>ID2</name>
+        <value>4</value>
+    </sample-list>
+</data>


### PR DESCRIPTION
lighty Initialization with multiple top elements in initial data fails. Deserialization from json to normalized node fails due to closing json writer right after first top element node. With providing correct resultBuilder to NormalizedNodeStreamWriter it is possible to parse multiple top elements and this type of result will be wrapped in base container (urn:ietf:params:xml:ns:netconf:base:1.0)data.