### PR TITLE
Add exec to entrypoint script

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/src/main/docker/entrypoint.sh
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/src/main/docker/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 echo "Starting RCgNMI lighty application"
-java $JAVA_OPTS -jar $@
+exec java $JAVA_OPTS -jar $@

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/src/main/docker/entrypoint.sh
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/src/main/docker/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 echo "Starting app"
-java $JAVA_OPTS -jar $@
+exec java $JAVA_OPTS -jar $@


### PR DESCRIPTION
Adding exec before java command in entrypoint script move application pid to 1 in docker container.

Solve `FAILED single_process_type` reported in issues:  #1048 #1047 

ID: 1839