### PR TITLE
Bump jetty to 9.4.48.v20220622

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -36,7 +36,7 @@
                      Remove when this will be fixed in upstream -->
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-bom</artifactId>
-                <version>9.4.47.v20220610</version>
+                <version>9.4.48.v20220622</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Bump jetty to 9.4.48.v20220622 [critical fix], see:
https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.48.v20220622

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>