### PR TITLE
Introduce lighty-app-modules-config

### DIFF
--- a/lighty-applications/lighty-app-modules-config/pom.xml
+++ b/lighty-applications/lighty-app-modules-config/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2022 PANTHEON.tech s.r.o. All Rights Reserved.
+
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License v1.0 which accompanies this distribution,
+  and is available at https://www.eclipse.org/legal/epl-v10.html
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.lighty.core</groupId>
+        <artifactId>lighty-parent</artifactId>
+        <version>17.0.0-SNAPSHOT</version>
+        <relativePath>../../lighty-core/lighty-parent/pom.xml</relativePath>
+    </parent>
+
+    <groupId>io.lighty.applications</groupId>
+    <artifactId>lighty-app-modules-config</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.lighty.core</groupId>
+            <artifactId>lighty-controller</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.lighty.resources</groupId>
+            <artifactId>log4j-properties</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/lighty-applications/lighty-app-modules-config/src/main/java/io/lighty/applications/util/ModulesConfig.java
+++ b/lighty-applications/lighty-app-modules-config/src/main/java/io/lighty/applications/util/ModulesConfig.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2022 PANTHEON.tech s.r.o. All Rights Reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ */
+package io.lighty.applications.util;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.lighty.core.controller.impl.config.ConfigurationException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ModulesConfig {
+    private static final Logger LOG = LoggerFactory.getLogger(ModulesConfig.class);
+    private static final String MODULES_ELEMENT_NAME = "modules";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private long moduleTimeoutSeconds = 60;
+
+    /**
+     * Load ModulesConfig configuration from InputStream containing JSON data.
+     *
+     * @param jsonConfigInputStream InputStream containing ModulesConfig configuration data in JSON format.
+     * @return Object representation of configuration data.
+     * @throws ConfigurationException In case InputStream does not contain valid JSON data,
+     *     or cannot bind Json tree to type.
+     */
+    public static ModulesConfig getModulesConfig(final InputStream jsonConfigInputStream)
+            throws ConfigurationException {
+        final JsonNode configNode;
+        try {
+            configNode = MAPPER.readTree(jsonConfigInputStream);
+        } catch (final IOException e) {
+            throw new ConfigurationException("Cannot deserialize Json content to Json tree nodes", e);
+        }
+        if (!configNode.has(MODULES_ELEMENT_NAME)) {
+            LOG.warn("Json config does not contain {} element. Using defaults.", MODULES_ELEMENT_NAME);
+            return ModulesConfig.getDefaultModulesConfig();
+        }
+        final var modulesNode = configNode.path(MODULES_ELEMENT_NAME);
+        try {
+            return MAPPER.treeToValue(modulesNode, ModulesConfig.class);
+        } catch (final JsonProcessingException e) {
+            throw new ConfigurationException(
+                    String.format("Cannot bind Json tree to type: %s", ModulesConfig.class), e);
+        }
+    }
+
+    /**
+     * Get default ModulesConfig configuration.
+     *
+     * @return Object representation of configuration data.
+     */
+    public static ModulesConfig getDefaultModulesConfig() {
+        return new ModulesConfig();
+    }
+
+    public long getModuleTimeoutSeconds() {
+        return moduleTimeoutSeconds;
+    }
+
+    public void setModuleTimeoutSeconds(final long moduleTimeoutSeconds) {
+        this.moduleTimeoutSeconds = moduleTimeoutSeconds;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ModulesConfig)) {
+            return false;
+        }
+        if (!super.equals(obj)) {
+            return false;
+        }
+        final ModulesConfig that = (ModulesConfig) obj;
+        return moduleTimeoutSeconds == that.moduleTimeoutSeconds;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), moduleTimeoutSeconds);
+    }
+}

--- a/lighty-applications/lighty-app-modules-config/src/test/java/io/lighty/applications/util/ModulesConfigTest.java
+++ b/lighty-applications/lighty-app-modules-config/src/test/java/io/lighty/applications/util/ModulesConfigTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022 PANTHEON.tech s.r.o. All Rights Reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v10.html
+ */
+package io.lighty.applications.util;
+
+import static org.testng.Assert.assertEquals;
+
+import io.lighty.core.controller.impl.config.ConfigurationException;
+import org.junit.jupiter.api.Test;
+
+public class ModulesConfigTest {
+
+    @Test
+    void loadJsonConfig() throws ConfigurationException {
+        final var config = ModulesConfig.getModulesConfig(this.getClass().getClassLoader()
+                .getResourceAsStream("sampleModulesConfig.json"));
+
+        assertEquals(config.getModuleTimeoutSeconds(), 180);
+    }
+
+    @Test
+    void loadMissingConfig() throws ConfigurationException {
+        final var config = ModulesConfig.getModulesConfig(this.getClass().getClassLoader()
+                .getResourceAsStream("missingModulesConfig.json"));
+
+        assertEquals(config.getModuleTimeoutSeconds(), 60);
+    }
+}

--- a/lighty-applications/lighty-app-modules-config/src/test/resources/missingModulesConfig.json
+++ b/lighty-applications/lighty-app-modules-config/src/test/resources/missingModulesConfig.json
@@ -1,0 +1,12 @@
+{
+    "controller":{
+    },
+    "restconf":{
+        "httpPort":8888,
+        "webSocketPort": 8185
+    },
+    "netconf-northbound":{
+    },
+    "netconf":{
+    }
+}

--- a/lighty-applications/lighty-app-modules-config/src/test/resources/sampleModulesConfig.json
+++ b/lighty-applications/lighty-app-modules-config/src/test/resources/sampleModulesConfig.json
@@ -1,0 +1,15 @@
+{
+    "modules": {
+      "moduleTimeoutSeconds": 180
+    },
+    "controller":{
+    },
+    "restconf":{
+        "httpPort":8888,
+        "webSocketPort": 8185
+    },
+    "netconf-northbound":{
+    },
+    "netconf":{
+    }
+}

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/README.md
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/README.md
@@ -29,16 +29,13 @@ To build and start the RCgNMI application in your local environment, follow thes
 4. To start the application with a custom lighty.io configuration, use the argument _-c_ and for a custom initial log4j configuration, use argument _-l_:  
    `java -jar lighty-rcgnmi-app-<version>.jar -c /path/to/config-file -l /path/to/log4j-config-file`  
 
-   Example configuration files are located on following path:  
-   `lighty-rcgnmi-app-docker/example-config/*`
+   To extend lighty modules time-out use `"modules": {"moduleTimeoutSeconds": SECONDS },` property inside JSON configuration. This property increases the time after which the exception is thrown if the module is not successfully initialized by then (Default 60).
+   Example configuration files are located on following folder [example-config](lighty-rcgnmi-app/src/main/resources/example-config).
 
-5. (Optional) To extend lighty modules time-out use the argument `-t/--timeout-in-seconds`. This argument increases the time after which the exception is thrown if the module is not successfully initialized by then. (Default 60)
-   `java -jar lighty-rcgnmi-app-<version>.jar -t 90`
-
-6. If the application was started successfully, then a log similar should be present in the console:  
+5. If the application was started successfully, then a log similar should be present in the console:  
   ` INFO [main] (RCgNMIApp.java:98) - RCgNMI lighty.io application started in 10.10 s`
 
-7. Test the RCgNMI lighty.io application. Default RESTCONF port is `8888`  
+6. Test the RCgNMI lighty.io application. Default RESTCONF port is `8888`  
    The default credential for http requests is login:`admin`, password: `admin`. 
 
 ## How to Use the RCgNMI Example App

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/configmaps.yaml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/configmaps.yaml
@@ -6,6 +6,9 @@ kind: ConfigMap
 data:
   lighty-config.json: |
     {
+      "modules": {
+        "moduleTimeoutSeconds": {{ .Values.lighty.moduleTimeOut | quote }}
+      },
       "controller":{
         "restoreDirectoryPath":"./clustered-datastore-restore",
         "maxDataBrokerFutureCallbackQueueSize":1000,

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/deployment.yaml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/deployment.yaml
@@ -22,8 +22,7 @@ spec:
           image: "{{ .Values.image.name }}:{{ .Values.image.version }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: [ "-c","{{ .Values.lighty.configDirectoryName }}/{{ .Values.lighty.configFilename }}",
-                  "-l","{{ .Values.lighty.configDirectoryName }}/{{ .Values.lighty.loggerConfigFilename }}",
-                  "-t","{{ .Values.lighty.moduleTimeOut }}"]
+                  "-l","{{ .Values.lighty.configDirectoryName }}/{{ .Values.lighty.loggerConfigFilename }}"]
           volumeMounts:
             - name: config-volume
               mountPath: {{ .Values.lighty.workdir }}/{{ .Values.lighty.configDirectoryName }}

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>lighty-gnmi-sb</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.lighty.applications</groupId>
+            <artifactId>lighty-app-modules-config</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.lighty.resources</groupId>
             <artifactId>singlenode-configuration</artifactId>
             <scope>test</scope>

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppConfiguration.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppConfiguration.java
@@ -8,6 +8,7 @@
 
 package io.lighty.applications.rcgnmi.module;
 
+import io.lighty.applications.util.ModulesConfig;
 import io.lighty.core.controller.impl.config.ControllerConfiguration;
 import io.lighty.gnmi.southbound.lightymodule.config.GnmiConfiguration;
 import io.lighty.modules.northbound.restconf.community.impl.config.RestConfConfiguration;
@@ -16,13 +17,15 @@ public class RcGnmiAppConfiguration {
     private final ControllerConfiguration controllerConfig;
     private final RestConfConfiguration restconfConfig;
     private final GnmiConfiguration gnmiConfiguration;
+    private final ModulesConfig modulesConfig;
 
     public RcGnmiAppConfiguration(final ControllerConfiguration controllerConfig,
-                                  final RestConfConfiguration restconfConfig,
-                                  final GnmiConfiguration gnmiConfiguration) {
+            final RestConfConfiguration restconfConfig, final GnmiConfiguration gnmiConfiguration,
+            final ModulesConfig modulesConfig) {
         this.controllerConfig = controllerConfig;
         this.restconfConfig = restconfConfig;
         this.gnmiConfiguration = gnmiConfiguration;
+        this.modulesConfig = modulesConfig;
     }
 
     public ControllerConfiguration getControllerConfig() {
@@ -37,4 +40,7 @@ public class RcGnmiAppConfiguration {
         return gnmiConfiguration;
     }
 
+    public ModulesConfig getModulesConfig() {
+        return modulesConfig;
+    }
 }

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
@@ -56,7 +56,7 @@ public class RcGnmiAppModule {
     private static final TimeUnit DEFAULT_LIGHTY_MODULE_TIME_UNIT = TimeUnit.SECONDS;
     private static final SecureRandom RANDOM = new SecureRandom();
 
-    private final int lightyModuleTimeout;
+    private final long lightyModuleTimeout;
     private final RcGnmiAppConfiguration appModuleConfig;
     private final ExecutorService gnmiExecutorService;
     private final CrossSourceStatementReactor customReactor;
@@ -66,12 +66,11 @@ public class RcGnmiAppModule {
 
     public RcGnmiAppModule(final RcGnmiAppConfiguration appModuleConfig,
                            final ExecutorService gnmiExecutorService,
-                           final int lightyModuleTimeout,
                            @Nullable final CrossSourceStatementReactor customReactor) {
         LOG.info("Creating instance of RgNMI lighty.io module...");
         this.appModuleConfig = Objects.requireNonNull(appModuleConfig);
         this.gnmiExecutorService = Objects.requireNonNull(gnmiExecutorService);
-        this.lightyModuleTimeout = lightyModuleTimeout;
+        this.lightyModuleTimeout = appModuleConfig.getModulesConfig().getModuleTimeoutSeconds();
         this.customReactor = customReactor;
         LOG.info("Instance of RCgNMI lighty.io module created!");
     }

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModuleConfigUtils.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModuleConfigUtils.java
@@ -9,6 +9,7 @@
 package io.lighty.applications.rcgnmi.module;
 
 import com.typesafe.config.Config;
+import io.lighty.applications.util.ModulesConfig;
 import io.lighty.core.controller.impl.config.ConfigurationException;
 import io.lighty.core.controller.impl.config.ControllerConfiguration;
 import io.lighty.core.controller.impl.util.ControllerConfigUtils;
@@ -46,7 +47,9 @@ public final class RcGnmiAppModuleConfigUtils {
         restconfConfig.setInetAddress(new InetSocketAddress(restconfConfig.getHttpPort()).getAddress());
         LOG.debug("Loading default lighty.io gNMI module configuration...");
         final GnmiConfiguration gnmiConfiguration = GnmiConfigUtils.getDefaultGnmiConfiguration();
-        return new RcGnmiAppConfiguration(controllerConfig, restconfConfig, gnmiConfiguration);
+        LOG.debug("Loading default lighty.io app modules configuration...");
+        final ModulesConfig modulesConfig = ModulesConfig.getDefaultModulesConfig();
+        return new RcGnmiAppConfiguration(controllerConfig, restconfConfig, gnmiConfiguration, modulesConfig);
     }
 
     public static RcGnmiAppConfiguration loadConfiguration(final Path path) throws ConfigurationException, IOException {
@@ -64,9 +67,12 @@ public final class RcGnmiAppModuleConfigUtils {
             restconfConfig.setInetAddress(new InetSocketAddress(restconfConfig.getHttpPort()).getAddress());
         }
 
-        LOG.debug("Loading default lighty.io gNMI module configuration...");
+        LOG.debug("Loading lighty.io gNMI module configuration...");
         final GnmiConfiguration gnmiConfiguration = GnmiConfigUtils.getGnmiConfiguration(Files.newInputStream(path));
-        return new RcGnmiAppConfiguration(controllerConfig, restconfConfig, gnmiConfiguration);
+
+        LOG.debug("Loading lighty.io app modules configuration...");
+        final ModulesConfig modulesConfig = ModulesConfig.getModulesConfig(Files.newInputStream(path));
+        return new RcGnmiAppConfiguration(controllerConfig, restconfConfig, gnmiConfiguration, modulesConfig);
     }
 
     private static void defaultModels(final Set<YangModuleInfo> modelPaths) {

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/test/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModuleConfigUtilsTest.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/test/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModuleConfigUtilsTest.java
@@ -12,6 +12,7 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 
+import io.lighty.applications.util.ModulesConfig;
 import io.lighty.core.controller.impl.config.ConfigurationException;
 import io.lighty.core.controller.impl.config.ControllerConfiguration;
 import io.lighty.core.controller.impl.util.DatastoreConfigurationUtils;
@@ -53,6 +54,8 @@ public class RcGnmiAppModuleConfigUtilsTest {
         assertTrue(controllerConfig.getDistributedEosProperties().isEmpty());
         assertEquals(controllerConfig.getDatastoreProperties(),
                 DatastoreConfigurationUtils.getDefaultDatastoreProperties());
+        final ModulesConfig modulesConfig = rcGnmiAppConfiguration.getModulesConfig();
+        assertEquals(180, modulesConfig.getModuleTimeoutSeconds());
     }
 
     @Test
@@ -81,6 +84,8 @@ public class RcGnmiAppModuleConfigUtilsTest {
         assertTrue(controllerConfig.getDistributedEosProperties().isEmpty());
         assertEquals(controllerConfig.getDatastoreProperties(),
                 DatastoreConfigurationUtils.getDefaultDatastoreProperties());
+        final ModulesConfig modulesConfig = rcGnmiAppConfiguration.getModulesConfig();
+        assertEquals(60, modulesConfig.getModuleTimeoutSeconds());
     }
 
 
@@ -109,6 +114,8 @@ public class RcGnmiAppModuleConfigUtilsTest {
         assertTrue(controllerConfig.getDistributedEosProperties().isEmpty());
         assertEquals(controllerConfig.getDatastoreProperties(),
                 DatastoreConfigurationUtils.getDefaultDatastoreProperties());
+        final ModulesConfig modulesConfig = rcGnmiAppConfiguration.getModulesConfig();
+        assertEquals(60, modulesConfig.getModuleTimeoutSeconds());
     }
 
 }

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/test/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModuleTest.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/test/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModuleTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 public class RcGnmiAppModuleTest {
-    private static final int MODULE_TIMEOUT = 60;
 
     private RcGnmiAppModule rcgnmiModule;
 
@@ -31,7 +30,7 @@ public class RcGnmiAppModuleTest {
     @Test
     public void gnmiModuleSmokeTest() throws ConfigurationException {
         rcgnmiModule = new RcGnmiAppModule(RcGnmiAppModuleConfigUtils.loadDefaultConfig(),
-                Executors.newCachedThreadPool(), MODULE_TIMEOUT, null);
+                Executors.newCachedThreadPool(), null);
         assertTrue(rcgnmiModule.initModules());
     }
 
@@ -39,7 +38,7 @@ public class RcGnmiAppModuleTest {
     public void gnmiModuleStartFailedTest() throws ConfigurationException {
         final var config = spy(RcGnmiAppModuleConfigUtils.loadDefaultConfig());
         when(config.getControllerConfig()).thenReturn(null);
-        rcgnmiModule = new RcGnmiAppModule(config, Executors.newCachedThreadPool(), MODULE_TIMEOUT, null);
+        rcgnmiModule = new RcGnmiAppModule(config, Executors.newCachedThreadPool(), null);
         assertFalse(rcgnmiModule.initModules());
     }
 }

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/test/resources/config.json
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/test/resources/config.json
@@ -1,4 +1,7 @@
 {
+    "modules": {
+      "moduleTimeoutSeconds": 180
+    },
     "controller":{
         "restoreDirectoryPath":"./clustered-datastore-restore-test",
         "maxDataBrokerFutureCallbackQueueSize":2000,

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/Arguments.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/Arguments.java
@@ -8,9 +8,7 @@
 
 package io.lighty.applications.rcgnmi.app;
 
-import com.beust.jcommander.IParameterValidator;
 import com.beust.jcommander.Parameter;
-import com.beust.jcommander.ParameterException;
 
 public class Arguments {
 
@@ -22,37 +20,11 @@ public class Arguments {
             + " (If absent, will look on classpath for it")
     private String loggerPath;
 
-    @Parameter(names = {"-t", "--timeout-in-seconds"}, validateWith = ModuleTimeoutValidator.class,
-               description = "Lighty modules timeout in seconds. Timeout exception is thrown when lighty module fails "
-                       + "to start within the specified time. Default value is 60. (range: 15 - Integer.MAX_VALUE)")
-    private Integer moduleTimeout = 60;
-
     public String getConfigPath() {
         return configPath;
     }
 
     public String getLoggerPath() {
         return loggerPath;
-    }
-
-    public Integer getModuleTimeout() {
-        return moduleTimeout;
-    }
-
-    public static final class ModuleTimeoutValidator implements IParameterValidator {
-        @Override
-        public void validate(final String name, final String value) throws ParameterException {
-            final int intValue;
-            try {
-                intValue = Integer.parseInt(value);
-            } catch (NumberFormatException e) {
-                throw new ParameterException("Expected number after parameter \"-t\", \"--timeout-in-seconds\". "
-                        + "Provided: " + value, e);
-            }
-            if (intValue < 15) {
-                throw new ParameterException("Provided module timeout value: [" + value
-                        + "] is not in range (15 - Integer.MAX_VALUE)");
-            }
-        }
     }
 }

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/RCgNMIApp.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/RCgNMIApp.java
@@ -81,8 +81,7 @@ public class RCgNMIApp {
                 .getControllerConfig().getSchemaServiceConfig().getModels()));
         final ExecutorService executorService = SpecialExecutors.newBoundedCachedThreadPool(10,
                 100, "gnmi_executor", Logger.class);
-        rcgnmiLightyModule = createRgnmiAppModule(rgnmiModuleConfig, executorService,
-                arguments.getModuleTimeout(), null);
+        rcgnmiLightyModule = createRgnmiAppModule(rgnmiModuleConfig, executorService, null);
 
         // Initialize RcGNMI modules
         if (rcgnmiLightyModule.initModules()) {
@@ -99,9 +98,8 @@ public class RCgNMIApp {
 
     public RcGnmiAppModule createRgnmiAppModule(final RcGnmiAppConfiguration rcGnmiAppConfiguration,
                                                 final ExecutorService gnmiExecutorService,
-                                                final Integer lightyModuleTimeout,
                                                 @Nullable final CrossSourceStatementReactor customReactor) {
-        return new RcGnmiAppModule(rcGnmiAppConfiguration, gnmiExecutorService, lightyModuleTimeout, customReactor);
+        return new RcGnmiAppModule(rcGnmiAppConfiguration, gnmiExecutorService, customReactor);
     }
 
     public void stop() {

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/resources/example-config/example_config.json
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/resources/example-config/example_config.json
@@ -1,4 +1,7 @@
 {
+    "modules": {
+      "moduleTimeoutSeconds": 180
+    },
     "controller":{
         "restoreDirectoryPath":"./clustered-datastore-restore",
         "maxDataBrokerFutureCallbackQueueSize":1000,

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/test/java/io/lighty/applications/rcgnmi/app/RCgNMIAppTest.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/test/java/io/lighty/applications/rcgnmi/app/RCgNMIAppTest.java
@@ -7,16 +7,12 @@
  */
 package io.lighty.applications.rcgnmi.app;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.beust.jcommander.ParameterException;
 import io.lighty.applications.rcgnmi.module.RcGnmiAppModule;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -29,9 +25,9 @@ public class RCgNMIAppTest {
         final RcGnmiAppModule appModule = Mockito.mock(RcGnmiAppModule.class);
         doReturn(true).when(appModule).initModules();
         doReturn(true).when(appModule).close();
-        doReturn(appModule).when(app).createRgnmiAppModule(any(), any(), eq(60), any());
+        doReturn(appModule).when(app).createRgnmiAppModule(any(), any(), any());
         app.start(new String[]{});
-        verify(app, times(1)).createRgnmiAppModule(any(), any(), eq(60), any());
+        verify(app, times(1)).createRgnmiAppModule(any(), any(), any());
     }
 
     @Test
@@ -40,22 +36,15 @@ public class RCgNMIAppTest {
         final RcGnmiAppModule appModule = Mockito.mock(RcGnmiAppModule.class);
         doReturn(true).when(appModule).initModules();
         doReturn(true).when(appModule).close();
-        doReturn(appModule).when(app).createRgnmiAppModule(any(), any(), eq(90), any());
-        app.start(new String[]{"-c", "src/main/resources/example-config/example_config.json", "-t", "90"});
-        verify(app, times(1)).createRgnmiAppModule(any(), any(), eq(90), any());
+        doReturn(appModule).when(app).createRgnmiAppModule(any(), any(), any());
+        app.start(new String[]{"-c", "src/main/resources/example-config/example_config.json"});
+        verify(app, times(1)).createRgnmiAppModule(any(), any(), any());
     }
 
     @Test
     public void testStartWithConfigFileNoSuchFile() {
         final RCgNMIApp app = Mockito.spy(new RCgNMIApp());
         app.start(new String[]{"-c", "no_config.json"});
-        verify(app, never()).createRgnmiAppModule(any(), any(), any(), any());
-    }
-
-    @Test
-    public void testStartWithWrongTimeOut() {
-        final RCgNMIApp app = spy(new RCgNMIApp());
-        assertThrows(ParameterException.class, () -> app.start(new String[]{"-t", "WRONG_TIME_OUT"}));
-        verify(app, never()).createRgnmiAppModule(any(), any(), any(), any());
+        verify(app, never()).createRgnmiAppModule(any(), any(), any());
     }
 }

--- a/lighty-applications/lighty-rnc-app-aggregator/README.md
+++ b/lighty-applications/lighty-rnc-app-aggregator/README.md
@@ -36,19 +36,16 @@ To build and start the lighty.io RNC application in the local environment, follo
    
 4. To start the application with custom lighty configuration, use arg -c and for custom initial log4j configuration use argument -l:  
    `java -jar lighty-rnc-app-<version>.jar -c /path/to/config-file -l /path/to/log4j-config-file`  
-   
-   Example configuration files are located on following path:  
-   `lighty-rnc-app-docker/example-config/*`
 
-5. (Optional) To extend lighty modules time-out use the argument `-t/--timeout-in-seconds`. This argument increases the time after which the exception is thrown if the module is not successfully initialized by then. (Default 60)
-   `java -jar lighty-rcgnmi-app-<version>.jar -t 90`
+   To extend lighty modules time-out use `"modules": { "moduleTimeoutSeconds": SECONDS },` property inside JSON configuration. This property increases the time after which the exception is thrown if the module is not successfully initialized by then (Default 60).
+   Example configuration files are located on following folder [example-config](lighty-rnc-app-docker/example-config).
 
-6. If the application was started successfully, then a log similar should be present in the console:  
+5. If the application was started successfully, then a log similar should be present in the console:  
    `INFO [main] (Main.java:80) - RNC lighty.io application started in 5989.108ms`
 
-7. Test the lighty.io RNC application. The default RESTCONF port is `8888`
+6. Test the lighty.io RNC application. The default RESTCONF port is `8888`
 
-8. The default credentials for http requests is login:`admin`, password: `admin`. 
+7. The default credentials for http requests is login:`admin`, password: `admin`. 
 To edit the user's credentials, [idmtool](https://docs.opendaylight.org/projects/aaa/en/stable-aluminium/user-guide.html#idmtool) can be used to:
     - create new `etc` directory and create there `org.ops4j.pax.web.cfg` file
     - add this two lines in the `org.ops4j.pax.web.cfg` file: 
@@ -76,7 +73,7 @@ To edit the user's credentials, [idmtool](https://docs.opendaylight.org/projects
     
     Also, it is possible to configure user's credentials via [REST](https://docs.opendaylight.org/projects/aaa/en/latest/user-guide.html#configuration-using-the-restful-web-service)
 
-9. For using a SSL connection, the correct certificate must be used.
+8. For using a SSL connection, the correct certificate must be used.
 By default, a test certificate is used (`lighty-rnc-module/src/main/resources/keystore/lightyio.jks`).
 For generating a JKS file `keytool` utility can be used. Example of command to regenerate keystore with self-signed certificate:
 

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/example-config/configuration.json
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/example-config/configuration.json
@@ -1,4 +1,7 @@
 {
+    "modules": {
+      "moduleTimeoutSeconds": 60
+    },
     "controller":{
         "restoreDirectoryPath":"./clustered-datastore-restore",
         "maxDataBrokerFutureCallbackQueueSize":1000,

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/configmaps.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/configmaps.yaml
@@ -6,6 +6,9 @@ kind: ConfigMap
 data:
   lighty-config.json: |
     {
+        "modules": {
+            "moduleTimeoutSeconds": {{ .Values.lighty.moduleTimeOut | quote }}
+        },
         "controller":{
             "restoreDirectoryPath":"./clustered-datastore-restore",
             "maxDataBrokerFutureCallbackQueueSize":1000,

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/deployment.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/deployment.yaml
@@ -22,8 +22,7 @@ spec:
           image: "{{ .Values.image.name }}:{{ .Values.image.version }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: [ "-c","{{ .Values.lighty.configDirectoryName }}/{{ .Values.lighty.configFilename }}",
-                  "-l","{{ .Values.lighty.configDirectoryName }}/{{ .Values.lighty.loggerConfigFilename }}",
-                  "-t","{{ .Values.lighty.moduleTimeOut }}"]
+                  "-l","{{ .Values.lighty.configDirectoryName }}/{{ .Values.lighty.loggerConfigFilename }}"]
           volumeMounts:
             - name: config-volume
               mountPath: {{ .Values.lighty.workdir }}/{{ .Values.lighty.configDirectoryName }}

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Arguments.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Arguments.java
@@ -7,9 +7,7 @@
  */
 package io.lighty.applications.rnc.app;
 
-import com.beust.jcommander.IParameterValidator;
 import com.beust.jcommander.Parameter;
-import com.beust.jcommander.ParameterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,11 +21,6 @@ public class Arguments {
             + " (If absent, will look on classpath for it")
     private String loggerPath;
 
-    @Parameter(names = {"-t", "--timeout-in-seconds"}, validateWith = ModuleTimeoutValidator.class,
-               description = "Lighty modules timeout in seconds. Timeout exception is thrown when lighty module fails "
-                       + "to start within the specified time. Default value is 60. (range: 15 - Integer.MAX_VALUE)")
-    private Integer moduleTimeout = 60;
-
     public String getConfigPath() {
         return configPath;
     }
@@ -36,24 +29,4 @@ public class Arguments {
         return loggerPath;
     }
 
-    public Integer getModuleTimeout() {
-        return moduleTimeout;
-    }
-
-    public static final class ModuleTimeoutValidator implements IParameterValidator {
-        @Override
-        public void validate(final String name, final String value) throws ParameterException {
-            final int intValue;
-            try {
-                intValue = Integer.parseInt(value);
-            } catch (NumberFormatException e) {
-                throw new ParameterException("Expected number after parameter \"-t\", \"--timeout-in-seconds\". "
-                        + "Provided: " + value, e);
-            }
-            if (intValue < 15) {
-                throw new ParameterException("Provided module timeout value: [" + value
-                        + "] is not in range (15 - Integer.MAX_VALUE)");
-            }
-        }
-    }
 }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Main.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Main.java
@@ -92,8 +92,7 @@ public class Main {
                 rncModuleConfig.getControllerConfig().getSchemaServiceConfig().getModels());
         LOG.info("Loaded YANG modules: {}", arrayNode);
 
-        final RncLightyModule rncLightyModule
-                = createRncLightyModule(rncModuleConfig, arguments.getModuleTimeout());
+        final RncLightyModule rncLightyModule = createRncLightyModule(rncModuleConfig);
         // Initialize RNC modules
         if (rncLightyModule.initModules()) {
             LOG.info("Registering ShutdownHook to gracefully shutdown application");
@@ -105,9 +104,8 @@ public class Main {
         }
     }
 
-    public RncLightyModule createRncLightyModule(final RncLightyModuleConfiguration rncModuleConfig,
-            final Integer lightyModuleTimeout) {
-        return new RncLightyModule(rncModuleConfig, lightyModuleTimeout);
+    public RncLightyModule createRncLightyModule(final RncLightyModuleConfiguration rncModuleConfig) {
+        return new RncLightyModule(rncModuleConfig);
     }
 
     /**

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/test/java/io/lighty/applications/rnc/app/MainTest.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/test/java/io/lighty/applications/rnc/app/MainTest.java
@@ -8,15 +8,12 @@
 package io.lighty.applications.rnc.app;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.testng.Assert.assertThrows;
 
-import com.beust.jcommander.ParameterException;
 import io.lighty.applications.rnc.module.RncLightyModule;
 import org.testng.annotations.Test;
 
@@ -28,7 +25,7 @@ public class MainTest {
         RncLightyModule lighty = mock(RncLightyModule.class);
         doReturn(true).when(lighty).initModules();
         doReturn(true).when(lighty).close();
-        doReturn(lighty).when(app).createRncLightyModule(any(), eq(60));
+        doReturn(lighty).when(app).createRncLightyModule(any());
         app.start(new String[] {});
     }
 
@@ -38,21 +35,14 @@ public class MainTest {
         RncLightyModule lighty = mock(RncLightyModule.class);
         doReturn(true).when(lighty).initModules();
         doReturn(true).when(lighty).close();
-        doReturn(lighty).when(app).createRncLightyModule(any(), eq(90));
-        app.start(new String[] {"-c","src/main/resources/configuration.json", "-t", "90"});
+        doReturn(lighty).when(app).createRncLightyModule(any());
+        app.start(new String[] {"-c","src/main/resources/configuration.json"});
     }
 
     @Test
     public void testStartWithConfigFileNoSuchFile() {
         Main app = spy(new Main());
         app.start(new String[] {"-c","no_config.json"});
-        verify(app, never()).createRncLightyModule(any(), any());
-    }
-
-    @Test
-    public void testStartWithWrongTimeOut() {
-        final Main app = spy(new Main());
-        assertThrows(ParameterException.class, () -> app.start(new String[] {"-t", "WRONG_TIME_OUT"}));
-        verify(app, never()).createRncLightyModule(any(), any());
+        verify(app, never()).createRncLightyModule(any());
     }
 }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/pom.xml
@@ -40,7 +40,11 @@
         <dependency>
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-swagger</artifactId>
-        </dependency>        
+        </dependency>
+        <dependency>
+            <groupId>io.lighty.applications</groupId>
+            <artifactId>lighty-app-modules-config</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.lighty.resources</groupId>

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/RncLightyModule.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/RncLightyModule.java
@@ -47,7 +47,7 @@ public class RncLightyModule {
 
     private final RncLightyModuleConfiguration rncModuleConfig;
 
-    private final int lightyModuleTimeout;
+    private final long lightyModuleTimeout;
     private LightyController lightyController;
     private CommunityRestConf lightyRestconf;
     private NetconfSBPlugin lightyNetconf;
@@ -55,10 +55,10 @@ public class RncLightyModule {
     private LightyServerBuilder jettyServerBuilder;
     private SwaggerLighty swagger;
 
-    public RncLightyModule(final RncLightyModuleConfiguration rncModuleConfig, final int lightyModuleTimeout) {
+    public RncLightyModule(final RncLightyModuleConfiguration rncModuleConfig) {
         LOG.info("Creating instance of RNC lighty.io module...");
         this.rncModuleConfig = rncModuleConfig;
-        this.lightyModuleTimeout = lightyModuleTimeout;
+        this.lightyModuleTimeout = rncModuleConfig.getModuleConfig().getModuleTimeoutSeconds();
         LOG.info("Instance of RNC lighty.io module created!");
     }
 

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/RncLightyModuleConfigUtils.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/RncLightyModuleConfigUtils.java
@@ -10,6 +10,7 @@ package io.lighty.applications.rnc.module.config;
 import com.typesafe.config.Config;
 import io.lighty.aaa.config.AAAConfiguration;
 import io.lighty.aaa.util.AAAConfigUtils;
+import io.lighty.applications.util.ModulesConfig;
 import io.lighty.core.controller.impl.config.ConfigurationException;
 import io.lighty.core.controller.impl.config.ControllerConfiguration;
 import io.lighty.core.controller.impl.util.ControllerConfigUtils;
@@ -43,6 +44,7 @@ public final class RncLightyModuleConfigUtils {
         final RestConfConfiguration restconfConfig;
         final NetconfConfiguration netconfConfig;
         final AAAConfiguration aaaConfig;
+        final ModulesConfig moduleConfig;
         try {
             LOG.debug("Loading lighty.io controller module configuration from file...");
             controllerConfig = ControllerConfigUtils.getConfiguration(Files.newInputStream(configPath));
@@ -66,11 +68,14 @@ public final class RncLightyModuleConfigUtils {
             LOG.debug("Loading lighty.io AAA module configuration from file...");
             aaaConfig = AAAConfigUtils.getAAAConfiguration(Files.newInputStream(configPath));
             LOG.debug("lighty.io AAA module configuration from file loaded!");
+            LOG.debug("Loading lighty.io app module configuration from file...");
+            moduleConfig = ModulesConfig.getModulesConfig(Files.newInputStream(configPath));
+            LOG.debug("lighty.io app module configuration from file loaded!");
         } catch (IOException e) {
             throw new ConfigurationException("Exception thrown while loading configuration!", e);
         }
         return new RncLightyModuleConfiguration(controllerConfig, lightyServerConfig, restconfConfig, netconfConfig,
-                aaaConfig);
+                aaaConfig, moduleConfig);
     }
 
     public static RncLightyModuleConfiguration loadDefaultConfig() throws ConfigurationException {
@@ -99,8 +104,11 @@ public final class RncLightyModuleConfigUtils {
         final AAAConfiguration aaaConfig = AAAConfigUtils.createDefaultAAAConfiguration();
         LOG.debug("Default lighty.io AAA module configuration loaded!");
 
+        LOG.debug("Loading default lighty.io app module configuration...");
+        final ModulesConfig modulesConfig = ModulesConfig.getDefaultModulesConfig();
+        LOG.debug("Default lighty.io app module configuration loaded!");
         return new RncLightyModuleConfiguration(controllerConfig, lightyServerConfig, restConfConfiguration,
-                netconfConfig, aaaConfig);
+                netconfConfig, aaaConfig, modulesConfig);
     }
 
     private static void addDefaultAppModels(final ControllerConfiguration controllerConfig) {

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/RncLightyModuleConfiguration.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/RncLightyModuleConfiguration.java
@@ -8,6 +8,7 @@
 package io.lighty.applications.rnc.module.config;
 
 import io.lighty.aaa.config.AAAConfiguration;
+import io.lighty.applications.util.ModulesConfig;
 import io.lighty.core.controller.impl.config.ControllerConfiguration;
 import io.lighty.modules.northbound.restconf.community.impl.config.RestConfConfiguration;
 import io.lighty.modules.southbound.netconf.impl.config.NetconfConfiguration;
@@ -19,17 +20,20 @@ public class RncLightyModuleConfiguration {
     private final RestConfConfiguration restConfConfiguration;
     private final NetconfConfiguration netconfConfig;
     private final AAAConfiguration aaaConfig;
+    private final ModulesConfig moduleConfig;
 
     public RncLightyModuleConfiguration(final ControllerConfiguration controllerConfig,
                                         final LightyServerConfig serverConfig,
                                         final RestConfConfiguration restConfConfiguration,
                                         final NetconfConfiguration netconfConfig,
-                                        final AAAConfiguration aaaConfig) {
+                                        final AAAConfiguration aaaConfig,
+                                        final ModulesConfig moduleConfig) {
         this.controllerConfig = controllerConfig;
         this.serverConfig = serverConfig;
         this.restConfConfiguration = restConfConfiguration;
         this.netconfConfig = netconfConfig;
         this.aaaConfig = aaaConfig;
+        this.moduleConfig = moduleConfig;
     }
 
     public ControllerConfiguration getControllerConfig() {
@@ -50,5 +54,9 @@ public class RncLightyModuleConfiguration {
 
     public AAAConfiguration getAaaConfig() {
         return aaaConfig;
+    }
+
+    public ModulesConfig getModuleConfig() {
+        return moduleConfig;
     }
 }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/java/io/lighty/applications/rnc/module/RncLightyModuleSmokeTest.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/java/io/lighty/applications/rnc/module/RncLightyModuleSmokeTest.java
@@ -33,14 +33,13 @@ import org.testng.annotations.Test;
 
 public class RncLightyModuleSmokeTest {
 
-    private static final int MODULE_TIMEOUT = 60;
     private static final String HTTPS_URI = "https://127.0.0.1:8888";
     private static final String HTTP_URI = "http://127.0.0.1:8888";
     private static final String TOPOLOGY_PATH = "/restconf/data/network-topology:network-topology";
 
     @Test
     public void rncLightyModuleDefaultConfigTest() throws Exception {
-        final var rncModule = new RncLightyModule(RncLightyModuleConfigUtils.loadDefaultConfig(), MODULE_TIMEOUT);
+        final var rncModule = new RncLightyModule(RncLightyModuleConfigUtils.loadDefaultConfig());
         assertTrue(rncModule.initModules());
         final var httpResponse = HttpClient.newHttpClient()
                 .send(createGetRequest(HTTP_URI + TOPOLOGY_PATH), BodyHandlers.ofString());
@@ -52,7 +51,7 @@ public class RncLightyModuleSmokeTest {
     public void rncLightyModuleHttpsTest() throws Exception {
         final var resource = RncLightyModuleSmokeTest.class.getResource("/httpsConfig.json");
         final var rncConfig = RncLightyModuleConfigUtils.loadConfigFromFile(Paths.get(resource.getPath()));
-        final var rncModule = new RncLightyModule(rncConfig, MODULE_TIMEOUT);
+        final var rncModule = new RncLightyModule(rncConfig);
         assertTrue(rncModule.initModules());
         final var sslClient = getHttpClientWithSsl();
         final var httpResponse = sslClient.send(createGetRequest(HTTPS_URI + TOPOLOGY_PATH), BodyHandlers.ofString());
@@ -64,7 +63,7 @@ public class RncLightyModuleSmokeTest {
     public void rncLightyModuleHttp2Test() throws Exception {
         final var resource = RncLightyModuleSmokeTest.class.getResource("/http2Config.json");
         final var rncConfig = RncLightyModuleConfigUtils.loadConfigFromFile(Paths.get(resource.getPath()));
-        final var rncModule = new RncLightyModule(rncConfig, MODULE_TIMEOUT);
+        final var rncModule = new RncLightyModule(rncConfig);
         assertTrue(rncModule.initModules());
         final var sslClient = getHttpClientWithSsl();
         final var httpResponse = sslClient.send(createGetRequest(HTTPS_URI + TOPOLOGY_PATH), BodyHandlers.ofString());
@@ -76,7 +75,7 @@ public class RncLightyModuleSmokeTest {
     public void rncLightyModuleStartFailed() throws ConfigurationException {
         final var config = spy(RncLightyModuleConfigUtils.loadDefaultConfig());
         when(config.getControllerConfig()).thenReturn(null);
-        final var rncModule = new RncLightyModule(config, MODULE_TIMEOUT);
+        final var rncModule = new RncLightyModule(config);
         final var isStarted = rncModule.initModules();
         final var isClose = rncModule.close();
 

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/java/io/lighty/applications/rnc/module/config/RncLightyModuleConfigUtilsTest.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/java/io/lighty/applications/rnc/module/config/RncLightyModuleConfigUtilsTest.java
@@ -11,6 +11,7 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 
+import io.lighty.applications.util.ModulesConfig;
 import io.lighty.core.controller.impl.config.ConfigurationException;
 import io.lighty.core.controller.impl.config.ControllerConfiguration;
 import io.lighty.core.controller.impl.util.DatastoreConfigurationUtils;
@@ -66,6 +67,9 @@ public class RncLightyModuleConfigUtilsTest {
         assertEquals(netconfConfig.getTopologyId(), "topology-netconf-test");
         assertEquals(netconfConfig.getWriteTxTimeout(), 0);
         assertFalse(netconfConfig.isClusterEnabled());
+
+        final ModulesConfig moduleConfig = rncConfig.getModuleConfig();
+        assertEquals(moduleConfig.getModuleTimeoutSeconds(), 180);
     }
 
     @Test
@@ -112,5 +116,8 @@ public class RncLightyModuleConfigUtilsTest {
         assertEquals(netconfConfig.getTopologyId(), "topology-netconf");
         assertEquals(netconfConfig.getWriteTxTimeout(), 0);
         assertFalse(netconfConfig.isClusterEnabled());
+
+        final ModulesConfig moduleConfig = rncConfig.getModuleConfig();
+        assertEquals(moduleConfig.getModuleTimeoutSeconds(), 60);
     }
 }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/config.json
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/config.json
@@ -1,4 +1,7 @@
 {
+    "modules": {
+      "moduleTimeoutSeconds": 180
+    },
     "controller":{
         "restoreDirectoryPath":"./clustered-datastore-restore-test",
         "maxDataBrokerFutureCallbackQueueSize":2000,

--- a/lighty-applications/pom.xml
+++ b/lighty-applications/pom.xml
@@ -22,5 +22,6 @@
     <modules>
         <module>lighty-rnc-app-aggregator</module>
         <module>lighty-rcgnmi-app-aggregator</module>
+        <module>lighty-app-modules-config</module>
     </modules>
 </project>

--- a/lighty-core/lighty-bom/pom.xml
+++ b/lighty-core/lighty-bom/pom.xml
@@ -178,6 +178,11 @@
                 <artifactId>lighty-rnc-module</artifactId>
                 <version>17.0.0-SNAPSHOT</version>
             </dependency>
+            <dependency>
+                <groupId>io.lighty.applications</groupId>
+                <artifactId>lighty-app-modules-config</artifactId>
+                <version>17.0.0-SNAPSHOT</version>
+            </dependency>
 
             <!-- lighty examples -->
             <dependency>

--- a/lighty-examples/lighty-bgp-community-restconf-app/pom.xml
+++ b/lighty-examples/lighty-bgp-community-restconf-app/pom.xml
@@ -43,6 +43,10 @@
             <artifactId>lighty-bgp</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.lighty.applications</groupId>
+            <artifactId>lighty-app-modules-config</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>

--- a/lighty-examples/lighty-bgp-community-restconf-app/src/main/resources/lightyConfiguration.json
+++ b/lighty-examples/lighty-bgp-community-restconf-app/src/main/resources/lightyConfiguration.json
@@ -1,4 +1,7 @@
 {
+    "modules": {
+      "moduleTimeoutSeconds":60
+    },
     "controller":{
         "restoreDirectoryPath":"./clustered-datastore-restore",
         "maxDataBrokerFutureCallbackQueueSize":1000,

--- a/lighty-examples/lighty-community-aaa-restconf-app/pom.xml
+++ b/lighty-examples/lighty-community-aaa-restconf-app/pom.xml
@@ -38,6 +38,10 @@
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-restconf-nb-community</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.lighty.applications</groupId>
+            <artifactId>lighty-app-modules-config</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/lighty-examples/lighty-community-aaa-restconf-app/src/main/assembly/resources/sampleConfigSingleNode.json
+++ b/lighty-examples/lighty-community-aaa-restconf-app/src/main/assembly/resources/sampleConfigSingleNode.json
@@ -1,4 +1,7 @@
 {
+    "modules": {
+        "moduleTimeoutSeconds":60
+    },
     "controller":{
         "restoreDirectoryPath":"./clustered-datastore-restore",
         "maxDataBrokerFutureCallbackQueueSize":1000,

--- a/lighty-examples/lighty-community-restconf-actions-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-actions-app/pom.xml
@@ -40,6 +40,10 @@
             <artifactId>lighty-swagger</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.lighty.applications</groupId>
+            <artifactId>lighty-app-modules-config</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>

--- a/lighty-examples/lighty-community-restconf-actions-app/src/main/assembly/resources/sampleConfigSingleNode.json
+++ b/lighty-examples/lighty-community-restconf-actions-app/src/main/assembly/resources/sampleConfigSingleNode.json
@@ -1,4 +1,7 @@
 {
+    "modules": {
+        "moduleTimeoutSeconds":60
+    },
     "controller":{
         "restoreDirectoryPath":"./clustered-datastore-restore",
         "maxDataBrokerFutureCallbackQueueSize":1000,

--- a/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>lighty-swagger</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.lighty.applications</groupId>
+            <artifactId>lighty-app-modules-config</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>

--- a/lighty-examples/lighty-community-restconf-netconf-app/src/main/assembly/resources/sampleConfigSingleNode.json
+++ b/lighty-examples/lighty-community-restconf-netconf-app/src/main/assembly/resources/sampleConfigSingleNode.json
@@ -1,4 +1,7 @@
 {
+    "modules": {
+        "moduleTimeoutSeconds":60
+    },
     "controller":{
         "restoreDirectoryPath":"./clustered-datastore-restore",
         "maxDataBrokerFutureCallbackQueueSize":1000,

--- a/lighty-tests-report/pom.xml
+++ b/lighty-tests-report/pom.xml
@@ -43,6 +43,10 @@
             <groupId>io.lighty.applications.rcgnmi</groupId>
             <artifactId>lighty-rcgnmi-app-module</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.lighty.applications</groupId>
+            <artifactId>lighty-app-modules-config</artifactId>
+        </dependency>
 
         <!-- Core -->
         <dependency>


### PR DESCRIPTION
This package serve to handle time-out of starting and shutting down lighty modules. This is a replacement for RNC/RcGNMI app argument `-t/--timeout-in-seconds`. Now module time-out will be set up in JSON configuration.

ID: 1279