### PR TITLE
Fix converting path to YIID in gNMI

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-commons/src/main/java/io/lighty/modules/gnmi/commons/util/DataConverter.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-commons/src/main/java/io/lighty/modules/gnmi/commons/util/DataConverter.java
@@ -36,7 +36,6 @@ import org.opendaylight.yangtools.yang.data.codec.gson.JsonParserStream;
 import org.opendaylight.yangtools.yang.data.impl.schema.ImmutableNormalizedNodeStreamWriter;
 import org.opendaylight.yangtools.yang.data.impl.schema.builder.impl.ImmutableContainerNodeBuilder;
 import org.opendaylight.yangtools.yang.data.util.DataSchemaContextTree;
-import org.opendaylight.yangtools.yang.model.api.DataSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
 import org.opendaylight.yangtools.yang.model.api.Module;
 import org.opendaylight.yangtools.yang.model.api.SchemaContext;
@@ -229,17 +228,6 @@ public final class DataConverter {
     public static Optional<Module> findModuleByQName(@NonNull final QName element,
                                                      @NonNull final EffectiveModelContext context) {
         return context.findModule(element.getModule());
-    }
-
-    public static Optional<DataSchemaNode> findAugmentationDataNode(@NonNull final String element,
-                                                                    @NonNull final EffectiveModelContext context) {
-        return context.getModules()
-                .stream()
-                .flatMap(module -> module.getAugmentations().stream())
-                .flatMap(augmentation -> augmentation.getChildNodes().stream())
-                .filter(childNode -> childNode.getQName().getLocalName().equals(element))
-                .map(DataSchemaNode.class::cast)
-                .findFirst();
     }
 
     private static boolean isListEntry(final NormalizedNode node) {

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/gnmi/GnmiCrudService.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/gnmi/GnmiCrudService.java
@@ -214,6 +214,10 @@ public class GnmiCrudService {
             resultingIdentifier = identifier.getParent();
         }
 
+        if (node.getIdentifier() instanceof AugmentationIdentifier && resultingIdentifier != null) {
+            resultingIdentifier = resultingIdentifier.getParent();
+        }
+
         if (isReplace) {
             dataService.writeDataByPath(DatastoreType.CONFIGURATION, resultingIdentifier,
                     node);

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/gnmi/GnmiCrudService.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/gnmi/GnmiCrudService.java
@@ -309,12 +309,11 @@ public class GnmiCrudService {
 
     private YangInstanceIdentifier instanceIdentifierFromPath(final QNameModule rootModule,
                                                               final Gnmi.Path path) {
-        QName qname = null;
         YangInstanceIdentifier identifier = null;
         for (final Gnmi.PathElem pathElem : path.getElemList()) {
             final String pathElemName = ElementNameWithModuleName.parseFromString(pathElem.getName()).getElementName();
             if (identifier == null) {
-                qname = QName.create(rootModule, pathElemName);
+                final QName qname = QName.create(rootModule, pathElemName);
                 identifier = YangInstanceIdentifier.of(qname);
             } else {
                 // Find yang node by local-name (pathElemName) and parent (identifier) namespace/revision
@@ -331,12 +330,10 @@ public class GnmiCrudService {
                 }
             }
             if (!pathElem.getKeyMap().isEmpty()) {
-                final QName finalQname = qname;
-                final Map<QName, Object> keysMap = pathElem.getKeyMap().entrySet().stream().collect(
-                        Collectors.toMap(e -> QName.create(finalQname, e.getKey()), Map.Entry::getValue)
-                );
-                identifier = identifier.node(YangInstanceIdentifier.NodeIdentifierWithPredicates.of(qname,
-                        keysMap));
+                final QName qname = identifier.getLastPathArgument().getNodeType();
+                final Map<QName, Object> keysMap = pathElem.getKeyMap().entrySet().stream()
+                        .collect(Collectors.toMap(e -> QName.create(qname, e.getKey()), Map.Entry::getValue));
+                identifier = identifier.node(NodeIdentifierWithPredicates.of(qname, keysMap));
             }
         }
         return identifier;

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/SimulatorCrudTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/SimulatorCrudTest.java
@@ -206,7 +206,6 @@ public class SimulatorCrudTest {
         LOG.info("Sending get request:\n{}", getRequest);
 
         assertThrows(ExecutionException.class, () -> sessionProvider.getGnmiSession().get(getRequest).get());
-
     }
 
     @Test
@@ -214,6 +213,35 @@ public class SimulatorCrudTest {
         final Gnmi.Path path = Gnmi.Path.newBuilder()
                 .addElem(Gnmi.PathElem.newBuilder()
                         .setName(OPENCONFIG_INTERFACES)
+                        .build())
+                .addElem(Gnmi.PathElem.newBuilder()
+                        .setName("interface")
+                        .putKey("name", "eth5")
+                        .build())
+                .build();
+        final Gnmi.Update update = Gnmi.Update.newBuilder()
+                .setPath(path)
+                .setVal(Gnmi.TypedValue.newBuilder()
+                        .setJsonIetfVal(ByteString.copyFromUtf8(getConfigData()))
+                        .build())
+                .build();
+        final Gnmi.SetRequest setRequest = Gnmi.SetRequest.newBuilder()
+                .addUpdate(update)
+                .build();
+        LOG.info("Sending set request:\n{}", setRequest);
+
+        final Gnmi.SetResponse setResponse = sessionProvider.getGnmiSession().set(setRequest).get();
+        assertEquals("UPDATE", setResponse.getResponse(0).getOp().toString());
+    }
+
+    @Test
+    public void setAugmentedTestInterfaceConfigTest() throws Exception {
+        final Gnmi.Path path = Gnmi.Path.newBuilder()
+                .addElem(Gnmi.PathElem.newBuilder()
+                        .setName("gnmi-test-model:test-data")
+                        .build())
+                .addElem(Gnmi.PathElem.newBuilder()
+                        .setName("nested-container")
                         .build())
                 .addElem(Gnmi.PathElem.newBuilder()
                         .setName("interface")
@@ -416,7 +444,6 @@ public class SimulatorCrudTest {
 
         assertThrows(ExecutionException.class, () -> sessionProvider.getGnmiSession().get(getRequest).get());
     }
-
 
     @Test
     public void crudComplexAugmentedValue() throws ExecutionException, InterruptedException, IOException,

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiGetITTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiGetITTest.java
@@ -55,7 +55,7 @@ public class GnmiGetITTest extends GnmiITBase {
         "openconfig-license semver: 0.2.0", "openconfig-messages semver: 0.0.1", "openconfig-procmon semver: 0.4.0",
         "openconfig-system semver: 0.10.0","openconfig-system-logging semver: 0.3.1",
         "openconfig-system-terminal semver: 0.3.1", "openconfig-openflow semver: 0.1.2",
-        "openconfig-openflow-types semver: 0.1.3");
+        "openconfig-openflow-types semver: 0.1.3", "gnmi-test-aug semver: 1.0.0");
 
     private static final String OC_INTERFACES_CONTAINER_EXPECTED_JSON_OBJ =
         "{\"openconfig-interfaces:interfaces\":"

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiSetITTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/rcgnmi/GnmiSetITTest.java
@@ -44,6 +44,10 @@ public class GnmiSetITTest extends GnmiITBase {
     private static final String GNMI_TEST_BASE_LIST_PATH = GNMI_DEVICE_MOUNTPOINT + "/gnmi-test-model:base-list=datO";
     private static final String WRONG_BASE_LIST_PATH = GNMI_DEVICE_MOUNTPOINT + "/gnmi-test-model:base-list=WRONG";
     private static final String NESTED_LIST_PATH = GNMI_TEST_BASE_LIST_PATH + "/nested-list=dat21";
+    private static final String AUGMENTED_TEST_INTERFACE_ETH10_PATH = GNMI_DEVICE_MOUNTPOINT
+            + "/gnmi-test-model:test-data/nested-container/gnmi-test-aug:interface=eth10";
+    private static final String AUGMENTED_TEST_DATA_PATH = GNMI_DEVICE_MOUNTPOINT
+            + "/gnmi-test-model:test-data/augmented-container";
     private static final String WRONG_NESTED_LIST_PATH = WRONG_BASE_LIST_PATH + "/nested-list=dat21";
     private static final String TEST_LEAF_LIST = "test-leaf-list";
     private static final String TEST_LIST = "test-list";
@@ -146,6 +150,24 @@ public class GnmiSetITTest extends GnmiITBase {
                      eth3ConfigContainerJSONObject.getJSONObject("openconfig-interfaces:config").toString(), false);
 
         restoreDeviceToOriginalState();
+    }
+
+    @Test
+    public void setAugmentedInterfaceListFromOuterModelTest() throws Exception {
+        final String payload = getAugmentedTestInterfaceBody();
+        //Set request
+        final HttpResponse<String> setAugResponse = sendPutRequestJSON(AUGMENTED_TEST_INTERFACE_ETH10_PATH, payload);
+        // Assertion
+        assertEquals(HttpURLConnection.HTTP_CREATED, setAugResponse.statusCode());
+    }
+
+    @Test
+    public void setAugmentedDataFromInnerModelTest() throws Exception {
+        final String payload = getAugmentedDataBody();
+        //Set request
+        final HttpResponse<String> setAugResponse = sendPutRequestJSON(AUGMENTED_TEST_DATA_PATH, payload);
+        // Assertion
+        assertEquals(HttpURLConnection.HTTP_CREATED, setAugResponse.statusCode());
     }
 
     @Test
@@ -425,7 +447,7 @@ public class GnmiSetITTest extends GnmiITBase {
         }
     }
 
-    private String getBaseListBody() {
+    private static String getBaseListBody() {
         return "{\n"
               + "    \"gnmi-test-model:base-list\": [\n"
               + "        {\n"
@@ -443,7 +465,7 @@ public class GnmiSetITTest extends GnmiITBase {
               + "}";
     }
 
-    private String getNestedListBody() {
+    private static String getNestedListBody() {
         return "{\n"
               + "      \"gnmi-test-model:nested-list\": [\n"
               + "          {\n"
@@ -453,7 +475,7 @@ public class GnmiSetITTest extends GnmiITBase {
               + "}";
     }
 
-    private String getNestedListBodyResponse() {
+    private static String getNestedListBodyResponse() {
         return "{\n"
               + "    \"gnmi-test-model:base-list\": [\n"
               + "        {\n"
@@ -468,7 +490,7 @@ public class GnmiSetITTest extends GnmiITBase {
               + "}";
     }
 
-    private String getNestedListUpdateBodyResponse() {
+    private static String getNestedListUpdateBodyResponse() {
         return "{\n"
               + "    \"gnmi-test-model:base-list\": [\n"
               + "        {\n"
@@ -489,7 +511,7 @@ public class GnmiSetITTest extends GnmiITBase {
               + "}";
     }
 
-    private String getInterfaceContainerListBody(final String name) {
+    private static String getInterfaceContainerListBody(final String name) {
         return String.format("{\n"
               + "  \"openconfig-interfaces:interfaces\": {\n"
               + "    \"interface\": [\n"
@@ -508,7 +530,7 @@ public class GnmiSetITTest extends GnmiITBase {
               + "}", name);
     }
 
-    private String getSimpleListData(final String keyId) {
+    private static String getSimpleListData(final String keyId) {
         return String.format("{\n"
               + "  \"gnmi-test-model:test-list\": [\n"
               + "    {\n"
@@ -518,7 +540,7 @@ public class GnmiSetITTest extends GnmiITBase {
               + "}", keyId);
     }
 
-    private String getSimpleListEntryResultData() {
+    private static String getSimpleListEntryResultData() {
         return "{\n"
                 + "    \"gnmi-test-model:test-data\" : {\n"
                 + "        \"test-list\" : [\n"
@@ -533,7 +555,7 @@ public class GnmiSetITTest extends GnmiITBase {
                 + "}";
     }
 
-    private String getNewListInContainerData() {
+    private static String getNewListInContainerData() {
         return "{\n"
               + "    \"gnmi-test-model:test-data\" : {\n"
               + "        \"test-list\" : [\n"
@@ -548,7 +570,7 @@ public class GnmiSetITTest extends GnmiITBase {
               + "}";
     }
 
-    private String getUpdateListInContainerData() {
+    private static String getUpdateListInContainerData() {
         return "{\n"
               + "    \"gnmi-test-model:test-data\" : {\n"
               + "        \"test-list\" : [\n"
@@ -563,7 +585,7 @@ public class GnmiSetITTest extends GnmiITBase {
               + "}";
     }
 
-    private String getUpdatedListInContainerResultData() {
+    private static String getUpdatedListInContainerResultData() {
         return "{\n"
               + "    \"gnmi-test-model:test-data\" : {\n"
               + "        \"test-list\" : [\n"
@@ -581,7 +603,7 @@ public class GnmiSetITTest extends GnmiITBase {
               + "}";
     }
 
-    private String getInterfaceListUpdateResponse(final String firstNameId, final String secondNameId) {
+    private static String getInterfaceListUpdateResponse(final String firstNameId, final String secondNameId) {
         return String.format("{\n"
               + "    \"openconfig-interfaces:interfaces\": {\n"
               + "        \"interface\": [\n"
@@ -608,5 +630,28 @@ public class GnmiSetITTest extends GnmiITBase {
               + "        ]\n"
               + "    }\n"
               + "}", firstNameId, secondNameId);
+    }
+
+    private static String getAugmentedTestInterfaceBody() {
+        return "{\n"
+                + "    \"gnmi-test-aug:interface\": [\n"
+                + "        {\n"
+                + "            \"name\": \"eth10\",\n"
+                + "            \"config\": {\n"
+                + "                \"mtu\": 1550,\n"
+                + "                \"type\": \"iana-if-type:l2vlan\",\n"
+                + "                \"name\": \"Vlan10\"\n"
+                + "            }\n"
+                + "        }\n"
+                + "    ]\n"
+                + "}";
+    }
+
+    private static String getAugmentedDataBody() {
+        return "{\n"
+                + "    \"gnmi-test-model:augmented-container\": {\n"
+                + "        \"augmented-data\": \"data\"\n"
+                + "    }\n"
+                + "}";
     }
 }

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/resources/additional/models/gnmi-test-aug.yang
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/resources/additional/models/gnmi-test-aug.yang
@@ -1,0 +1,39 @@
+module gnmi-test-aug {
+
+  yang-version "1";
+  namespace "test:aug";
+  prefix "gta";
+
+  import openconfig-extensions { prefix oc-ext; }
+  import gnmi-test-model {prefix gtm;}
+
+  oc-ext:openconfig-version "1.0.0";
+
+  augment /gtm:test-data {
+    leaf interface {
+      type string;
+    }
+  }
+
+  augment "/gtm:test-data/gtm:nested-container" {
+    list interface {
+      key "name";
+      description
+        "The list of named interfaces on the device.";
+      leaf name {
+        type string;
+      }
+      container config {
+        leaf name {
+          type string;
+        }
+        leaf type {
+          type string;
+        }
+        leaf mtu {
+          type uint16;
+        }
+      }
+    }
+  }
+}

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/resources/additional/models/gnmi-test-model.yang
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/resources/additional/models/gnmi-test-model.yang
@@ -19,6 +19,11 @@ module gnmi-test-model {
             type string;
         }
     }
+    container nested-container {
+        leaf nc-leaf {
+            type string;
+        }
+    }
   }
 
   list base-list {
@@ -30,6 +35,14 @@ module gnmi-test-model {
       list nested-list {
           key nested-list-key;
           leaf nested-list-key {
+              type string;
+          }
+      }
+  }
+
+  augment /test-data {
+      container augmented-container {
+          leaf augmented-data {
               type string;
           }
       }

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/resources/json/simulator_config.json
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/resources/json/simulator_config.json
@@ -1,5 +1,6 @@
 {
   "gnmi_simulator": {
+    "yangsPath": "src/test/resources/additional/models",
     "schemaServiceConfig": {
       "topLevelModels": [
         { "nameSpace":"http://openconfig.net/yang/aaa","name":"openconfig-aaa","revision":"2020-07-30"},


### PR DESCRIPTION
1) If in schemacontext is present, augmentation node with same name as searched node. It will find first augmentation node instead of searched node. For example, if in gNMI is sent update request
```bash
update {
  path {
    elem {
      name: "openconfig-interfaces:interfaces"
    }
    elem {
      name: "interface"
      key {
        key: "name"
        value: "eth5"
      }
    }
  }
  ```
  It will convert it to YangInstanceIdentifier:
  `/(http://openconfig.net/yang/interfaces?revision=2021-04-06)interfaces/AugmentationIdentifier{childNames=[(test:aug)interface]}/(test:aug)interface/(http://openconfig.net/yang/interfaces?revision=2021-04-06)interfaces[{(http://openconfig.net/yang/interfaces?revision=2021-04-06)name=eth5}]`
  
 2) When is creating path for YangInstanceIdentifier and list is augmented, it will set wrong namespace to key nodes in predicates:
 ```
 2 = {YangInstanceIdentifier$AugmentationIdentifier@9754} "AugmentationIdentifier{childNames=[(test:aug)interface]}"
3 = {YangInstanceIdentifier$NodeIdentifier@9755} "(test:aug)interface"
4 = {YangInstanceIdentifier$NodeIdentifierWithPredicates$Singleton@9746} "(test:model)nested-container[{(test:model)name=eth5}]"
```

3) If in gNMI is updating augmented node than DataConverter create NormalizedNode wrapped with ImmutableAugmentationNode container. This will not match with the provided YangInstanceIdentifier which will point to the actual node. So YangInstanceIdentifier will look like:
`/(test:model)test-data/nested-container/AugmentationIdentifier{childNames=[(test:aug)interface]}/(test:aug)interface`

ID: 1779