### PR TITLE
Draft: Fix Sonatype god classes report in every PR

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -1,4 +1,5 @@
 build = "maven"
 jdkVersion = "17"
 summaryComments = true
+disableTools = ["refactor-first"]
 


### PR DESCRIPTION
 Ignore since it reports lightyController as a God Class which
 could be false-positive.

Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>