### PR TITLE
Align maven-gpg-plugin versions

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -275,7 +275,7 @@
                       <plugin>
                           <groupId>org.apache.maven.plugins</groupId>
                           <artifactId>maven-gpg-plugin</artifactId>
-                          <version>1.6</version>
+                          <version>3.0.1</version>
                           <executions>
                               <execution>
                                   <id>sign-artifacts</id>


### PR DESCRIPTION
Bump maven-gpg-plugin version to 3.0.1 in dependency-versions pom.xml to make it the same as used on other places in project.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit 751162b8fba08e87da02a70388f60d21c8dcb334)

Cherry-pick of https://github.com/PANTHEONtech/lighty/pull/1091