### PR TITLE
(cherry-pick) Add instance-identifier-patch-module to default configuration

### DIFF
--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
@@ -38,6 +38,8 @@ public final class RestConfConfigUtils {
             org.opendaylight.yang.gen.v1.urn.sal.restconf.event.subscription.rev140708
                     .$YangModuleInfoImpl.getInstance(),
             org.opendaylight.yang.gen.v1.subscribe.to.notification.rev161028
+                    .$YangModuleInfoImpl.getInstance(),
+            org.opendaylight.yang.gen.v1.instance.identifier.patch.module.rev151121
                     .$YangModuleInfoImpl.getInstance()
             );
     public static final int MAXIMUM_FRAGMENT_LENGTH = 0;


### PR DESCRIPTION
Default configuration in lighty was missing instance-identifier-patch-module which was causing YANG Patch model to not work: https://github.com/PANTHEONtech/lighty/issues/533
