### PR TITLE
Remove log4j2 version overrides

### DIFF
--- a/lighty-examples/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/lighty-controller-springboot-netconf/pom.xml
@@ -43,27 +43,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- TODO: Remove log4j overriding when spring-boot will be bumped to 2.5.8 or higher -->
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-to-slf4j</artifactId>
-                <version>2.17.1</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-api</artifactId>
-                <version>2.17.1</version>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-classic</artifactId>
-                <version>1.2.10</version>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-core</artifactId>
-                <version>1.2.10</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
We have bumped spring-boot to 2.5.12 making
log4j2 and logback version overrides unnecessary.

Signed-off-by: Ivan Hrasko [ivan.hrasko@pantheon.tech](mailto:ivan.hrasko@pantheon.tech)