### PR TITLE
Add Startup probe to RNC & RCgNMI helm

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/deployment.yaml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/deployment.yaml
@@ -27,11 +27,18 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: {{ .Values.lighty.workdir }}/{{ .Values.lighty.configDirectoryName }}
+          startupProbe:
+            httpGet:
+              path: /restconf/data/network-topology:network-topology
+              port: {{ .Values.lighty.restconf.restconfPort }}
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 20
+            timeoutSeconds: 1
           readinessProbe:
             httpGet:
               path: /restconf/data/network-topology:network-topology
               port: {{ .Values.lighty.restconf.restconfPort }}
-            initialDelaySeconds: 20
             periodSeconds: 15
             failureThreshold: 3
             timeoutSeconds: 1
@@ -39,7 +46,6 @@ spec:
             httpGet:
               path: /restconf/data/network-topology:network-topology
               port: {{ .Values.lighty.restconf.restconfPort }}
-            initialDelaySeconds: 30
             periodSeconds: 15
             failureThreshold: 3
             timeoutSeconds: 1

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/deployment.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/deployment.yaml
@@ -29,11 +29,18 @@ spec:
               mountPath: {{ .Values.lighty.workdir }}/{{ .Values.lighty.configDirectoryName }}
             - name: secrets-volume
               mountPath: {{ .Values.lighty.workdir }}/{{ .Values.lighty.server.keyStoreDirectory }}
+          startupProbe:
+            httpGet:
+              path: /restconf/data/network-topology:network-topology
+              port: {{ .Values.lighty.restconf.restconfPort }}
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 20
+            timeoutSeconds: 1
           readinessProbe:
             httpGet:
               path: /restconf/data/network-topology:network-topology
               port: {{ .Values.lighty.restconf.restconfPort }}
-            initialDelaySeconds: 20
             periodSeconds: 15
             failureThreshold: 3
             timeoutSeconds: 1
@@ -41,7 +48,6 @@ spec:
             httpGet:
               path: /restconf/data/network-topology:network-topology
               port: {{ .Values.lighty.restconf.restconfPort }}
-            initialDelaySeconds: 30
             periodSeconds: 15
             failureThreshold: 3
             timeoutSeconds: 1


### PR DESCRIPTION
Add startup probe which will validate if app is successfully started.
When the startup probe succeeds, liveness and readiness probe will start.
So no longer required to have initialDelay in those probes.

ID: 1858