### PR TITLE
Bump jsonassert to 1.5.1

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -139,6 +139,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.skyscreamer</groupId>
+                <artifactId>jsonassert</artifactId>
+                <version>1.5.1</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.fusesource.leveldbjni</groupId>
                 <artifactId>leveldbjni-all</artifactId>
                 <version>1.8</version>


### PR DESCRIPTION
Declare jsonassert version in our project directly
as it is no more managed by ODL upstreams.

Bump it to version 1.5.1.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>