### PR TITLE
Prepare separate RNC/RCgNMI deploy actions

### DIFF
--- a/.github/workflows/publish-action/action.yml
+++ b/.github/workflows/publish-action/action.yml
@@ -1,0 +1,80 @@
+name: Publish docker image and prepare helm charts
+description: 'Publish docker image and prepare helm charts'
+inputs:
+  app-modules:
+    description: Name of the modules with format ':{module-name},...' required to build docker image, e.g. ":lighty-rnc-app,:lighty-rnc-app-docker,:lighty-rnc-module"
+    required: true
+  app-docker-pom-path:
+    description: Path to docker pom.xml file from repository root, e.g. "lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml"
+    required: true
+  app-helm-values-path:
+    description: Path to Helm YAML values from repository root, e.g. "lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/values.yaml"
+    required: true
+  image-name:
+    description: Desired NAME of docker image, e.g. "lighty-rnc"
+    required: true
+  version:
+    description: Desired version of published docker image & helm charts, e.g. "14.0.0"
+    required: true
+  image-tag-latest:
+    description: Should be this docker labeled with tag latest? Enter `true` if the tag `latest` should be added for image.
+    default: "false"
+    required: true
+  publish-access-key:
+    description: The branch, tag or SHA to checkout. (if "default" the selected branch will be used)
+    default: default
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Env docker image name
+      shell: bash
+      run: |
+        DOCKER_IMAGE_NAME=$(echo ghcr.io/pantheontech/${{ inputs.image-name }})
+        DOCKER_IMAGE_NAME_TAG=$(echo $DOCKER_IMAGE_NAME:${{ inputs.version }})
+        echo "DOCKER_IMAGE_NAME=$(echo $DOCKER_IMAGE_NAME)" >> $GITHUB_ENV
+        echo "DOCKER_IMAGE_NAME_TAG=$(echo $DOCKER_IMAGE_NAME_TAG)" >> $GITHUB_ENV
+    - name: Build docker image
+      shell: bash
+      run: mvn install -B -pl ${{ inputs.app-modules }} -P docker
+    - name: Tag image
+      shell: bash
+      run: |
+        image_name=$(mvn help:evaluate -f ${{ inputs.app-docker-pom-path }} -Dexpression=image.name -q -DforceStdout)
+        docker tag $image_name $DOCKER_IMAGE_NAME_TAG
+        if [ "${{ inputs.image-tag-latest }}" = 'true' ]; then
+          docker tag $image_name $DOCKER_IMAGE_NAME:latest
+        fi
+        docker images | grep $image_name
+    - name: List docker images
+      shell: bash
+      run: |
+        docker images
+    - name: Docker log in (ghcr.io)
+      shell: bash
+      run: |
+        echo ${{ inputs.publish-access-key}} | docker login  --username ${{ github.actor }} --password-stdin ghcr.io
+    - name: Publish docker image (ghcr.io)
+      shell: bash
+      run: |
+        docker push $DOCKER_IMAGE_NAME_TAG
+        if [ "${{ inputs.image-tag-latest }}" = 'true' ]; then
+          docker push $DOCKER_IMAGE_NAME:latest
+        fi
+    - name: Check if docker image is pullable  (ghcr.io)
+      shell: bash
+      run: |
+        docker rmi $DOCKER_IMAGE_NAME_TAG
+        docker pull $DOCKER_IMAGE_NAME_TAG
+    - name: Install yq (yaml processor)
+      shell: bash
+      run: |
+        sudo snap install yq
+    - name: Set image.name, image.version in values.yaml of helm chart
+      shell: bash
+      run: |
+        yq eval '.image.name="ghcr.io/pantheontech/${{ inputs.image-name }}" | .image.version="${{ inputs.version }}"' ${{ inputs.app-helm-values-path }} -i
+    - name: Print values.yaml
+      shell: bash
+      run: |
+        cat -A ${{ inputs.app-helm-values-path }}

--- a/.github/workflows/publish-rcgnmi.yml
+++ b/.github/workflows/publish-rcgnmi.yml
@@ -1,0 +1,69 @@
+name: Publish RCgNMI docker image and helm charts
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Desired version of published docker image & helm charts, e.g. "XX.YY.ZZ"
+        required: true
+      checkout-ref:
+        description: The branch, tag or SHA to checkout. (if "default" the selected branch will be used)
+        default: default
+        required: true
+      image-tag-latest:
+        description: Should be this docker labeled with tag latest? Enter `true` if the tag `latest` should be added for image.
+        default: "false"
+        required: true
+
+jobs:
+  publish-docker-helm:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      APP-MODULES: ":lighty-rcgnmi-app,:lighty-rcgnmi-app-docker,:lighty-rcgnmi-app-module"
+      APP-DOCKER-POM-PATH: "lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/pom.xml"
+      APP-HELM-FOLDER-PATH: "lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/"
+      APP-HELM-VALUES-PATH: "lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/values.yaml"
+      IMAGE-NAME: "lighty-rcgnmi"
+      PUBLISH_ACCESS_KEY: ${{ secrets.MM_PKG_WRITE }}
+    name: "Publish RCgNMI docker image and helm charts. Checkout-ref: ${{ github.event.inputs.checkout-ref }}"
+    steps:
+      - name: Clone Repository
+        if: ${{ github.event.inputs.checkout-ref == 'default' }}
+        uses: actions/checkout@v2
+      - name: "Clone Repository, Ref: ${{ github.event.inputs.checkout-ref }}"
+        if: ${{ github.event.inputs.checkout-ref != 'default' }}
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.checkout-ref }}
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: "Publish RcGNMI docker and prepare helm-charts"
+        uses: ./.github/workflows/publish-action
+        with:
+          app-modules: ${{ env.APP-MODULES }}
+          app-docker-pom-path: ${{ env.APP-DOCKER-POM-PATH }}
+          app-helm-values-path: ${{ env.APP-HELM-VALUES-PATH }}
+          image-name: ${{ env.IMAGE-NAME }}
+          version: ${{ github.event.inputs.version }}
+          image-tag-latest: ${{ github.event.inputs.image-tag-latest }}
+          publish-access-key: ${{ env.PUBLISH_ACCESS_KEY }}
+      - name: "Publish RCgNMI Helm chart to Helm repository (Version: ${{ github.event.inputs.version }} )"
+        if: ${{ github.event.inputs.version != '' }}
+        uses: stefanprodan/helm-gh-pages@master
+        with:
+          token: ${{ env.PUBLISH_ACCESS_KEY }}
+          charts_dir: ${{ env.APP-HELM-FOLDER-PATH }}
+          charts_url: https://pantheontech.github.io/helm-charts/
+          repository: helm-charts
+          branch: main
+          chart_version: ${{ github.event.inputs.version }}

--- a/.github/workflows/publish-rnc.yml
+++ b/.github/workflows/publish-rnc.yml
@@ -1,0 +1,69 @@
+name: Publish RNC docker image and helm charts
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Desired version of published docker image & helm charts, e.g. "XX.YY.ZZ"
+        required: true
+      checkout-ref:
+        description: The branch, tag or SHA to checkout. (if "default" the selected branch will be used)
+        default: default
+        required: true
+      image-tag-latest:
+        description: Should be this docker labeled with tag latest? Enter `true` if the tag `latest` should be added for image.
+        default: "false"
+        required: true
+
+jobs:
+  publish-docker-helm:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      APP-MODULES: ":lighty-rnc-app,:lighty-rnc-app-docker,:lighty-rnc-module"
+      APP-DOCKER-POM-PATH: "lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml"
+      APP-HELM-FOLDER-PATH: "lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/"
+      APP-HELM-VALUES-PATH: "lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/values.yaml"
+      IMAGE-NAME: "lighty-rnc"
+      PUBLISH_ACCESS_KEY: ${{ secrets.MM_PKG_WRITE }}
+    name: "Publish RNC docker image and helm charts. Checkout-ref: ${{ github.event.inputs.checkout-ref }}"
+    steps:
+      - name: Clone Repository
+        if: ${{ github.event.inputs.checkout-ref == 'default' }}
+        uses: actions/checkout@v2
+      - name: "Clone Repository, Ref: ${{ github.event.inputs.checkout-ref }}"
+        if: ${{ github.event.inputs.checkout-ref != 'default' }}
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.checkout-ref }}
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: "Publish RNC docker and prepare helm-charts"
+        uses: ./.github/workflows/publish-action
+        with:
+          app-modules: ${{ env.APP-MODULES }}
+          app-docker-pom-path: ${{ env.APP-DOCKER-POM-PATH }}
+          app-helm-values-path: ${{ env.APP-HELM-VALUES-PATH }}
+          image-name: ${{ env.IMAGE-NAME }}
+          version: ${{ github.event.inputs.version }}
+          image-tag-latest: ${{ github.event.inputs.image-tag-latest }}
+          publish-access-key: ${{ env.PUBLISH_ACCESS_KEY }}
+      - name: "Publish RNC Helm chart to Helm repository (Version: ${{ github.event.inputs.version }} )"
+        if: ${{ github.event.inputs.version != '' }}
+        uses: stefanprodan/helm-gh-pages@master
+        with:
+          token: ${{ env.PUBLISH_ACCESS_KEY }}
+          charts_dir: ${{ env.APP-HELM-FOLDER-PATH }}
+          charts_url: https://pantheontech.github.io/helm-charts/
+          repository: helm-charts
+          branch: main
+          chart_version: ${{ github.event.inputs.version }}


### PR DESCRIPTION
Create separate RNC/RCgNMI apps workflow to deploy docker and
helm charts with providing only changeable variables in deploy.

Leave old generic deploy unchanged if anything goes wrongs in next
deploy. Then it should be removed.