### PR TITLE
Fix writing data into list in gNMI Simulator

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-commons/src/main/java/io/lighty/modules/gnmi/commons/util/JsonUtils.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-commons/src/main/java/io/lighty/modules/gnmi/commons/util/JsonUtils.java
@@ -16,7 +16,10 @@ import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
+import org.opendaylight.yangtools.yang.common.QName;
+import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier.NodeIdentifierWithPredicates;
 
 public final class JsonUtils {
 
@@ -28,8 +31,13 @@ public final class JsonUtils {
         return "{\"" + key + "\":" + value + "}";
     }
 
-    public static String wrapJsonWithArray(final String jsonString, final String wrapper, final Gson gson) {
-        final JsonObject innerJson = new JsonParser().parse(jsonString).getAsJsonObject();
+    public static String wrapJsonWithArray(final String jsonString, final String wrapper, final Gson gson,
+            final NodeIdentifierWithPredicates predicates) {
+        final JsonObject innerJson = JsonParser.parseString(jsonString).getAsJsonObject();
+        for (final Entry<QName, Object> key : predicates.entrySet()) {
+            innerJson.add(key.getKey().getLocalName(), gson.toJsonTree(key.getValue()));
+        }
+
         final JsonObject result = new JsonObject();
         final JsonArray array = new JsonArray();
         array.add(innerJson);

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/gnmi/GnmiCrudService.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/gnmi/GnmiCrudService.java
@@ -34,6 +34,7 @@ import org.opendaylight.yangtools.yang.common.QName;
 import org.opendaylight.yangtools.yang.common.QNameModule;
 import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier;
 import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier.AugmentationIdentifier;
+import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier.NodeIdentifierWithPredicates;
 import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
 import org.opendaylight.yangtools.yang.model.api.DataSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
@@ -198,10 +199,13 @@ public class GnmiCrudService {
                             Iterables.getLast(identifier.getPathArguments()).getNodeType().getLocalName()), gson);
             node = DataConverter.nodeFromJsonString(identifier, json, context);
         } else {
+            final NodeIdentifierWithPredicates lastPathArgument
+                    = (NodeIdentifierWithPredicates) identifier.getLastPathArgument();
             json = JsonUtils.wrapJsonWithArray(update.getVal().getJsonIetfVal().toStringUtf8(),
                     String.format("%s:%s",
                             module.getName(),
-                            Iterables.getLast(identifier.getPathArguments()).getNodeType().getLocalName()), gson);
+                            Iterables.getLast(identifier.getPathArguments()).getNodeType().getLocalName()), gson,
+                    lastPathArgument);
             node = DataConverter.nodeFromJsonString(identifier, json, context);
             // In case of list entry, point to the list itself
             resultingIdentifier = identifier.getParent();

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/mountpoint/codecs/GetResponseToNormalizedNodeCodec.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/mountpoint/codecs/GetResponseToNormalizedNodeCodec.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.opendaylight.yangtools.yang.common.QName;
 import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier;
+import org.opendaylight.yangtools.yang.data.api.YangInstanceIdentifier.NodeIdentifierWithPredicates;
 import org.opendaylight.yangtools.yang.data.api.schema.AugmentationNode;
 import org.opendaylight.yangtools.yang.data.api.schema.NormalizedNode;
 import org.opendaylight.yangtools.yang.model.api.Module;
@@ -101,9 +102,13 @@ public class GetResponseToNormalizedNodeCodec implements BiCodec<Gnmi.GetRespons
 
                     final String wrapWith = String.format("%s:%s", moduleByQName.getName(),
                             lastName.getLocalName());
-                    responseJson = isMapEntryPath(identifier)
-                            ? JsonUtils.wrapJsonWithArray(responseJson, wrapWith, gson)
-                            : JsonUtils.wrapJsonWithObject(responseJson, wrapWith, gson);
+                    if (identifier.getLastPathArgument() instanceof NodeIdentifierWithPredicates) {
+                        final NodeIdentifierWithPredicates lastPathArgument
+                                = (NodeIdentifierWithPredicates) identifier.getLastPathArgument();
+                        responseJson = JsonUtils.wrapJsonWithArray(responseJson, wrapWith, gson, lastPathArgument);
+                    } else {
+                        responseJson = JsonUtils.wrapJsonWithObject(responseJson, wrapWith, gson);
+                    }
                 }
                 return resolveJsonResponse(identifier, responseJson);
                 /*
@@ -168,9 +173,4 @@ public class GetResponseToNormalizedNodeCodec implements BiCodec<Gnmi.GetRespons
                     inputJson), e);
         }
     }
-
-    private static boolean isMapEntryPath(final YangInstanceIdentifier yid) {
-        return yid.getLastPathArgument() instanceof YangInstanceIdentifier.NodeIdentifierWithPredicates;
-    }
-
 }

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/SimulatorCrudTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/SimulatorCrudTest.java
@@ -210,6 +210,32 @@ public class SimulatorCrudTest {
     }
 
     @Test
+    public void setContainerInsideList() throws Exception {
+        final Gnmi.Path path = Gnmi.Path.newBuilder()
+                .addElem(Gnmi.PathElem.newBuilder()
+                        .setName(OPENCONFIG_INTERFACES)
+                        .build())
+                .addElem(Gnmi.PathElem.newBuilder()
+                        .setName("interface")
+                        .putKey("name", "eth5")
+                        .build())
+                .build();
+        final Gnmi.Update update = Gnmi.Update.newBuilder()
+                .setPath(path)
+                .setVal(Gnmi.TypedValue.newBuilder()
+                        .setJsonIetfVal(ByteString.copyFromUtf8(getConfigData()))
+                        .build())
+                .build();
+        final Gnmi.SetRequest setRequest = Gnmi.SetRequest.newBuilder()
+                .addUpdate(update)
+                .build();
+        LOG.info("Sending set request:\n{}", setRequest);
+
+        final Gnmi.SetResponse setResponse = sessionProvider.getGnmiSession().set(setRequest).get();
+        assertEquals("UPDATE", setResponse.getResponse(0).getOp().toString());
+    }
+
+    @Test
     public void crudComplexValueTest() throws ExecutionException, InterruptedException, IOException, JSONException {
         final Gnmi.Path path = Gnmi.Path.newBuilder()
                 .addElem(Gnmi.PathElem.newBuilder()
@@ -569,5 +595,15 @@ public class SimulatorCrudTest {
                        + "}"
                    + "}"
                + "}";
+    }
+
+    private static String getConfigData() {
+        return "{\n"
+                + "    \"config\": {\n"
+                + "      \"name\": \"Vlan10\",\n"
+                + "      \"type\": \"iana-if-type:l2vlan\",\n"
+                + "      \"mtu\": 1550\n"
+                + "    }\n"
+                + "}";
     }
 }


### PR DESCRIPTION
Writing data to list inside gNMI simulator fails due to missing key nodes.
For example:
```bash
cat << EOF > cfg.json
{
    "config": {
      "name": "Vlan10",
      "type": "iana-if-type:l2vlan",
      "mtu": 1550
    }
}
EOF
```
```bash
gnmic -a 127.0.0.1:3333 --update-path openconfig-interfaces:interfaces/interface[name=Vlan10] --update-file cfg.json --encoding json_ietf
```

Fails because it will try to write data
```json
{
    "openconfig-interfaces:interface": [
        {
            "config": {
                "name": "Vlan10",
                "type": "iana-if-type:l2vlan",
                "mtu": 1550
            }
        }
    ]
}
```
to path:
`Absolute{qnames=[(http://openconfig.net/yang/interfaces?revision=2021-06-15)interfaces]`