### PR TITLE
Provide module shards Config to Controller instead of tmp file

### DIFF
--- a/lighty-core/lighty-clustering/pom.xml
+++ b/lighty-core/lighty-clustering/pom.xml
@@ -38,6 +38,10 @@
         </dependency>
         <dependency>
             <groupId>org.opendaylight.controller</groupId>
+            <artifactId>sal-distributed-datastore</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opendaylight.controller</groupId>
             <artifactId>eos-dom-akka</artifactId>
         </dependency>
         <dependency>

--- a/lighty-core/lighty-clustering/src/main/java/io/lighty/core/cluster/ClusteringHandler.java
+++ b/lighty-core/lighty-clustering/src/main/java/io/lighty/core/cluster/ClusteringHandler.java
@@ -7,6 +7,7 @@
  */
 package io.lighty.core.cluster;
 
+import com.typesafe.config.Config;
 import java.util.Optional;
 import org.eclipse.jdt.annotation.NonNull;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.controller.md.sal.cluster.admin.rev151013.ClusterAdminService;
@@ -17,5 +18,5 @@ public interface ClusteringHandler {
 
     void start(@NonNull ClusterAdminService clusterAdminRPCService);
 
-    Optional<String> getModuleConfig();
+    Optional<Config> getModuleShardsConfig();
 }

--- a/lighty-core/lighty-clustering/src/main/java/io/lighty/core/cluster/config/ClusteringConfigUtils.java
+++ b/lighty-core/lighty-clustering/src/main/java/io/lighty/core/cluster/config/ClusteringConfigUtils.java
@@ -12,7 +12,6 @@ import java.util.List;
 
 public final class ClusteringConfigUtils {
 
-    public static final String MODULE_SHARDS_TMP_PATH = "/tmp/module-shards.conf";
     public static final String AKKA_DISCOVERY_METHOD_PATH = "akka.discovery.method";
     public static final String K8S_DISCOVERY_API_NAME = "kubernetes-api";
 

--- a/lighty-core/lighty-clustering/src/main/java/io/lighty/core/cluster/config/ClusteringConfigUtils.java
+++ b/lighty-core/lighty-clustering/src/main/java/io/lighty/core/cluster/config/ClusteringConfigUtils.java
@@ -25,7 +25,7 @@ public final class ClusteringConfigUtils {
      * @param memberRoles - roles (members) to which the module shards should be replicated to
      * @return generated content
      */
-    public static String generateModuleShardsForMembers(List<String> memberRoles) {
+    public static String generateModuleShardsForMembers(final List<String> memberRoles) {
         return String.format("module-shards = [%n%s]", String.join(",\n",
                 new String[]{generateShard("default", memberRoles),
                         generateShard("topology", memberRoles),
@@ -33,12 +33,12 @@ public final class ClusteringConfigUtils {
                 }));
     }
 
-    public static boolean isKubernetesDeployment(Config actorSystemConfig) {
+    public static boolean isKubernetesDeployment(final Config actorSystemConfig) {
         return actorSystemConfig.hasPath(AKKA_DISCOVERY_METHOD_PATH)
                 && actorSystemConfig.getString(AKKA_DISCOVERY_METHOD_PATH).equalsIgnoreCase(K8S_DISCOVERY_API_NAME);
     }
 
-    private static String generateShard(String name, List<String> replicas) {
+    private static String generateShard(final String name, final List<String> replicas) {
         return "    {"
                 + "        name = \"" + name + "\"\n"
                 + "        shards = [\n"

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
@@ -60,7 +60,9 @@ import org.opendaylight.controller.cluster.datastore.DefaultDatastoreSnapshotRes
 import org.opendaylight.controller.cluster.datastore.DistributedDataStoreFactory;
 import org.opendaylight.controller.cluster.datastore.DistributedDataStoreInterface;
 import org.opendaylight.controller.cluster.datastore.admin.ClusterAdminRpcService;
+import org.opendaylight.controller.cluster.datastore.config.Configuration;
 import org.opendaylight.controller.cluster.datastore.config.ConfigurationImpl;
+import org.opendaylight.controller.cluster.datastore.config.HybridModuleShardConfigProvider;
 import org.opendaylight.controller.config.threadpool.ScheduledThreadPool;
 import org.opendaylight.controller.config.threadpool.ThreadPool;
 import org.opendaylight.controller.config.threadpool.util.FixedThreadPoolWrapper;
@@ -152,7 +154,7 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
     private final int mailboxCapacity;
     private final boolean metricCaptureEnabled;
 
-    private String moduleShardsConfig;
+    private Configuration clusterConfiguration;
     private ActorSystemProviderImpl actorSystemProvider;
     private DatastoreSnapshotRestore datastoreSnapshotRestore;
     private AbstractDataStore configDatastore;
@@ -221,7 +223,7 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
         this.mailboxCapacity = mailboxCapacity;
         this.distributedEosProperties = distributedEosProperties;
         this.modulesConfig = modulesConfig;
-        this.moduleShardsConfig = moduleShardsConfig;
+        this.clusterConfiguration = new ConfigurationImpl(moduleShardsConfig, modulesConfig);
         this.configDatastoreContext = configDatastoreContext;
         this.operDatastoreContext = operDatastoreContext;
         this.datastoreProperties = datastoreProperties;
@@ -254,8 +256,10 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
                 this.actorSystemConfig);
         this.clusteringHandler.ifPresent(handler -> {
             handler.initClustering();
-            if (handler.getModuleConfig().isPresent()) {
-                this.moduleShardsConfig = handler.getModuleConfig().get();
+            if (handler.getModuleShardsConfig().isPresent()) {
+                final HybridModuleShardConfigProvider shardConfigProvider = new HybridModuleShardConfigProvider(
+                        handler.getModuleShardsConfig().get(), this.modulesConfig);
+                this.clusterConfiguration = new ConfigurationImpl(shardConfigProvider);
             }
         });
 
@@ -285,11 +289,10 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
         this.codec = new ConstantAdapterContext(bindingCodecContext);
 
         // CONFIG DATASTORE
-        this.configDatastore = prepareDataStore(this.configDatastoreContext, this.moduleShardsConfig,
-                this.modulesConfig, this.schemaService, this.datastoreSnapshotRestore,
-                this.actorSystemProvider);
+        this.configDatastore = prepareDataStore(this.configDatastoreContext, this.clusterConfiguration,
+                this.schemaService, this.datastoreSnapshotRestore, this.actorSystemProvider);
         // OPERATIONAL DATASTORE
-        this.operDatastore = prepareDataStore(this.operDatastoreContext, this.moduleShardsConfig, this.modulesConfig,
+        this.operDatastore = prepareDataStore(this.operDatastoreContext, this.clusterConfiguration,
                 this.schemaService, this.datastoreSnapshotRestore, this.actorSystemProvider);
 
         createConcurrentDOMDataBroker();
@@ -368,10 +371,9 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
     }
 
     private AbstractDataStore prepareDataStore(final DatastoreContext datastoreContext,
-            final String newModuleShardsConfig, final String newModulesConfig, final DOMSchemaService domSchemaService,
+            final Configuration configuration, final DOMSchemaService domSchemaService,
             final DatastoreSnapshotRestore newDatastoreSnapshotRestore,
             final ActorSystemProvider newActorSystemProvider) {
-        final ConfigurationImpl configuration = new ConfigurationImpl(newModuleShardsConfig, newModulesConfig);
         final DefaultDatastoreContextIntrospectorFactory introspectorFactory
                 = new DefaultDatastoreContextIntrospectorFactory(this.codec.currentSerializer());
         final DatastoreContextIntrospector introspector = introspectorFactory


### PR DESCRIPTION
Provide custom moduleShardsConfig in controller instead of storing
moduleShardsConfig in tmp file: "/tmp/module-shards.conf".
This file was later read in initializing class ConfigurationImpl.