### PR TITLE
Bump Netconf to 3.0.6

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -81,7 +81,7 @@
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>netconf-artifacts</artifactId>
-                <version>3.0.5</version>
+                <version>3.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Bump ODL Netconf to 3.0.6 since contain fixed issue: https://jira.opendaylight.org/browse/NETCONF-884

Signed-off-by: Peter Suna <peter.suna@pantheon.tech>