### PR TITLE
Fix reported CVE-2020-36518 & CVE-2022-2048 issues

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -23,6 +23,16 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <!-- Override odlparent version to fix: https://www.cve.org/CVERecord?id=CVE-2020-36518
+                     Remove when this will be fixed in upstream -->
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.13.3</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
                 <version>10.0.2</version>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -31,6 +31,15 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <!-- Override odlparent version to fix: https://www.cve.org/CVERecord?id=CVE-2022-2048
+                     Remove when this will be fixed in upstream -->
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-bom</artifactId>
+                <version>9.4.47.v20220610</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
 
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>


### PR DESCRIPTION
Override version dependency management from ODL for
Jackson-bom and jetty-bom to fix CVE-2020-36518, CVE-2022-2048