### PR TITLE
Fixed leaf-list manipulation and list deleting

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-commons/src/main/java/io/lighty/modules/gnmi/commons/util/DataConverter.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-commons/src/main/java/io/lighty/modules/gnmi/commons/util/DataConverter.java
@@ -59,7 +59,11 @@ public final class DataConverter {
     public static String jsonStringFromNormalizedNodes(@NonNull final YangInstanceIdentifier identifier,
                                                        @NonNull final NormalizedNode data,
                                                        @NonNull final EffectiveModelContext context) {
-        return toJson(toSchemaPath(identifier), data, context);
+        if (identifier.getLastPathArgument() instanceof YangInstanceIdentifier.NodeWithValue) {
+            return toJson(toSchemaPath(identifier.getParent()), data, context);
+        } else {
+            return toJson(toSchemaPath(identifier), data, context);
+        }
     }
 
     public static NormalizedNode nodeFromJsonString(@NonNull final YangInstanceIdentifier yangInstanceIdentifier,

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/mountpoint/broker/GnmiDataBrokerFactoryImpl.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/mountpoint/broker/GnmiDataBrokerFactoryImpl.java
@@ -34,7 +34,8 @@ public class GnmiDataBrokerFactoryImpl implements GnmiDataBrokerFactory {
 
         final GnmiSet setOperation = new GnmiSet(deviceConnection,
                 new GnmiSetRequestFactoryImpl(yiiToPathCodec,
-                        new YangInstanceNormToGnmiUpdateCodec(deviceConnection, yiiToPathCodec, gson)),
+                        new YangInstanceNormToGnmiUpdateCodec(deviceConnection, yiiToPathCodec, gson,
+                                prefixFirstElement)),
                 deviceConnection.getIdentifier());
 
         return new GnmiDataBroker(getOperation, setOperation);

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/java/io/lighty/gnmi/southbound/mountpoint/codecs/YangInstanceNormToGnmiUpdateCodecTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/java/io/lighty/gnmi/southbound/mountpoint/codecs/YangInstanceNormToGnmiUpdateCodecTest.java
@@ -37,7 +37,7 @@ public class YangInstanceNormToGnmiUpdateCodecTest {
         codec = new YangInstanceNormToGnmiUpdateCodec(
                 testCases.getSchemaContextProvider(),
                 new YangInstanceIdentifierToPathCodec(testCases.getSchemaContextProvider(),
-                        false), new Gson());
+                        false), new Gson(), false);
     }
 
     @Test

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/java/io/lighty/gnmi/southbound/mountpoint/codecs/testcases/YangInstanceIdentifiertoPathTestCases.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/java/io/lighty/gnmi/southbound/mountpoint/codecs/testcases/YangInstanceIdentifiertoPathTestCases.java
@@ -85,11 +85,15 @@ public class YangInstanceIdentifiertoPathTestCases extends CodecTestCasesBase {
                         .setName("interface")
                         .putKey("name", "br0"))
                 .addElem(Gnmi.PathElem.newBuilder()
-                        .setName("ethernet"))
+                        .setName(addPrefixToTopElement
+                                ? makePrefixString(OC_IF_ETHERNET_ID, "ethernet")
+                                : "ethernet"))
                 .addElem(Gnmi.PathElem.newBuilder()
                         .setName("config"))
                 .addElem(Gnmi.PathElem.newBuilder()
-                        .setName("aggregate-id"))
+                        .setName(addPrefixToTopElement
+                                ? makePrefixString(OC_IF_AGGREGATE_ID, "aggregate-id")
+                                : "aggregate-id"))
                 .build();
         return Maps.immutableEntry(super.leafAgumentedCase().left, path);
     }

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/java/io/lighty/gnmi/southbound/mountpoint/transactions/WriteTransactionTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/java/io/lighty/gnmi/southbound/mountpoint/transactions/WriteTransactionTest.java
@@ -126,7 +126,7 @@ public class WriteTransactionTest {
                 = new YangInstanceIdentifierToPathCodec(deviceConnection, true);
         final GnmiSet gnmiSet = new GnmiSet(deviceConnection,
                 new GnmiSetRequestFactoryImpl(yiiToPathCodec, new YangInstanceNormToGnmiUpdateCodec(deviceConnection,
-                        yiiToPathCodec, new Gson())),
+                        yiiToPathCodec, new Gson(), false)),
                 deviceConnection.getIdentifier());
         this.gnmiDataBroker = new GnmiDataBroker(Mockito.mock(GnmiGet.class), gnmiSet);
     }


### PR DESCRIPTION
When updating a data resource, there is a need to know if the device is 3.1.2, therefore an additional boolean in the constructor was needed. For deleting lists, namespaces needed to be added to every element, whose parent has a different namespace from its child. As for leaf-list manipulation, support for them needed to be added in the **YangInstanceNormToGnmiUpdateCodec** class. Tests were adjusted as well to not fail with these new changes.