### PR TITLE
Bump third party dependencies

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -109,7 +109,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.35</version>
+                <version>2.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -193,11 +193,11 @@
                             <artifactId>spotbugs</artifactId>
                             <version>11.0.0</version>
                         </dependency>
+                        <!-- The SpotBugs Maven plugin uses SLF4J-2 -->
                         <dependency>
-                            <!-- The SpotBugs Maven plugin uses SLF4J 1.8 beta 4 -->
                             <groupId>org.slf4j</groupId>
                             <artifactId>slf4j-simple</artifactId>
-                            <version>1.8.0-beta4</version>
+                            <version>2.0.0</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -169,7 +169,7 @@
                         <dependency>
                             <groupId>com.github.sevntu-checkstyle</groupId>
                             <artifactId>sevntu-checks</artifactId>
-                            <version>1.41.0</version>
+                            <version>1.42.0</version>
                         </dependency>
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -196,6 +196,11 @@
                         <!-- The SpotBugs Maven plugin uses SLF4J-2 -->
                         <dependency>
                             <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-api</artifactId>
+                            <version>2.0.0</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.slf4j</groupId>
                             <artifactId>slf4j-simple</artifactId>
                             <version>2.0.0</version>
                         </dependency>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -164,7 +164,7 @@
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
                             <!-- This should match the dependency management on com.puppycrawl.tools:checkstyle above -->
-                            <version>9.2.1</version>
+                            <version>10.3.3</version>
                         </dependency>
                         <dependency>
                             <groupId>com.github.sevntu-checkstyle</groupId>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -186,7 +186,7 @@
                         <dependency>
                             <groupId>com.github.spotbugs</groupId>
                             <artifactId>spotbugs</artifactId>
-                            <version>4.5.3</version>
+                            <version>4.7.2</version>
                         </dependency>
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
@@ -23,7 +23,7 @@
 
     <properties>
         <protobuf.version>3.21.2</protobuf.version>
-        <grpc.version>1.47.0</grpc.version>
+        <grpc.version>1.49.1</grpc.version>
     </properties>
 
     <dependencies>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
@@ -22,7 +22,7 @@
     <version>17.0.0-SNAPSHOT</version>
 
     <properties>
-        <protobuf.version>3.21.2</protobuf.version>
+        <protobuf.version>3.21.6</protobuf.version>
         <grpc.version>1.49.1</grpc.version>
     </properties>
 

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/device/connection/ConfigurableParameters.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/device/connection/ConfigurableParameters.java
@@ -34,7 +34,7 @@ public class ConfigurableParameters {
             gnmiParameters = null;
             forceCapabilities = null;
         }
-        modelDataList = loadModelDataList();
+        modelDataList = loadModelDataList(forceCapabilities);
         useModelNamePrefix = loadUseModelNamePrefix();
         overwriteDataType = loadOverwriteDataType();
         pathTarget = loadPathTarget();
@@ -61,7 +61,7 @@ public class ConfigurableParameters {
         return Optional.empty();
     }
 
-    private Optional<List<Gnmi.ModelData>> loadModelDataList() {
+    private static Optional<List<Gnmi.ModelData>> loadModelDataList(final ForceCapabilities forceCapabilities) {
         if (forceCapabilities != null && forceCapabilities.getForceCapability() != null) {
             return Optional.of(forceCapabilities.getForceCapability()
                 .entrySet()


### PR DESCRIPTION
Bump com.puppycrawl.tools.checkstyle 9.2.1 -> 10.3.3
Bump com.github.sevntu-checkstyle.sevntu-checks 1.41.0 -> 1.42.0
Bump com.github.spotbugs.spotbugs 4.5.3 -> 4.7.2
Bump org.slf4j.slf4j-simple 1.8.0-beta4 -> 2.0.0
Bump org.slf4j.slf4j-api 1.7.35 -> 2.0.0
Bump io.grpc dependencies 1.47.0 -> 1.49.1
Bump com.google.protobuf dependencies 3.21.2 -> 3.21.6

[Add org.slf4j.slf4j-api to spotbugs-maven-plugin](https://github.com/PANTHEONtech/lighty/commit/7a9c8511ddd65ed3cf19d12315faefb483ced41d)
[Fix new bug found by spotbugs](https://github.com/PANTHEONtech/lighty/commit/eb84c93d000327b624f45aa40ecfa0248c3f97dc)

ID: 71