### PR TITLE
Add instance-identifier-patch-module to default configuration

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/configmaps.yaml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/configmaps.yaml
@@ -43,6 +43,7 @@ data:
             { "usedBy": "RESTCONF", "name": "sal-remote-augment", "revision": "2014-07-08", "nameSpace": "urn:sal:restconf:event:subscription"},
             { "usedBy": "RESTCONF", "name": "ietf-yang-library", "revision": "2019-01-04", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library"},
             { "usedBy": "RESTCONF", "name": "ietf-restconf", "revision": "2017-01-26", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-restconf"},
+            { "usedBy": "RESTCONF", "name": "instance-identifier-patch-module", "revision": "2015-11-21", "nameSpace": "instance:identifier:patch:module"},
             { "usedBy": "GNMI", "name": "gnmi-topology", "revision": "2021-03-16", "nameSpace": "urn:lighty:gnmi:topology"},
             { "usedBy": "GNMI", "name": "gnmi-yang-storage", "revision": "2021-03-31", "nameSpace": "urn:lighty:gnmi:yang:storage"},
             { "usedBy": "GNMI", "name": "gnmi-certificate-storage", "revision": "2021-05-04", "nameSpace": "urn:lighty:gnmi:certificate:storage"},

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/test/resources/config.json
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/test/resources/config.json
@@ -32,6 +32,7 @@
                 { "usedBy": "RESTCONF", "name": "subscribe-to-notification", "revision": "2016-10-28", "nameSpace": "subscribe:to:notification"},
                 { "usedBy": "RESTCONF", "name": "sal-remote-augment", "revision": "2014-07-08", "nameSpace": "urn:sal:restconf:event:subscription"},
                 { "usedBy": "RESTCONF", "name": "ietf-restconf", "revision": "2017-01-26", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-restconf"},
+                { "usedBy": "RESTCONF", "name": "instance-identifier-patch-module", "revision": "2015-11-21", "nameSpace": "instance:identifier:patch:module"},
                 { "usedBy": "GNMI", "name": "gnmi-topology", "revision": "2021-03-16", "nameSpace": "urn:lighty:gnmi:topology"},
                 { "usedBy": "GNMI", "name": "gnmi-yang-storage", "revision": "2021-03-31", "nameSpace": "urn:lighty:gnmi:yang:storage"},
                 { "usedBy": "GNMI", "name": "gnmi-certificate-storage", "revision": "2021-05-04", "nameSpace": "urn:lighty:gnmi:certificate:storage"},

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/resources/example-config/example_config.json
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/resources/example-config/example_config.json
@@ -36,6 +36,7 @@
                 { "usedBy": "RESTCONF", "name": "subscribe-to-notification", "revision": "2016-10-28", "nameSpace": "subscribe:to:notification"},
                 { "usedBy": "RESTCONF", "name": "sal-remote-augment", "revision": "2014-07-08", "nameSpace": "urn:sal:restconf:event:subscription"},
                 { "usedBy": "RESTCONF", "name": "ietf-restconf", "revision": "2017-01-26", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-restconf"},
+                { "usedBy": "RESTCONF", "name": "instance-identifier-patch-module", "revision": "2015-11-21", "nameSpace": "instance:identifier:patch:module"},
                 { "usedBy": "GNMI", "name": "gnmi-topology", "revision": "2021-03-16", "nameSpace": "urn:lighty:gnmi:topology"},
                 { "usedBy": "GNMI", "name": "gnmi-yang-storage", "revision": "2021-03-31", "nameSpace": "urn:lighty:gnmi:yang:storage"},
                 { "usedBy": "GNMI", "name": "gnmi-certificate-storage", "revision": "2021-05-04", "nameSpace": "urn:lighty:gnmi:certificate:storage"},

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/example-config/configuration.json
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/example-config/configuration.json
@@ -35,6 +35,7 @@
                 { "usedBy": "RESTCONF", "name": "subscribe-to-notification", "revision": "2016-10-28", "nameSpace": "subscribe:to:notification"},
                 { "usedBy": "RESTCONF", "name": "ietf-restconf", "revision": "2017-01-26", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-restconf"},
                 { "usedBy": "RESTCONF", "name": "sal-remote-augment", "revision": "2014-07-08", "nameSpace": "urn:sal:restconf:event:subscription"},
+                { "usedBy": "RESTCONF", "name": "instance-identifier-patch-module", "revision": "2015-11-21", "nameSpace": "instance:identifier:patch:module"},
                 { "usedBy": "RESTCONF/NETCONF", "name": "ietf-yang-library", "revision": "2019-01-04", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library"},
                 { "usedBy": "NETCONF", "name": "netconf-keystore", "revision": "2017-10-17", "nameSpace": "urn:opendaylight:netconf:keystore"},
                 { "usedBy": "NETCONF", "name": "netconf-node-topology", "revision": "2015-01-14", "nameSpace": "urn:opendaylight:netconf-node-topology"},

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/configmaps.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/configmaps.yaml
@@ -42,6 +42,7 @@ data:
                   { "usedBy": "RESTCONF", "name": "subscribe-to-notification", "revision": "2016-10-28", "nameSpace": "subscribe:to:notification"},
                   { "usedBy": "RESTCONF", "name": "sal-remote-augment", "revision": "2014-07-08", "nameSpace": "urn:sal:restconf:event:subscription"},
                   { "usedBy": "RESTCONF", "name": "ietf-restconf", "revision": "2017-01-26", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-restconf"},
+                  { "usedBy": "RESTCONF", "name": "instance-identifier-patch-module", "revision": "2015-11-21", "nameSpace": "instance:identifier:patch:module"},
                   { "usedBy": "RESTCONF/NETCONF", "name": "ietf-yang-library", "revision": "2019-01-04", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library"},
                   { "usedBy": "NETCONF", "name": "netconf-keystore", "revision": "2017-10-17", "nameSpace": "urn:opendaylight:netconf:keystore"},
                   { "usedBy": "NETCONF", "name": "netconf-node-topology", "revision": "2015-01-14", "nameSpace": "urn:opendaylight:netconf-node-topology"},

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/config.json
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/config.json
@@ -31,6 +31,7 @@
                 { "usedBy": "RESTCONF", "name": "sal-remote-augment", "revision": "2014-07-08", "nameSpace": "urn:sal:restconf:event:subscription"},
                 { "usedBy": "RESTCONF", "name": "ietf-restconf", "revision": "2017-01-26", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-restconf"},
                 { "usedBy": "RESTCONF", "name": "ietf-restconf-monitoring", "revision": "2017-01-26", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-restconf-monitoring"},
+                { "usedBy": "RESTCONF", "name": "instance-identifier-patch-module", "revision": "2015-11-21", "nameSpace": "instance:identifier:patch:module"},
                 { "usedBy": "RESTCONF/NETCONF", "name": "ietf-yang-library", "revision": "2019-01-04", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library"},
                 { "usedBy": "NETCONF", "name": "netconf-keystore", "revision": "2017-10-17", "nameSpace": "urn:opendaylight:netconf:keystore"},
                 { "usedBy": "NETCONF", "name": "netconf-node-topology", "revision": "2015-01-14", "nameSpace": "urn:opendaylight:netconf-node-topology"},

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/http2Config.json
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/http2Config.json
@@ -31,6 +31,7 @@
         { "usedBy": "RESTCONF", "name": "subscribe-to-notification", "revision": "2016-10-28", "nameSpace": "subscribe:to:notification"},
         { "usedBy": "RESTCONF", "name": "ietf-restconf", "revision": "2017-01-26", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-restconf"},
         { "usedBy": "RESTCONF", "name": "sal-remote-augment", "revision": "2014-07-08", "nameSpace": "urn:sal:restconf:event:subscription"},
+        { "usedBy": "RESTCONF", "name": "instance-identifier-patch-module", "revision": "2015-11-21", "nameSpace": "instance:identifier:patch:module"},
         { "usedBy": "RESTCONF/NETCONF", "name": "ietf-yang-library", "revision": "2019-01-04", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library"},
         { "usedBy": "NETCONF", "name": "netconf-keystore", "revision": "2017-10-17", "nameSpace": "urn:opendaylight:netconf:keystore"},
         { "usedBy": "NETCONF", "name": "netconf-node-topology", "revision": "2015-01-14", "nameSpace": "urn:opendaylight:netconf-node-topology"},

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/httpsConfig.json
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/httpsConfig.json
@@ -31,6 +31,7 @@
         { "usedBy": "RESTCONF", "name": "subscribe-to-notification", "revision": "2016-10-28", "nameSpace": "subscribe:to:notification"},
         { "usedBy": "RESTCONF", "name": "ietf-restconf", "revision": "2017-01-26", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-restconf"},
         { "usedBy": "RESTCONF", "name": "sal-remote-augment", "revision": "2014-07-08", "nameSpace": "urn:sal:restconf:event:subscription"},
+        { "usedBy": "RESTCONF", "name": "instance-identifier-patch-module", "revision": "2015-11-21", "nameSpace": "instance:identifier:patch:module"},
         { "usedBy": "RESTCONF/NETCONF", "name": "ietf-yang-library", "revision": "2019-01-04", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library"},
         { "usedBy": "NETCONF", "name": "netconf-keystore", "revision": "2017-10-17", "nameSpace": "urn:opendaylight:netconf:keystore"},
         { "usedBy": "NETCONF", "name": "netconf-node-topology", "revision": "2015-01-14", "nameSpace": "urn:opendaylight:netconf-node-topology"},

--- a/lighty-examples/lighty-community-aaa-restconf-app/src/main/assembly/resources/sampleConfigSingleNode.json
+++ b/lighty-examples/lighty-community-aaa-restconf-app/src/main/assembly/resources/sampleConfigSingleNode.json
@@ -36,6 +36,7 @@
                 { "usedBy":"RESTCONF","name":"sal-remote","revision":"2014-01-14","nameSpace":"urn:opendaylight:params:xml:ns:yang:controller:md:sal:remote"},
                 { "usedBy":"RESTCONF","name":"sal-remote-augment","revision":"2014-07-08","nameSpace":"urn:sal:restconf:event:subscription"},
                 { "usedBy":"RESTCONF","name":"subscribe-to-notification","revision":"2016-10-28","nameSpace":"subscribe:to:notification"},
+                { "usedBy":"RESTCONF", "name": "instance-identifier-patch-module", "revision": "2015-11-21", "nameSpace": "instance:identifier:patch:module"},
                 { "usedBy":"AAA","name":"aaa-cert-mdsal","revision":"2016-03-21","nameSpace":"urn:opendaylight:yang:aaa:cert:mdsal"},
                 { "usedBy":"AAA","name":"aaa","revision":"2016-12-14","nameSpace":"urn:opendaylight:params:xml:ns:yang:aaa"},
                 { "usedBy":"AAA","name":"aaa-encrypt-service-config","revision":"2016-09-15","nameSpace":"config:aaa:authn:encrypt:service:config"}

--- a/lighty-examples/lighty-community-aaa-restconf-app/src/test/resources/testConfig.json
+++ b/lighty-examples/lighty-community-aaa-restconf-app/src/test/resources/testConfig.json
@@ -36,6 +36,7 @@
                 { "usedBy":"RESTCONF","name":"sal-remote","revision":"2014-01-14","nameSpace":"urn:opendaylight:params:xml:ns:yang:controller:md:sal:remote"},
                 { "usedBy":"RESTCONF","name":"sal-remote-augment","revision":"2014-07-08","nameSpace":"urn:sal:restconf:event:subscription"},
                 { "usedBy":"RESTCONF","name":"subscribe-to-notification","revision":"2016-10-28","nameSpace":"subscribe:to:notification"},
+                { "usedBy":"RESTCONF", "name": "instance-identifier-patch-module", "revision": "2015-11-21", "nameSpace": "instance:identifier:patch:module"},
                 { "usedBy":"AAA","name":"aaa-cert-mdsal","revision":"2016-03-21","nameSpace":"urn:opendaylight:yang:aaa:cert:mdsal"},
                 { "usedBy":"AAA","name":"aaa","revision":"2016-12-14","nameSpace":"urn:opendaylight:params:xml:ns:yang:aaa"},
                 { "usedBy":"AAA","name":"aaa-encrypt-service-config","revision":"2016-09-15","nameSpace":"config:aaa:authn:encrypt:service:config"}

--- a/lighty-examples/lighty-community-restconf-actions-app/src/main/assembly/resources/sampleConfigSingleNode.json
+++ b/lighty-examples/lighty-community-restconf-actions-app/src/main/assembly/resources/sampleConfigSingleNode.json
@@ -36,6 +36,7 @@
                 { "usedBy":"RESTCONF","name":"sal-remote","revision":"2014-01-14","nameSpace":"urn:opendaylight:params:xml:ns:yang:controller:md:sal:remote"},
                 { "usedBy":"RESTCONF","name":"sal-remote-augment","revision":"2014-07-08","nameSpace":"urn:sal:restconf:event:subscription"},
                 { "usedBy":"RESTCONF","name":"subscribe-to-notification","revision":"2016-10-28","nameSpace":"subscribe:to:notification"},
+                { "usedBy":"RESTCONF", "name": "instance-identifier-patch-module", "revision": "2015-11-21", "nameSpace": "instance:identifier:patch:module"},
                 { "usedBy":"NETCONF","name":"netconf-keystore","revision":"2017-10-17","nameSpace":"urn:opendaylight:netconf:keystore"},
                 { "usedBy":"NETCONF","name":"netconf-node-topology","revision":"2015-01-14","nameSpace":"urn:opendaylight:netconf-node-topology"},
                 { "usedBy":"NETCONF","name":"netconf-node-optional","revision":"2019-06-14","nameSpace":"urn:opendaylight:netconf-node-optional"},

--- a/lighty-examples/lighty-community-restconf-netconf-app/src/main/assembly/resources/sampleConfigSingleNode.json
+++ b/lighty-examples/lighty-community-restconf-netconf-app/src/main/assembly/resources/sampleConfigSingleNode.json
@@ -36,6 +36,7 @@
                 { "usedBy":"RESTCONF","name":"sal-remote","revision":"2014-01-14","nameSpace":"urn:opendaylight:params:xml:ns:yang:controller:md:sal:remote"},
                 { "usedBy":"RESTCONF","name":"sal-remote-augment","revision":"2014-07-08","nameSpace":"urn:sal:restconf:event:subscription"},
                 { "usedBy":"RESTCONF","name":"subscribe-to-notification","revision":"2016-10-28","nameSpace":"subscribe:to:notification"},
+                { "usedBy":"RESTCONF", "name": "instance-identifier-patch-module", "revision": "2015-11-21", "nameSpace": "instance:identifier:patch:module"},
                 { "usedBy":"NETCONF","name":"netconf-keystore","revision":"2017-10-17","nameSpace":"urn:opendaylight:netconf:keystore"},
                 { "usedBy":"NETCONF","name":"netconf-node-topology","revision":"2015-01-14","nameSpace":"urn:opendaylight:netconf-node-topology"},
                 { "usedBy":"NETCONF","name":"netconf-node-optional","revision":"2019-06-14","nameSpace":"urn:opendaylight:netconf-node-optional"},

--- a/lighty-examples/lighty-gnmi-community-restconf-app/example_config.json
+++ b/lighty-examples/lighty-gnmi-community-restconf-app/example_config.json
@@ -31,6 +31,7 @@
                 { "usedBy": "RESTCONF", "name": "subscribe-to-notification", "revision": "2016-10-28", "nameSpace": "subscribe:to:notification"},
                 { "usedBy": "RESTCONF", "name": "sal-remote-augment", "revision": "2014-07-08", "nameSpace": "urn:sal:restconf:event:subscription"},
                 { "usedBy": "RESTCONF", "name": "ietf-restconf", "revision": "2017-01-26", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-restconf"},
+                { "usedBy": "RESTCONF", "name": "instance-identifier-patch-module", "revision": "2015-11-21", "nameSpace": "instance:identifier:patch:module"},
                 { "usedBy": "GNMI", "name": "gnmi-topology", "revision": "2021-03-16", "nameSpace": "urn:lighty:gnmi:topology"},
                 { "usedBy": "GNMI", "name": "gnmi-yang-storage", "revision": "2021-03-31", "nameSpace": "urn:lighty:gnmi:yang:storage"},
                 { "usedBy": "GNMI", "name": "gnmi-certificate-storage", "revision": "2021-05-04", "nameSpace": "urn:lighty:gnmi:certificate:storage"},

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/resources/json/app_init_config.json
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/resources/json/app_init_config.json
@@ -32,6 +32,7 @@
         { "usedBy": "RESTCONF", "name": "sal-remote-augment", "revision": "2014-07-08", "nameSpace": "urn:sal:restconf:event:subscription"},
         { "usedBy": "RESTCONF", "name": "ietf-yang-library", "revision": "2019-01-04", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library"},
         { "usedBy": "RESTCONF", "name": "ietf-restconf", "revision": "2017-01-26", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-restconf"},
+        { "usedBy": "RESTCONF", "name": "instance-identifier-patch-module", "revision": "2015-11-21", "nameSpace": "instance:identifier:patch:module"},
         { "usedBy": "GNMI", "name": "gnmi-topology", "revision": "2021-03-16", "nameSpace": "urn:lighty:gnmi:topology"},
         { "usedBy": "GNMI", "name": "gnmi-yang-storage", "revision": "2021-03-31", "nameSpace": "urn:lighty:gnmi:yang:storage"},
         { "usedBy": "GNMI", "name": "gnmi-certificate-storage", "revision": "2021-05-04", "nameSpace": "urn:lighty:gnmi:certificate:storage"},

--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
@@ -38,6 +38,8 @@ public final class RestConfConfigUtils {
             org.opendaylight.yang.gen.v1.urn.sal.restconf.event.subscription.rev140708
                     .$YangModuleInfoImpl.getInstance(),
             org.opendaylight.yang.gen.v1.subscribe.to.notification.rev161028
+                    .$YangModuleInfoImpl.getInstance(),
+            org.opendaylight.yang.gen.v1.instance.identifier.patch.module.rev151121
                     .$YangModuleInfoImpl.getInstance()
             );
     public static final int MAXIMUM_FRAGMENT_LENGTH = 0;


### PR DESCRIPTION
Default configuration in lighty was missing instance-identifier-patch-module which was causing YANG Patch model to not work: https://github.com/PANTHEONtech/lighty/issues/533

Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>