### PR TITLE
Update required maven version

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ _This branch maintains compatibility with __OpenDaylight Silicon,__ release._
 ## Build & Install
 In order to build and install lighty.io artifacts locally, follow the steps below:
 1. __Install JDK__ - make sure [JDK 11](https://jdk.java.net/11/) is installed
-2. __Install maven__ - make sure you have maven 3.6.3 or later installed
+2. __Install maven__ - make sure you have maven 3.8.3 or later installed
 3. __Setup maven__ - make sure you have the proper [settings.xml](https://github.com/opendaylight/odlparent/blob/master/settings.xml) in your ```~/.m2``` directory
 4. __Build & Install locally__ - by running command: ``mvn clean install -DskipTests``
 

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/README.md
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/README.md
@@ -12,7 +12,7 @@ A lighty.io application, which starts and wires the following components:
 ## Prerequisites
 In order to build & start the RCgNMI application locally, you need:
 * Java 11 (or later)
-* Maven 3.5.4 (or later)
+* Maven 3.8.3 (or later)
 
 ## Build & Start
 To build and start the RCgNMI application in your local environment, follow these steps:

--- a/lighty-applications/lighty-rnc-app-aggregator/README.md
+++ b/lighty-applications/lighty-rnc-app-aggregator/README.md
@@ -19,7 +19,7 @@ Most important lighty.io components used are:
 ## Prerequisites
 In order to build and start the lighty.io RNC application locally, you need:
 * Java 11 or later 
-* maven 3.5.4 or later
+* Maven 3.8.3 or later
 * (Optional) Docker for creating and running Docker images
 
 ## Build and start

--- a/lighty-core/lighty-minimal-parent/pom.xml
+++ b/lighty-core/lighty-minimal-parent/pom.xml
@@ -58,7 +58,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>3.5.0</version>
+                                    <version>3.8.3</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>

--- a/lighty-examples/lighty-bgp-community-restconf-app/README.md
+++ b/lighty-examples/lighty-bgp-community-restconf-app/README.md
@@ -9,7 +9,7 @@ Application starts the following components:
 
 In order to build and start the application locally, you need:
 * Java 11 or later 
-* maven 3.5.4 or later
+* Maven 3.8.3 or later
 
 ## Build
 

--- a/lighty-examples/lighty-gnmi-community-restconf-app/README.md
+++ b/lighty-examples/lighty-gnmi-community-restconf-app/README.md
@@ -21,7 +21,7 @@ This application starts:
 ## Prerequisites
 In order to build and start and run this example, the lighty.io gNMI/RESTCONF application locally, you need:
 * Java 11 or later
-* Maven 3.5.4 or later
+* Maven 3.8.3 or later
 * Postman v7.36.5. or later
 * Linux-based system with bash
 


### PR DESCRIPTION
Since ODL Sulfur (16) odlparent requires maven version 3.8.3.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>