### PR TITLE
Mark confusing methods deprecated

### DIFF
--- a/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/NodeConverter.java
+++ b/lighty-core/lighty-codecs-util/src/main/java/io/lighty/codecs/util/NodeConverter.java
@@ -15,7 +15,7 @@ import org.opendaylight.yangtools.yang.common.QName;
 import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier;
 import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
 import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
-import org.opendaylight.yangtools.yang.model.api.stmt.SchemaNodeIdentifier;
+import org.opendaylight.yangtools.yang.model.api.stmt.SchemaNodeIdentifier.Absolute;
 import org.opendaylight.yangtools.yang.model.util.SchemaInferenceStack;
 import org.opendaylight.yangtools.yang.model.util.SchemaInferenceStack.Inference;
 
@@ -26,15 +26,23 @@ import org.opendaylight.yangtools.yang.model.util.SchemaInferenceStack.Inference
  */
 public interface NodeConverter {
 
-    default Writer serializeData(SchemaNodeIdentifier.Absolute schemaNodeIdentifier, NormalizedNode normalizedNode)
+    default Writer serializeData(Absolute schemaNodeIdentifier, NormalizedNode normalizedNode)
             throws SerializationException {
         final Inference inference = SchemaInferenceStack.of(getModelContext(), schemaNodeIdentifier).toInference();
         return serializeData(inference, normalizedNode);
     }
 
+    /**
+     * Serialize data.
+     *
+     * @deprecated This method can confuse its users. They have to realize that they have to provide all QNames
+     *     to build {@code Absolute} and/or {@code Inference}. Thus, it's better for them to have just those methods
+     *     that require {@code Absolute} and/or {@code Inference} available.
+     */
+    @Deprecated(forRemoval = true)
     default Writer serializeData(NormalizedNode normalizedNode, QName... schemaIdentifierPath)
             throws SerializationException {
-        return serializeData(SchemaNodeIdentifier.Absolute.of(schemaIdentifierPath), normalizedNode);
+        return serializeData(Absolute.of(schemaIdentifierPath), normalizedNode);
     }
 
     default Writer serializeData(NormalizedNode normalizedNode) throws SerializationException {
@@ -50,12 +58,20 @@ public interface NodeConverter {
     Writer serializeData(Inference inference, NormalizedNode normalizedNode)
             throws SerializationException;
 
+    /**
+     * Serialize RPC.
+     *
+     * @deprecated This method can confuse its users. They have to realize that they have to provide all QNames
+     *     to build {@code Absolute} and/or {@code Inference}. Thus, it's better for them to have just those methods
+     *     that require {@code Absolute} and/or {@code Inference} available.
+     */
+    @Deprecated(forRemoval = true)
     default Writer serializeRpc(NormalizedNode normalizedNode, QName... schemaIdentifierPath)
             throws SerializationException {
-        return serializeRpc(SchemaNodeIdentifier.Absolute.of(schemaIdentifierPath), normalizedNode);
+        return serializeRpc(Absolute.of(schemaIdentifierPath), normalizedNode);
     }
 
-    default Writer serializeRpc(SchemaNodeIdentifier.Absolute schemaNodeIdentifier, NormalizedNode normalizedNode)
+    default Writer serializeRpc(Absolute schemaNodeIdentifier, NormalizedNode normalizedNode)
             throws SerializationException {
         final Inference inference = SchemaInferenceStack.of(getModelContext(), schemaNodeIdentifier).toInference();
         return serializeRpc(inference, normalizedNode);
@@ -78,12 +94,20 @@ public interface NodeConverter {
     Writer serializeRpc(Inference inference, NormalizedNode normalizedNode)
             throws SerializationException;
 
+    /**
+     * Deserialize data.
+     *
+     * @deprecated This method can confuse its users. They have to realize that they have to provide all QNames
+     *     to build {@code Absolute} and/or {@code Inference}. Thus, it's better for them to have just those methods
+     *     that require {@code Absolute} and/or {@code Inference} available.
+     */
+    @Deprecated(forRemoval = true)
     default NormalizedNode deserialize(Reader inputData, QName... schemaIdentifierPath)
             throws DeserializationException {
-        return deserialize(SchemaNodeIdentifier.Absolute.of(schemaIdentifierPath), inputData);
+        return deserialize(Absolute.of(schemaIdentifierPath), inputData);
     }
 
-    default NormalizedNode deserialize(SchemaNodeIdentifier.Absolute schemaNodeIdentifier, Reader inputData)
+    default NormalizedNode deserialize(Absolute schemaNodeIdentifier, Reader inputData)
             throws DeserializationException {
         return deserialize(SchemaInferenceStack.of(getModelContext(), schemaNodeIdentifier).toInference(), inputData);
     }

--- a/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/JsonNodeConverterTest.java
+++ b/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/JsonNodeConverterTest.java
@@ -20,6 +20,7 @@ import org.opendaylight.yang.gen.v1.http.pantheon.tech.ns.test.models.rev180119.
 import org.opendaylight.yang.gen.v1.http.pantheon.tech.ns.test.models.rev180119.TopLevelContainer;
 import org.opendaylight.yang.gen.v1.http.pantheon.tech.ns.test.models.rev180119.container.group.SampleContainer;
 import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
+import org.opendaylight.yangtools.yang.model.api.stmt.SchemaNodeIdentifier.Absolute;
 import org.opendaylight.yangtools.yang.parser.api.YangParserException;
 
 public class JsonNodeConverterTest extends AbstractCodecTest {
@@ -32,15 +33,15 @@ public class JsonNodeConverterTest extends AbstractCodecTest {
 
     @Test
     public void testSerializeRpcLeafInput() throws SerializationException {
-        final Writer serializedRpc = bindingSerializer.serializeRpc(rpcLeafInputNode,
-                LEAF_RPC_QNAME, SimpleInputOutputRpcInput.QNAME);
+        final Writer serializedRpc = bindingSerializer.serializeRpc(Absolute.of(LEAF_RPC_QNAME,
+                SimpleInputOutputRpcInput.QNAME), rpcLeafInputNode);
         assertValidJson(serializedRpc.toString());
     }
 
     @Test
     public void testSerializeRpcLeafOutput() throws SerializationException {
-        final Writer serializedRpc = bindingSerializer.serializeRpc(rpcLeafOutputNode,
-                LEAF_RPC_QNAME, SimpleInputOutputRpcOutput.QNAME);
+        final Writer serializedRpc = bindingSerializer.serializeRpc(Absolute.of(LEAF_RPC_QNAME,
+                SimpleInputOutputRpcOutput.QNAME), rpcLeafOutputNode);
         assertValidJson(serializedRpc.toString());
     }
 
@@ -52,7 +53,8 @@ public class JsonNodeConverterTest extends AbstractCodecTest {
 
     @Test
     public void testSerializeInnerContainer() throws SerializationException {
-        final Writer serializeData = bindingSerializer.serializeData(innerContainerNode, TopLevelContainer.QNAME);
+        final Writer serializeData = bindingSerializer.serializeData(Absolute.of(TopLevelContainer.QNAME),
+                innerContainerNode);
         assertValidJson(serializeData.toString());
     }
 
@@ -64,7 +66,7 @@ public class JsonNodeConverterTest extends AbstractCodecTest {
 
     @Test
     public void testSerializeListEntry() throws SerializationException {
-        final Writer serializedData = bindingSerializer.serializeData(listEntryNode, SampleList.QNAME);
+        final Writer serializedData = bindingSerializer.serializeData(Absolute.of(SampleList.QNAME), listEntryNode);
         assertValidJson(serializedData.toString());
     }
 
@@ -77,22 +79,22 @@ public class JsonNodeConverterTest extends AbstractCodecTest {
 
     @Test
     public void testDeserializeRpcInput() throws DeserializationException {
-        final NormalizedNode deserializeRpc = bindingSerializer.deserialize(
-                new StringReader(loadResourceAsString("rpc-leaf-Input.json")), LEAF_RPC_QNAME);
+        final NormalizedNode deserializeRpc = bindingSerializer.deserialize(Absolute.of(LEAF_RPC_QNAME),
+                new StringReader(loadResourceAsString("rpc-leaf-Input.json")));
         assertNotNull(deserializeRpc);
     }
 
     @Test
     public void testDeserializeRpcOutput() throws DeserializationException {
-        final NormalizedNode deserializeRpc = bindingSerializer.deserialize(
-                new StringReader(loadResourceAsString("rpc-leaf-output.json")), LEAF_RPC_QNAME);
+        final NormalizedNode deserializeRpc = bindingSerializer.deserialize(Absolute.of(LEAF_RPC_QNAME),
+                new StringReader(loadResourceAsString("rpc-leaf-output.json")));
         assertNotNull(deserializeRpc);
     }
 
     @Test
     public void testDeserializeRpcContainerInput() throws DeserializationException {
-        final NormalizedNode deserializeData = bindingSerializer.deserialize(
-                new StringReader(loadResourceAsString("rpc-container-input.json")), CONTAINER_RPC_QNAME);
+        final NormalizedNode deserializeData = bindingSerializer.deserialize(Absolute.of(CONTAINER_RPC_QNAME),
+                new StringReader(loadResourceAsString("rpc-container-input.json")));
         assertNotNull(deserializeData);
     }
 
@@ -105,16 +107,15 @@ public class JsonNodeConverterTest extends AbstractCodecTest {
 
     @Test
     public void testDeserializeInnerContainer() throws DeserializationException {
-        final NormalizedNode deserializeContainer = bindingSerializer.deserialize(
-                new StringReader(loadResourceAsString("inner-container.json")), TopLevelContainer.QNAME);
+        final NormalizedNode deserializeContainer = bindingSerializer.deserialize(Absolute.of(TopLevelContainer.QNAME),
+                new StringReader(loadResourceAsString("inner-container.json")));
         assertNotNull(deserializeContainer);
     }
 
     @Test
     public void testDeserializeInnerLeaf() throws DeserializationException {
-        final NormalizedNode result = bindingSerializer.deserialize(
-                new StringReader(loadResourceAsString("inner-leaf.json")),
-                TopLevelContainer.QNAME, SampleContainer.QNAME);
+        final NormalizedNode result = bindingSerializer.deserialize(Absolute.of(TopLevelContainer.QNAME,
+                SampleContainer.QNAME), new StringReader(loadResourceAsString("inner-leaf.json")));
         assertNotNull(result);
     }
 
@@ -131,6 +132,4 @@ public class JsonNodeConverterTest extends AbstractCodecTest {
                 new StringReader(loadResourceAsString("multiple-list-entries.json")));
         assertNotNull(result);
     }
-
-
 }

--- a/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/XmlNodeConverterTest.java
+++ b/lighty-core/lighty-codecs-util/src/test/java/io/lighty/codecs/util/XmlNodeConverterTest.java
@@ -24,6 +24,7 @@ import org.opendaylight.yang.gen.v1.http.pantheon.tech.ns.test.models.rev180119.
 import org.opendaylight.yang.gen.v1.http.pantheon.tech.ns.test.models.rev180119.TopLevelContainer;
 import org.opendaylight.yang.gen.v1.http.pantheon.tech.ns.test.models.rev180119.container.group.SampleContainer;
 import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
+import org.opendaylight.yangtools.yang.model.api.stmt.SchemaNodeIdentifier.Absolute;
 import org.opendaylight.yangtools.yang.parser.api.YangParserException;
 
 public class XmlNodeConverterTest extends AbstractCodecTest {
@@ -36,15 +37,15 @@ public class XmlNodeConverterTest extends AbstractCodecTest {
 
     @Test
     public void testSerializeRpcLeafInput() throws SerializationException {
-        final Writer serializedRpc = bindingSerializer.serializeRpc(rpcLeafInputNode,
-                LEAF_RPC_QNAME, SimpleInputOutputRpcInput.QNAME);
+        final Writer serializedRpc = bindingSerializer.serializeRpc(Absolute.of(LEAF_RPC_QNAME,
+                SimpleInputOutputRpcInput.QNAME), rpcLeafInputNode);
         assertValidXML(serializedRpc.toString());
     }
 
     @Test
     public void testSerializeRpcLeafOutput() throws SerializationException {
-        final Writer serializedRpc = bindingSerializer.serializeRpc(rpcLeafOutputNode,
-                LEAF_RPC_QNAME, SimpleInputOutputRpcOutput.QNAME);
+        final Writer serializedRpc = bindingSerializer.serializeRpc(Absolute.of(LEAF_RPC_QNAME,
+                SimpleInputOutputRpcOutput.QNAME), rpcLeafOutputNode);
         assertValidXML(serializedRpc.toString());
     }
 
@@ -56,7 +57,8 @@ public class XmlNodeConverterTest extends AbstractCodecTest {
 
     @Test
     public void testSerializeInnerContainer() throws SerializationException {
-        final Writer serializeData = bindingSerializer.serializeData(innerContainerNode, TopLevelContainer.QNAME);
+        final Writer serializeData = bindingSerializer.serializeData(Absolute.of(TopLevelContainer.QNAME),
+                innerContainerNode);
         assertValidXML(serializeData.toString());
     }
 
@@ -68,31 +70,28 @@ public class XmlNodeConverterTest extends AbstractCodecTest {
 
     @Test
     public void testSerializeListEntry() throws SerializationException {
-        final Writer serializedData = bindingSerializer.serializeData(
-                listEntryNode, SampleList.QNAME);
+        final Writer serializedData = bindingSerializer.serializeData(Absolute.of(SampleList.QNAME), listEntryNode);
         assertNotNull(serializedData.toString());
     }
 
     @Test
     public void testDeserializeData() throws DeserializationException {
-        NormalizedNode deserializeData = bindingSerializer.deserialize(
-                new StringReader(loadResourceAsString("toaster-container.xml")), Toaster.QNAME);
+        NormalizedNode deserializeData = bindingSerializer.deserialize(Absolute.of(Toaster.QNAME),
+                new StringReader(loadResourceAsString("toaster-container.xml")));
         assertNotNull(deserializeData);
     }
 
     @Test
     public void testDeserializeRpcInput() throws DeserializationException {
-        final NormalizedNode deserializeRpc = bindingSerializer.deserialize(
-                new StringReader(loadResourceAsString("rpc-leaf-input.xml")), LEAF_RPC_QNAME,
-                SimpleInputOutputRpcInput.QNAME);
+        final NormalizedNode deserializeRpc = bindingSerializer.deserialize(Absolute.of(LEAF_RPC_QNAME,
+                SimpleInputOutputRpcInput.QNAME), new StringReader(loadResourceAsString("rpc-leaf-input.xml")));
         assertNotNull(deserializeRpc);
     }
 
     @Test
     public void testDeserializeRpcOutput() throws DeserializationException {
-        final NormalizedNode deserializeRpc = bindingSerializer.deserialize(
-                new StringReader(loadResourceAsString("rpc-leaf-output.xml")), LEAF_RPC_QNAME,
-                SimpleInputOutputRpcOutput.QNAME);
+        final NormalizedNode deserializeRpc = bindingSerializer.deserialize(Absolute.of(LEAF_RPC_QNAME,
+                SimpleInputOutputRpcOutput.QNAME), new StringReader(loadResourceAsString("rpc-leaf-output.xml")));
         assertNotNull(deserializeRpc);
     }
 
@@ -106,39 +105,37 @@ public class XmlNodeConverterTest extends AbstractCodecTest {
 
     @Test
     public void testDeserializeContainerRpcInput() throws DeserializationException {
-        final NormalizedNode deserializeData = bindingSerializer.deserialize(
-                new StringReader(loadResourceAsString("rpc-container-input.xml")),
-                CONTAINER_RPC_QNAME, ContainerIoRpcInput.QNAME);
+        final NormalizedNode deserializeData = bindingSerializer.deserialize(Absolute.of(CONTAINER_RPC_QNAME,
+                ContainerIoRpcInput.QNAME), new StringReader(loadResourceAsString("rpc-container-input.xml")));
         assertNotNull(deserializeData);
     }
 
     @Test
     public void testDeserializeTopLevelContainer() throws DeserializationException {
-        final NormalizedNode result = bindingSerializer.deserialize(
-                new StringReader(loadResourceAsString("top-level-container.xml")), TopLevelContainer.QNAME);
+        final NormalizedNode result = bindingSerializer.deserialize(Absolute.of(TopLevelContainer.QNAME),
+                new StringReader(loadResourceAsString("top-level-container.xml")));
         assertNotNull(result);
     }
 
     @Test
     public void testDeserializeInnerContainer() throws DeserializationException {
-        final NormalizedNode result = bindingSerializer.deserialize(
-                new StringReader(loadResourceAsString("inner-container.xml")),
-                TopLevelContainer.QNAME, SampleContainer.QNAME);
+        final NormalizedNode result = bindingSerializer.deserialize(Absolute.of(TopLevelContainer.QNAME,
+                SampleContainer.QNAME), new StringReader(loadResourceAsString("inner-container.xml")));
         assertNotNull(result);
     }
 
     @Test
     public void testDeserializeInnerLeaf() throws DeserializationException {
-        final NormalizedNode result = bindingSerializer.deserialize(
-                new StringReader(loadResourceAsString("inner-leaf.xml")),
-                TopLevelContainer.QNAME, SampleContainer.QNAME, $YangModuleInfoImpl.qnameOf("name"));
+        final NormalizedNode result = bindingSerializer.deserialize(Absolute.of(TopLevelContainer.QNAME,
+                SampleContainer.QNAME, $YangModuleInfoImpl.qnameOf("name")),
+                new StringReader(loadResourceAsString("inner-leaf.xml")));
         assertNotNull(result);
     }
 
     @Test
     public void testDeserializeListSingleEntry() throws DeserializationException {
-        NormalizedNode result = bindingSerializer.deserialize(
-                new StringReader(loadResourceAsString("single-list-entry.xml")), SampleList.QNAME);
+        NormalizedNode result = bindingSerializer.deserialize(Absolute.of(SampleList.QNAME),
+                new StringReader(loadResourceAsString("single-list-entry.xml")));
         assertNotNull(result.toString());
     }
 
@@ -148,5 +145,4 @@ public class XmlNodeConverterTest extends AbstractCodecTest {
                 new StringReader(loadResourceAsString("multiple-list-entries.xml")));
         assertNotNull(result.toString());
     }
-
 }


### PR DESCRIPTION
Mark methods which require list of QNames as parameter
in order to construct Absolute/Inference deprecated.
    
Those methods can confuse users - they have to provide
all QNames to construct Absolute/Inference anyway - thus
we will provide only those methods - to make it clear.