### PR TITLE
Bump iana-if-type model revision to 2021-06-21

### DIFF
--- a/lighty-examples/lighty-gnmi-community-restconf-app/example_config.json
+++ b/lighty-examples/lighty-gnmi-community-restconf-app/example_config.json
@@ -50,7 +50,7 @@
         ],
         "initialYangModels" : [
             {"name": "ietf-interfaces", "revision": "2018-02-20", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-interfaces"},
-            {"name": "iana-if-type", "revision": "2017-01-19", "nameSpace": "urn:ietf:params:xml:ns:yang:iana-if-type"},
+            {"name": "iana-if-type", "revision": "2021-06-21", "nameSpace": "urn:ietf:params:xml:ns:yang:iana-if-type"},
             {"name": "ietf-yang-types", "revision": "2013-07-15", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-types"}
         ]
     }

--- a/lighty-modules/lighty-netconf-sb/src/main/resources/sampleConfigCluster.json
+++ b/lighty-modules/lighty-netconf-sb/src/main/resources/sampleConfigCluster.json
@@ -17,7 +17,7 @@
         },
         "schemaServiceConfig":{
             "topLevelModels": [
-                { "usedBy":"CONTROLLER","name":"iana-if-type","revision":"2017-01-19","nameSpace":"urn:ietf:params:xml:ns:yang:iana-if-type"},
+                { "usedBy":"CONTROLLER","name":"iana-if-type","revision":"2021-06-21","nameSpace":"urn:ietf:params:xml:ns:yang:iana-if-type"},
                 { "usedBy":"CONTROLLER","name":"ietf-interfaces","revision":"2018-02-20","nameSpace":"urn:ietf:params:xml:ns:yang:ietf-interfaces"},
                 { "usedBy":"CONTROLLER","name":"ietf-yang-types","revision":"2013-07-15","nameSpace":"urn:ietf:params:xml:ns:yang:ietf-yang-types"},
                 { "usedBy":"CONTROLLER","name":"opendaylight-l2-types","revision":"2013-08-27","nameSpace":"urn:opendaylight:l2:types"},

--- a/lighty-modules/lighty-netconf-sb/src/main/resources/sampleConfigSingleNode.json
+++ b/lighty-modules/lighty-netconf-sb/src/main/resources/sampleConfigSingleNode.json
@@ -17,7 +17,7 @@
         },
         "schemaServiceConfig":{
             "topLevelModels": [
-                { "usedBy":"CONTROLLER","name":"iana-if-type","revision":"2017-01-19","nameSpace": "urn:ietf:params:xml:ns:yang:iana-if-type"},
+                { "usedBy":"CONTROLLER","name":"iana-if-type","revision":"2021-06-21","nameSpace": "urn:ietf:params:xml:ns:yang:iana-if-type"},
                 { "usedBy":"CONTROLLER","name":"ietf-interfaces","revision":"2018-02-20","nameSpace":"urn:ietf:params:xml:ns:yang:ietf-interfaces"},
                 { "usedBy":"CONTROLLER","name":"ietf-yang-types","revision":"2013-07-15","nameSpace":"urn:ietf:params:xml:ns:yang:ietf-yang-types"},
                 { "usedBy":"CONTROLLER","name":"opendaylight-l2-types","revision":"2013-08-27","nameSpace":"urn:opendaylight:l2:types"},

--- a/lighty-modules/lighty-netconf-sb/src/test/java/io/lighty/modules/southbound/netconf/tests/SampleConfigTest.java
+++ b/lighty-modules/lighty-netconf-sb/src/test/java/io/lighty/modules/southbound/netconf/tests/SampleConfigTest.java
@@ -33,7 +33,7 @@ public class SampleConfigTest {
                 .getEffectiveModelContext().getModules().size();
         assertTrue(lightyController.shutdown().get(TIME_OUT, TimeUnit.SECONDS));
 
-        assertEquals(loadedModulesSize, 15);
+        assertEquals(loadedModulesSize, 16);
     }
 
     @Test
@@ -45,7 +45,7 @@ public class SampleConfigTest {
                 .getEffectiveModelContext().getModules().size();
         assertTrue(lightyController.shutdown().get(TIME_OUT, TimeUnit.SECONDS));
 
-        assertEquals(loadedModulesSize, 16);
+        assertEquals(loadedModulesSize, 17);
     }
 
     private LightyController getLightyController(final String resource) throws Exception {


### PR DESCRIPTION
Fix iana-if-type model revision from 2017-01-19 to 2021-06-21 inside gNMI example JSON configuration since its prevent to connect gNMI device.
Fix other iana-if-type revision to newer version.
