### PR TITLE
Remove deprecated SemVer methods from gNMI

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/gnmi/GnmiCapabilitiesService.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/gnmi/GnmiCapabilitiesService.java
@@ -13,7 +13,10 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import org.eclipse.jdt.annotation.Nullable;
+import org.opendaylight.yangtools.concepts.SemVer;
+import org.opendaylight.yangtools.openconfig.model.api.OpenConfigVersionEffectiveStatement;
 import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
 import org.opendaylight.yangtools.yang.model.api.Module;
 import org.slf4j.Logger;
@@ -43,8 +46,10 @@ public class GnmiCapabilitiesService {
             final Gnmi.ModelData.Builder builder = Gnmi.ModelData.newBuilder()
                 .setOrganization(module.getOrganization().orElse("UNKNOWN-ORGANIZATION"))
                 .setName(module.getName());
-            if (module.getSemanticVersion().isPresent()) {
-                builder.setVersion(module.getSemanticVersion().get().toString());
+            final Optional<SemVer> optSemVer = module.asEffectiveStatement()
+                    .findFirstEffectiveSubstatementArgument(OpenConfigVersionEffectiveStatement.class);
+            if (optSemVer.isPresent()) {
+                builder.setVersion(optSemVer.get().toString());
             } else if (module.getRevision().isPresent()) {
                 builder.setVersion(module.getRevision().get().toString());
             }

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/schema/impl/SchemaContextHolderImpl.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/schema/impl/SchemaContextHolderImpl.java
@@ -177,8 +177,7 @@ public class SchemaContextHolderImpl implements SchemaContextHolder {
         for (ModuleImport moduleImport : dependencyInfo.getDependencies()) {
             if (!processedModuleNames.contains(moduleImport.getModuleName())) {
                 final GnmiDeviceCapability importedCapability = new GnmiDeviceCapability(moduleImport.getModuleName(),
-                        moduleImport.getSemanticVersion().orElse(null),
-                        moduleImport.getRevision().orElse(null));
+                        null, moduleImport.getRevision().orElse(null));
                 final Optional<GnmiYangModel> gnmiYangModel = tryToReadModel(importedCapability);
                 if (gnmiYangModel.isPresent()) {
                     models.add(gnmiYangModel.get());

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/schema/impl/SchemaContextHolderImpl.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/schema/impl/SchemaContextHolderImpl.java
@@ -31,12 +31,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.yang.storage.rev210331.gnmi.yang.models.GnmiYangModel;
-import org.opendaylight.yangtools.concepts.SemVer;
 import org.opendaylight.yangtools.yang.common.Revision;
 import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
 import org.opendaylight.yangtools.yang.model.api.ModuleImport;
 import org.opendaylight.yangtools.yang.model.repo.api.RevisionSourceIdentifier;
-import org.opendaylight.yangtools.yang.model.repo.api.SemVerSourceIdentifier;
 import org.opendaylight.yangtools.yang.model.repo.api.YangTextSchemaSource;
 import org.opendaylight.yangtools.yang.parser.api.YangSyntaxErrorException;
 import org.opendaylight.yangtools.yang.parser.rfc7950.repo.YangModelDependencyInfo;
@@ -230,10 +228,7 @@ public class SchemaContextHolderImpl implements SchemaContextHolder {
     }
 
     private YangTextSchemaSource makeTextSchemaSource(final GnmiYangModel model) {
-        if (model.getVersion().getValue().matches(SchemaConstants.SEMVER_REGEX)) {
-            return YangTextSchemaSource.delegateForByteSource(SemVerSourceIdentifier.create(model.getName(),
-                    SemVer.valueOf(model.getVersion().getValue())), bodyByteSource(model.getBody()));
-        } else if (model.getVersion().getValue().matches(SchemaConstants.REVISION_REGEX)) {
+        if (model.getVersion().getValue().matches(SchemaConstants.REVISION_REGEX)) {
             return YangTextSchemaSource.delegateForByteSource(RevisionSourceIdentifier.create(model.getName(),
                     Revision.of(model.getVersion().getValue())), bodyByteSource(model.getBody()));
         } else {


### PR DESCRIPTION
Get SemVer for gNMI models without using deprecated methods, which will be removed in next release.

ID: 1835