### PR TITLE
Remove draft path from swagger

### DIFF
--- a/lighty-examples/lighty-community-restconf-actions-app/src/test/java/io/lighty/examples/controller/actions/RestconfActionsAppTest.java
+++ b/lighty-examples/lighty-community-restconf-actions-app/src/test/java/io/lighty/examples/controller/actions/RestconfActionsAppTest.java
@@ -68,7 +68,7 @@ public class RestconfActionsAppTest {
     @Test
     public void swaggerURLsTest() throws Exception {
         HttpResponse<String> operations;
-        operations = restClient.GET("apidoc/openapi3/18/apis/single");
+        operations = restClient.GET("apidoc/openapi3/apis/single");
         assertEquals(operations.statusCode(), 200);
         operations = restClient.GET("apidoc/explorer/index.html");
         assertEquals(operations.statusCode(), 200);

--- a/lighty-examples/lighty-community-restconf-netconf-app/src/test/java/io/lighty/examples/controllers/restconfapp/tests/RestconfAppTest.java
+++ b/lighty-examples/lighty-community-restconf-netconf-app/src/test/java/io/lighty/examples/controllers/restconfapp/tests/RestconfAppTest.java
@@ -61,7 +61,7 @@ public class RestconfAppTest {
     @Test
     public void swaggerURLsTest() throws IOException, InterruptedException {
         HttpResponse<String> operations;
-        operations = restClient.GET("apidoc/openapi3/18/apis/single");
+        operations = restClient.GET("apidoc/openapi3/apis/single");
         Assert.assertEquals(operations.statusCode(), 200);
         operations = restClient.GET("apidoc/explorer/index.html");
         Assert.assertEquals(operations.statusCode(), 200);

--- a/lighty-modules/lighty-swagger/src/main/java/io/lighty/swagger/SwaggerLighty.java
+++ b/lighty-modules/lighty-swagger/src/main/java/io/lighty/swagger/SwaggerLighty.java
@@ -79,8 +79,6 @@ public class SwaggerLighty extends AbstractLightyModule {
         ServletContextHandler mainHandler =   new ServletContextHandler(contexts, APIDOC_PATH, true, false);
         mainHandler.addServlet(restServletHolder, "/swagger2/apis/*");
         mainHandler.addServlet(restServletHolder, "/openapi3/apis/*");
-        mainHandler.addServlet(restServletHolder, "/swagger2/18/apis/*");
-        mainHandler.addServlet(restServletHolder, "/openapi3/18/apis/*");
 
         addStaticResources(mainHandler, "/explorer", "static-content");
 

--- a/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyRFC8040Test.java
+++ b/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyRFC8040Test.java
@@ -12,8 +12,8 @@ import org.testng.annotations.Test;
 
 public class SwaggerLightyRFC8040Test extends SwaggerLightyTest {
 
-    private static final String SWAGGER2_BASE_URI = "http://localhost:8888/apidoc/swagger2/18/apis";
-    private static final String OPENAPI3_BASE_URI = "http://localhost:8888/apidoc/openapi3/18/apis";
+    private static final String SWAGGER2_BASE_URI = "http://localhost:8888/apidoc/swagger2/apis";
+    private static final String OPENAPI3_BASE_URI = "http://localhost:8888/apidoc/openapi3/apis";
 
     @Test
     public void simpleSwaggerModuleTest() {


### PR DESCRIPTION
Remove no more needed RESTCONF draft 18 paths from
Lighty.io swagger UI.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>