### PR TITLE
Bump to new released Sulfur versions

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -34,14 +34,14 @@
             <dependency>
                 <groupId>org.opendaylight.aaa</groupId>
                 <artifactId>aaa-artifacts</artifactId>
-                <version>0.15.2</version>
+                <version>0.15.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>controller-artifacts</artifactId>
-                <version>5.0.2</version>
+                <version>5.0.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -62,7 +62,7 @@
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>netconf-artifacts</artifactId>
-                <version>3.0.1</version>
+                <version>3.0.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -76,7 +76,7 @@
             <dependency>
                 <groupId>org.opendaylight.bgpcep</groupId>
                 <artifactId>bgpcep-artifacts</artifactId>
-                <version>0.17.1</version>
+                <version>0.17.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/util/DatastoreConfigurationUtils.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/util/DatastoreConfigurationUtils.java
@@ -46,8 +46,7 @@ public final class DatastoreConfigurationUtils {
                 .shardBatchedModificationCount(configNode.path("shardBatchedModificationCount").asInt())
                 .shardCommitQueueExpiryTimeoutInMillis(configNode.path("shardCommitQueueExpiryTimeoutInMillis").asInt())
                 .transactionDebugContextEnabled(configNode.path("transactionDebugContextEnabled").booleanValue())
-                // TODO: Workaround for bug: https://jira.opendaylight.org/browse/CONTROLLER-2040. Revert when this will be resolved
-                .useTellBasedProtocol(configNode.path("useTellBasedProtocol").asBoolean(true))
+                .useTellBasedProtocol(configNode.path("useTellBasedProtocol").booleanValue())
                 .customRaftPolicyImplementation(NO_CUSTOM_POLICY)
                 .maximumMessageSliceSize(configNode.path("maximumMessageSliceSize").asInt())
                 .tempFileDirectory(TEMP_FILE_DIRECTORY)
@@ -65,8 +64,6 @@ public final class DatastoreConfigurationUtils {
         return DatastoreContext.newBuilder()
                 .logicalStoreType(LogicalDatastoreType.OPERATIONAL)
                 .tempFileDirectory(TEMP_FILE_DIRECTORY)
-                // TODO: Workaround for bug: https://jira.opendaylight.org/browse/CONTROLLER-2040. Remove when this will be resolved
-                .useTellBasedProtocol(true)
                 .persistent(false)
                 .build();
     }
@@ -74,8 +71,6 @@ public final class DatastoreConfigurationUtils {
     public static DatastoreContext createDefaultConfigDatastoreContext() {
         return DatastoreContext.newBuilder()
                 .logicalStoreType(LogicalDatastoreType.CONFIGURATION)
-                // TODO: Workaround for bug: https://jira.opendaylight.org/browse/CONTROLLER-2040. Remove when this will be resolved
-                .useTellBasedProtocol(true)
                 .tempFileDirectory(TEMP_FILE_DIRECTORY)
                 .build();
     }

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/util/DatastoreConfigurationUtils.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/util/DatastoreConfigurationUtils.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.opendaylight.controller.cluster.datastore.DatastoreContext;
+import org.opendaylight.controller.cluster.datastore.DatastoreContext.Builder;
 import org.opendaylight.mdsal.common.api.LogicalDatastoreType;
 
 public final class DatastoreConfigurationUtils {
@@ -26,38 +27,71 @@ public final class DatastoreConfigurationUtils {
 
     public static DatastoreContext createDatastoreContext(final JsonNode configNode,
             final LogicalDatastoreType logicalDatastoreType) {
-        return DatastoreContext.newBuilder()
-                .shardTransactionIdleTimeout(configNode.path("shardTransactionIdleTimeout").asLong(),
-                    TimeUnit.MILLISECONDS)
-                .operationTimeoutInMillis(configNode.path("operationTimeoutInMillis").asLong())
+        final Builder builder = DatastoreContext.newBuilder()
+                .operationTimeoutInMillis(configNode.path("operationTimeoutInMillis")
+                        .asLong(DatastoreContext.DEFAULT_OPERATION_TIMEOUT_IN_MS))
                 .shardTransactionCommitTimeoutInSeconds(configNode.path("shardTransactionCommitTimeoutInSeconds")
-                    .asInt())
-                .shardJournalRecoveryLogBatchSize(configNode.path("shardJournalRecoveryLogBatchSize").asInt())
-                .shardSnapshotBatchCount(configNode.path("shardSnapshotBatchCount").asInt())
-                .shardSnapshotDataThresholdPercentage(configNode.path("shardSnapshotDataThresholdPercentage").asInt())
-                .shardHeartbeatIntervalInMillis(configNode.path("shardHeartbeatIntervalInMillis").asInt())
-                .shardTransactionCommitQueueCapacity(configNode.path("shardTransactionCommitQueueCapacity").asInt())
-                .shardInitializationTimeout(configNode.path("shardInitializationTimeout").asLong(),
-                    TimeUnit.MILLISECONDS)
-                .shardLeaderElectionTimeout(configNode.path("shardLeaderElectionTimeout").asLong(),
-                    TimeUnit.MILLISECONDS)
-                .persistent(configNode.path("persistent").asBoolean())
+                        .asInt(DatastoreContext.DEFAULT_SHARD_TX_COMMIT_TIMEOUT_IN_SECONDS))
+                .shardJournalRecoveryLogBatchSize(configNode.path("shardJournalRecoveryLogBatchSize")
+                        .asInt(DatastoreContext.DEFAULT_JOURNAL_RECOVERY_BATCH_SIZE))
+                .shardSnapshotBatchCount(configNode.path("shardSnapshotBatchCount")
+                        .asInt(DatastoreContext.DEFAULT_SNAPSHOT_BATCH_COUNT))
+                .shardSnapshotDataThresholdPercentage(configNode.path("shardSnapshotDataThresholdPercentage")
+                        .asInt(DatastoreContext.DEFAULT_SHARD_SNAPSHOT_DATA_THRESHOLD_PERCENTAGE))
+                .shardHeartbeatIntervalInMillis(configNode.path("shardHeartbeatIntervalInMillis")
+                        .asInt(DatastoreContext.DEFAULT_HEARTBEAT_INTERVAL_IN_MILLIS))
+                .shardTransactionCommitQueueCapacity(configNode.path("shardTransactionCommitQueueCapacity")
+                        .asInt(DatastoreContext.DEFAULT_SHARD_TX_COMMIT_QUEUE_CAPACITY))
+                .persistent(configNode.path("persistent").asBoolean(DatastoreContext.DEFAULT_PERSISTENT))
                 .logicalStoreType(logicalDatastoreType)
-                .shardBatchedModificationCount(configNode.path("shardBatchedModificationCount").asInt())
-                .shardCommitQueueExpiryTimeoutInMillis(configNode.path("shardCommitQueueExpiryTimeoutInMillis").asInt())
-                .transactionDebugContextEnabled(configNode.path("transactionDebugContextEnabled").booleanValue())
-                .useTellBasedProtocol(configNode.path("useTellBasedProtocol").booleanValue())
+                .shardBatchedModificationCount(configNode.path("shardBatchedModificationCount")
+                        .asInt(DatastoreContext.DEFAULT_SHARD_BATCHED_MODIFICATION_COUNT))
+                .shardCommitQueueExpiryTimeoutInMillis(configNode.path("shardCommitQueueExpiryTimeoutInMillis")
+                        .asLong(DatastoreContext.DEFAULT_SHARD_COMMIT_QUEUE_EXPIRY_TIMEOUT_IN_MS))
                 .customRaftPolicyImplementation(NO_CUSTOM_POLICY)
-                .maximumMessageSliceSize(configNode.path("maximumMessageSliceSize").asInt())
+                .maximumMessageSliceSize(configNode.path("maximumMessageSliceSize")
+                        .asInt(DatastoreContext.DEFAULT_MAX_MESSAGE_SLICE_SIZE))
                 .tempFileDirectory(TEMP_FILE_DIRECTORY)
-                .fileBackedStreamingThresholdInMegabytes(configNode.path("fileBackedStreamingThresholdInMegabytes")
-                    .asInt())
-                .syncIndexThreshold(configNode.path("syncIndexThreshold").asInt())
-                .backendAlivenessTimerIntervalInSeconds(configNode.path("backendAlivenessTimerIntervalInSeconds")
-                    .asInt())
-                .frontendRequestTimeoutInSeconds(configNode.path("frontendRequestTimeoutInSeconds").asLong())
-                .frontendNoProgressTimeoutInSeconds(configNode.path("frontendNoProgressTimeoutInSeconds").asLong())
-                .build();
+                .syncIndexThreshold(configNode.path("syncIndexThreshold")
+                        .asLong(DatastoreContext.DEFAULT_SYNC_INDEX_THRESHOLD));
+
+        return setNotNullElementWithoutDefaultConstant(configNode, builder).build();
+    }
+
+    private static Builder setNotNullElementWithoutDefaultConstant(final JsonNode configNode, final Builder builder) {
+        if (!configNode.path("transactionDebugContextEnabled").asText().isBlank()) {
+            builder.transactionDebugContextEnabled(configNode.path("transactionDebugContextEnabled").asBoolean());
+        }
+        if (!configNode.path("useTellBasedProtocol").asText().isBlank()) {
+            builder.useTellBasedProtocol(configNode.path("useTellBasedProtocol").asBoolean());
+        }
+        if (!configNode.path("fileBackedStreamingThresholdInMegabytes").asText().isBlank()) {
+            builder.fileBackedStreamingThresholdInMegabytes(
+                    configNode.path("fileBackedStreamingThresholdInMegabytes").asInt());
+        }
+        if (!configNode.path("backendAlivenessTimerIntervalInSeconds").asText().isBlank()) {
+            builder.backendAlivenessTimerIntervalInSeconds(
+                    configNode.path("backendAlivenessTimerIntervalInSeconds").asLong());
+        }
+        if (!configNode.path("frontendRequestTimeoutInSeconds").asText().isBlank()) {
+            builder.frontendRequestTimeoutInSeconds(configNode.path("frontendRequestTimeoutInSeconds").asLong());
+        }
+        if (!configNode.path("frontendNoProgressTimeoutInSeconds").asText().isBlank()) {
+            builder.frontendNoProgressTimeoutInSeconds(configNode.path("frontendNoProgressTimeoutInSeconds").asLong());
+        }
+        if (!configNode.path("shardTransactionIdleTimeout").asText().isBlank()) {
+            builder.shardTransactionIdleTimeout(configNode.path("shardTransactionIdleTimeout").asLong(),
+                    TimeUnit.MILLISECONDS);
+        }
+        if (!configNode.path("shardInitializationTimeout").asText().isBlank()) {
+            builder.shardInitializationTimeout(configNode.path("shardInitializationTimeout").asLong(),
+                    TimeUnit.MILLISECONDS);
+        }
+        if (!configNode.path("shardLeaderElectionTimeout").asText().isBlank()) {
+            builder.shardLeaderElectionTimeout(configNode.path("shardLeaderElectionTimeout").asLong(),
+                    TimeUnit.MILLISECONDS);
+        }
+        return builder;
     }
 
     public static DatastoreContext createDefaultOperationalDatastoreContext() {

--- a/lighty-core/lighty-controller/src/test/resources/testLightyControllerConfig-noDsContexts.json
+++ b/lighty-core/lighty-controller/src/test/resources/testLightyControllerConfig-noDsContexts.json
@@ -22,6 +22,8 @@
         { "nameSpace": "urn:TBD:params:xml:ns:yang:network-topology", "name": "network-topology", "revision": "2013-10-21" },
         { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-restconf", "name": "ietf-restconf", "revision": "2013-10-19" }
       ]
+    },
+    "configurationDatastoreContext" : {
     }
   }
 }

--- a/lighty-examples/lighty-community-restconf-actions-app/src/test/java/io/lighty/examples/controller/actions/RestconfActionsAppTest.java
+++ b/lighty-examples/lighty-community-restconf-actions-app/src/test/java/io/lighty/examples/controller/actions/RestconfActionsAppTest.java
@@ -64,9 +64,8 @@ public class RestconfActionsAppTest {
 
     /**
      * Check if Swagger service and UI is responding.
-     * TODO: Enable test when "https://jira.opendaylight.org/browse/NETCONF-872" will be resolved.
      */
-    @Test(enabled = false)
+    @Test
     public void swaggerURLsTest() throws Exception {
         HttpResponse<String> operations;
         operations = restClient.GET("apidoc/openapi3/18/apis/single");


### PR DESCRIPTION
aaa-artifacts - 0.15.3
controller-artifacts - 5.0.3
netconf-artifacts - 3.0.2
bgpcep-artifacts - 0.17.2

- Fix loading default DatastoreContext values from JSON configuration.
If any attribute is missing in DatastoreContext configuration when is load through JSON, lighty will use default value from Jackson. Fix this by using default DatastoreContext values if is not specified in JSON configuration.