### PR TITLE
Bump testng to 7.6.1

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -129,7 +129,7 @@
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>6.14.3</version>
+                <version>7.6.1</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Bump testng from version 6.14.3 to 7.6.1.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>