### PR TITLE
Fix value added to set

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/schema/impl/SchemaContextHolderImpl.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/schema/impl/SchemaContextHolderImpl.java
@@ -186,7 +186,7 @@ public class SchemaContextHolderImpl implements SchemaContextHolder {
                 } else {
                     schemaException.addMissingModel(importedCapability);
                 }
-                processedModuleNames.add(moduleImport.getModuleName().toString());
+                processedModuleNames.add(moduleImport.getModuleName().getLocalName());
             }
         }
         return models;


### PR DESCRIPTION
The set processedModuleNames contains modules local names,
add local name instead of toString value.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>