### PR TITLE
Bump JUnit 5 to 5.8.2

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -126,7 +126,13 @@
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
-                <version>5.5.2</version>
+                <version>5.8.2</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>5.8.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Bump to the latest JUnit 5 API and engine.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>