### PR TITLE
Bump third-party dependencies

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
@@ -54,6 +54,7 @@ public class RcGnmiAppModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(RcGnmiAppModule.class);
     private static final TimeUnit DEFAULT_LIGHTY_MODULE_TIME_UNIT = TimeUnit.SECONDS;
+    private static final SecureRandom RANDOM = new SecureRandom();
 
     private final int lightyModuleTimeout;
     private final RcGnmiAppConfiguration appModuleConfig;
@@ -226,9 +227,8 @@ public class RcGnmiAppModule {
     }
 
     private AaaEncryptServiceConfig getDefaultAaaEncryptServiceConfig() {
-        final SecureRandom random = new SecureRandom();
         final byte[] bytes = new byte[16];
-        random.nextBytes(bytes);
+        RANDOM.nextBytes(bytes);
         final String salt = new String(Base64.getEncoder().encode(bytes), StandardCharsets.UTF_8);
         return new AaaEncryptServiceConfigBuilder().setEncryptKey("V1S1ED4OMeEh")
                 .setPasswordLength(12).setEncryptSalt(salt)

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/RncRestConfConfiguration.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/config/RncRestConfConfiguration.java
@@ -29,7 +29,7 @@ public class RncRestConfConfiguration extends RestConfConfiguration {
     public RncRestConfConfiguration() {
         super();
         // by default listen on any IP address (0.0.0.0) not only on loopback
-        this.setInetAddress(new InetSocketAddress(this.getHttpPort()).getAddress());
+        this.setInetAddress(new InetSocketAddress(super.getHttpPort()).getAddress());
     }
 
     public RncRestConfConfiguration(final RncRestConfConfiguration rncRestConfConfiguration) {

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -116,7 +116,7 @@
             <dependency>
                 <groupId>com.beust</groupId>
                 <artifactId>jcommander</artifactId>
-                <version>1.78</version>
+                <version>1.82</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -127,7 +127,7 @@
             <dependency>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-annotations</artifactId>
-                <version>3.1.12</version>
+                <version>4.5.3</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
@@ -145,12 +145,12 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.8.0</version>
+                <version>2.11.0</version>
             </dependency>
             <dependency>
                 <groupId>org.awaitility</groupId>
                 <artifactId>awaitility</artifactId>
-                <version>4.0.3</version>
+                <version>4.2.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -161,77 +161,77 @@
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-remote_2.13</artifactId>
-                <version>2.6.16</version>
+                <version>2.6.19</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-slf4j_2.13</artifactId>
-                <version>2.6.16</version>
+                <version>2.6.19</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-cluster_2.13</artifactId>
-                <version>2.6.16</version>
+                <version>2.6.19</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-discovery_2.13</artifactId>
-                <version>2.6.16</version>
+                <version>2.6.19</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-protobuf_2.13</artifactId>
-                <version>2.6.16</version>
+                <version>2.6.19</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-coordination_2.13</artifactId>
-                <version>2.6.16</version>
+                <version>2.6.19</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-distributed-data_2.13</artifactId>
-                <version>2.6.16</version>
+                <version>2.6.19</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-cluster-tools_2.13</artifactId>
-                <version>2.6.16</version>
+                <version>2.6.19</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-cluster-sharding_2.13</artifactId>
-                <version>2.6.16</version>
+                <version>2.6.19</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-actor_2.13</artifactId>
-                <version>2.6.16</version>
+                <version>2.6.19</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-stream_2.13</artifactId>
-                <version>2.6.16</version>
+                <version>2.6.19</version>
             </dependency>
             <dependency>
                 <groupId>com.lightbend.akka.management</groupId>
                 <artifactId>akka-management_2.13</artifactId>
-                <version>1.0.10</version>
+                <version>1.1.3</version>
             </dependency>
             <dependency>
                 <groupId>com.lightbend.akka.management</groupId>
                 <artifactId>akka-management-cluster-http_2.13</artifactId>
-                <version>1.0.10</version>
+                <version>1.1.3</version>
             </dependency>
             <dependency>
                 <groupId>com.lightbend.akka.management</groupId>
                 <artifactId>akka-management-cluster-bootstrap_2.13</artifactId>
-                <version>1.0.10</version>
+                <version>1.1.3</version>
             </dependency>
             <dependency>
                 <groupId>com.lightbend.akka.discovery</groupId>
                 <artifactId>akka-discovery-kubernetes-api_2.13</artifactId>
-                <version>1.0.10</version>
+                <version>1.1.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/lighty-core/lighty-bom/pom.xml
+++ b/lighty-core/lighty-bom/pom.xml
@@ -249,7 +249,7 @@
                       <plugin>
                           <groupId>org.apache.maven.plugins</groupId>
                           <artifactId>maven-gpg-plugin</artifactId>
-                          <version>1.6</version>
+                          <version>3.0.1</version>
                           <executions>
                               <execution>
                                   <id>sign-artifacts</id>

--- a/lighty-core/lighty-clustering/src/main/java/io/lighty/core/cluster/kubernetes/MemberRemovedListener.java
+++ b/lighty-core/lighty-clustering/src/main/java/io/lighty/core/cluster/kubernetes/MemberRemovedListener.java
@@ -27,11 +27,12 @@ public class MemberRemovedListener extends AbstractActor {
 
     private static final Logger LOG = LoggerFactory.getLogger(MemberRemovedListener.class);
 
-    private final Cluster cluster = Cluster.get(getContext().getSystem());
+    private final Cluster cluster;
     private final ClusterAdminService clusterAdminRPCService;
 
     public MemberRemovedListener(final ClusterAdminService clusterAdminRPCService) {
         LOG.info("{} created", this.getClass());
+        this.cluster = Cluster.get(super.getContext().getSystem());
         this.clusterAdminRPCService = clusterAdminRPCService;
     }
 

--- a/lighty-core/lighty-minimal-parent/pom.xml
+++ b/lighty-core/lighty-minimal-parent/pom.xml
@@ -48,7 +48,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M2</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>
@@ -76,7 +76,7 @@
                       <plugin>
                           <groupId>org.apache.maven.plugins</groupId>
                           <artifactId>maven-gpg-plugin</artifactId>
-                          <version>1.6</version>
+                          <version>3.0.1</version>
                           <executions>
                               <execution>
                                   <id>sign-artifacts</id>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -105,7 +105,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.7</version>
+                    <version>0.8.8</version>
                     <executions>
                         <execution>
                             <id>jacoco-prepare-agent</id>
@@ -164,12 +164,12 @@
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
                             <!-- This should match the dependency management on com.puppycrawl.tools:checkstyle above -->
-                            <version>8.45.1</version>
+                            <version>9.2.1</version>
                         </dependency>
                         <dependency>
                             <groupId>com.github.sevntu-checkstyle</groupId>
                             <artifactId>sevntu-checks</artifactId>
-                            <version>1.40.0</version>
+                            <version>1.41.0</version>
                         </dependency>
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
@@ -181,12 +181,12 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>3.1.12.2</version>
+                    <version>4.5.3.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.github.spotbugs</groupId>
                             <artifactId>spotbugs</artifactId>
-                            <version>3.1.12</version>
+                            <version>4.5.3</version>
                         </dependency>
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
@@ -194,10 +194,10 @@
                             <version>10.0.0</version>
                         </dependency>
                         <dependency>
-                            <!-- The SpotBugs Maven plugin uses SLF4J 1.8 beta 2 -->
+                            <!-- The SpotBugs Maven plugin uses SLF4J 1.8 beta 4 -->
                             <groupId>org.slf4j</groupId>
                             <artifactId>slf4j-simple</artifactId>
-                            <version>1.8.0-beta2</version>
+                            <version>1.8.0-beta4</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -265,7 +265,7 @@
                                 <plugin>
                                     <groupId>jp.skypencil.findbugs.slf4j</groupId>
                                     <artifactId>bug-pattern</artifactId>
-                                    <version>1.4.2</version>
+                                    <version>1.5.0</version>
                                 </plugin>
                             </plugins>
                             <!--

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -50,12 +50,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.10.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -137,12 +137,12 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.4.0</version>
                     <configuration combine.children="append">
                         <!-- Keep things quiet except for warnings/errors -->
                         <quiet>true</quiet>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
@@ -95,4 +95,21 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>source-quality</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/device/connection/ConfigurableParameters.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/device/connection/ConfigurableParameters.java
@@ -10,6 +10,7 @@ package io.lighty.gnmi.southbound.device.connection;
 
 import gnmi.Gnmi;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.force.capabilities.rev210702.ForceCapabilities;
@@ -65,7 +66,7 @@ public class ConfigurableParameters {
             return Optional.of(forceCapabilities.getForceCapability()
                 .entrySet()
                 .stream()
-                .map(model -> model.getValue())
+                .map(Entry::getValue)
                 .map(model -> Gnmi.ModelData.newBuilder()
                     .setName(model.getName())
                     .setVersion(model.getVersion().getValue()).build())

--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/util/NetconfConfigUtils.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/util/NetconfConfigUtils.java
@@ -70,6 +70,7 @@ public final class NetconfConfigUtils {
                     .$YangModuleInfoImpl.getInstance()
     );
     private static final Logger LOG = LoggerFactory.getLogger(NetconfConfigUtils.class);
+    private static final SecureRandom RANDOM = new SecureRandom();
 
     private NetconfConfigUtils() {
     }
@@ -157,9 +158,8 @@ public final class NetconfConfigUtils {
      * @return default configuration.
      */
     public static AaaEncryptServiceConfig getDefaultAaaEncryptServiceConfig() {
-        final SecureRandom random = new SecureRandom();
         final byte[] bytes = new byte[16];
-        random.nextBytes(bytes);
+        RANDOM.nextBytes(bytes);
         final String salt = new String(Base64.getEncoder().encode(bytes), StandardCharsets.UTF_8);
         return new AaaEncryptServiceConfigBuilder().setEncryptKey("V1S1ED4OMeEh")
                 .setPasswordLength(12).setEncryptSalt(salt)


### PR DESCRIPTION
Bump third-party dependencies to the same version as odlparent use:
https://github.com/opendaylight/odlparent/blob/v10.0.0/odlparent/pom.xml

- org.jacoco.jacoco-maven-plugin                        0.8.7 -> 0.8.8
- maven-checkstyle-plugin
   - com.puppycrawl.tools.checkstyle                    8.45.1 -> 9.2.1
   - com.github.sevntu-checkstyle.sevntu-checks 1.40.0 -> 1.41.0
- com.github.spotbugs.spotbugs-maven-plugin  3.1.12.2 -> 4.5.3.0
   - com.github.spotbug.spotbugs                        3.1.12 -> 4.5.3
   - org.slf4j.slf4j-simple                                        1.8.0-beta2 -> 1.8.0-beta4
- jp.skypencil.findbugs.slf4j.bug-pattern              1.4.2 -> 1.5.0

Bump other third-party dependencies to the latest version

- com.beust.jcommander 1.78 -> 1.82
- com.github.spotbugs.spotbugs-annotations 3.1.12 -> 4.5.3
- commons-io.commons-io 2.8.0 -> 2.11.0
- org.awaitility.awaitility 4.0.3 -> 4.2.0
- org.codehaus.mojo.build-helper-maven-plugin 3.2.0 -> 3.3.0
- org.apache.maven.plugins.maven-gpg-plugin 1.6 -> 3.0.1
- org.apache.maven.plugins.maven-enforcer-plugin 3.0.0-M2 -> 3.0.0
- org.apache.maven.plugins.maven-compiler-plugin 3.8.1 -> 3.10.1
- org.apache.maven.plugins.maven-clean-plugin 3.1.0 -> 3.2.0
- org.apache.maven.plugins.maven-javadoc-plugin 3.1.1 -> 3.4.0
- com.typesafe.akka 2.6.16 -> 2.6.19
- com.lightbend.akka.management 1.0.10 -> 1.1.3

Resolve new bugs found After increasing versions of spotbugs-maven-plugin: DMI_RANDOM_USED_ONLY_ONCE,
MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR

Skip spotbugs-maven-plugin check in gnmi-proto