### PR TITLE
16.x: Add liveness and readiness probe to RNC & RCgNMI app

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/deployment.yaml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/deployment.yaml
@@ -27,6 +27,14 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: {{ .Values.lighty.workdir }}/{{ .Values.lighty.configDirectoryName }}
+          readinessProbe:
+            httpGet:
+              path: /restconf/data/network-topology:network-topology
+              port: {{ .Values.lighty.restconf.restconfPort }}
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            failureThreshold: 3
+            timeoutSeconds: 1
           securityContext:
             allowPrivilegeEscalation: false
             runAsUser: {{ .Values.deploymentSecurity.runAsUser }}

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/deployment.yaml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/deployment.yaml
@@ -35,6 +35,14 @@ spec:
             periodSeconds: 15
             failureThreshold: 3
             timeoutSeconds: 1
+          livenessProbe:
+            httpGet:
+              path: /restconf/data/network-topology:network-topology
+              port: {{ .Values.lighty.restconf.restconfPort }}
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 3
+            timeoutSeconds: 1
           securityContext:
             allowPrivilegeEscalation: false
             runAsUser: {{ .Values.deploymentSecurity.runAsUser }}

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/deployment.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/deployment.yaml
@@ -29,6 +29,14 @@ spec:
               mountPath: {{ .Values.lighty.workdir }}/{{ .Values.lighty.configDirectoryName }}
             - name: secrets-volume
               mountPath: {{ .Values.lighty.workdir }}/{{ .Values.lighty.restconf.keyStoreDirectory }}
+          readinessProbe:
+            httpGet:
+              path: /restconf/data/network-topology:network-topology
+              port: {{ .Values.lighty.restconf.restconfPort }}
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            failureThreshold: 3
+            timeoutSeconds: 1
           securityContext:
             allowPrivilegeEscalation: false
             runAsUser: {{ .Values.deploymentSecurity.runAsUser }}

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/deployment.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/deployment.yaml
@@ -37,6 +37,14 @@ spec:
             periodSeconds: 15
             failureThreshold: 3
             timeoutSeconds: 1
+          livenessProbe:
+            httpGet:
+              path: /restconf/data/network-topology:network-topology
+              port: {{ .Values.lighty.restconf.restconfPort }}
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 3
+            timeoutSeconds: 1
           securityContext:
             allowPrivilegeEscalation: false
             runAsUser: {{ .Values.deploymentSecurity.runAsUser }}


### PR DESCRIPTION
Add readiness probe to check if RNC & RCgNMI app is ready to receive traffic.
Add liveness probe to RNC & RCgNMI app to check if app is healthy.

Solve FAILED liveness & FAILED readiness reported in issues: https://github.com/PANTHEONtech/lighty/issues/1048 https://github.com/PANTHEONtech/lighty/issues/1047

ID: 1840, 1841