### PR TITLE
Use the latest maven plugin's transitive dependencies

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -109,12 +109,12 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>2.0.0</version>
+                <version>2.0.3</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-reload4j</artifactId>
-                <version>1.7.35</version>
+                <version>2.0.3</version>
             </dependency>
             <dependency>
                 <groupId>com.google.inject</groupId>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -152,7 +152,7 @@
             <dependency>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-annotations</artifactId>
-                <version>4.5.3</version>
+                <version>4.7.2</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -197,12 +197,12 @@
                         <dependency>
                             <groupId>org.slf4j</groupId>
                             <artifactId>slf4j-api</artifactId>
-                            <version>2.0.0</version>
+                            <version>2.0.3</version>
                         </dependency>
                         <dependency>
                             <groupId>org.slf4j</groupId>
                             <artifactId>slf4j-simple</artifactId>
-                            <version>2.0.0</version>
+                            <version>2.0.3</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -164,7 +164,7 @@
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
                             <!-- This should match the dependency management on com.puppycrawl.tools:checkstyle above -->
-                            <version>10.3.3</version>
+                            <version>10.3.4</version>
                         </dependency>
                         <dependency>
                             <groupId>com.github.sevntu-checkstyle</groupId>


### PR DESCRIPTION
Bump com.puppycrawl.tools from 10.3.3 to 10.3.4.
Bump org.slf4j from 2.0.0 to 2.0.3.