### PR TITLE
Remove duplicate maven build in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,11 +38,9 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - name: Maven install (skip test)
-        run: mvn install -DskipTests=true -B -V -Psource-quality
       - name: Maven test + SonarCloud
         if: ${{ env.SONAR_TOKEN != 0 }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+        run: mvn verify -B -V -Psource-quality org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
           -Dsonar.java.source=1.11
           -Dsonar.projectKey=${{ env.SONAR_PROJECT_KEY }}
           -Dsonar.organization=${{ env.SONAR_ORGANIZATION }}
@@ -51,7 +49,7 @@ jobs:
           -Dsonar.coverage.exclusions=**/lighty-codecs/**/*
       - name: Maven test no SonarCloud
         if: ${{ env.SONAR_TOKEN == 0 }}
-        run: mvn -B verify
+        run: mvn verify -B -V -Psource-quality
       - name: Upload surefire test results
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Remove duplicate Maven build from build workflow. Running two builds, one without test and one with tests, takes longer time ~5 minutes plus.