### PR TITLE
Add smoke test to Https RNC app

### DIFF
--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/java/io/lighty/applications/rnc/module/RncLightyModuleSmokeTest.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/java/io/lighty/applications/rnc/module/RncLightyModuleSmokeTest.java
@@ -28,6 +28,15 @@ public class RncLightyModuleSmokeTest {
     }
 
     @Test
+    public void rncLightyModuleHttpsSmokeTest() throws Exception {
+        final var rncLightyModuleConfiguration = RncLightyModuleConfigUtils.loadDefaultConfig();
+        rncLightyModuleConfiguration.getServerConfig().setUseHttps(true);
+        final var rncModule = new RncLightyModule(rncLightyModuleConfiguration, MODULE_TIMEOUT);
+        rncModule.initModules();
+        rncModule.close();
+    }
+
+    @Test
     public void rncLightyModuleStartFailed() throws ConfigurationException {
         final RncLightyModuleConfiguration config = spy(RncLightyModuleConfigUtils.loadDefaultConfig());
         when(config.getControllerConfig()).thenReturn(null);


### PR DESCRIPTION
add smoke test to initialize RNC application with enabled
https server

Signed-off-by: Peter Suna <peter.suna@pantheon.tech>