### PR TITLE
Remove unnecessary dependency overrides

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -23,15 +23,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <!-- Override odlparent version to fix: https://www.cve.org/CVERecord?id=CVE-2020-36518
-                     Remove when this will be fixed in upstream -->
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>2.13.3</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-            <dependency>
                 <!-- Override odlparent version to fix: https://www.cve.org/CVERecord?id=CVE-2022-2048
                      Remove when this will be fixed in upstream -->
                 <groupId>org.eclipse.jetty</groupId>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -36,7 +36,7 @@
                      Remove when this will be fixed in upstream -->
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-bom</artifactId>
-                <version>10.0.10</version>
+                <version>9.4.48.v20220622</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -23,16 +23,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <!-- Override odlparent version to fix: https://www.cve.org/CVERecord?id=CVE-2022-2048
-                     Remove when this will be fixed in upstream -->
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-bom</artifactId>
-                <version>9.4.48.v20220622</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-
-            <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
                 <version>11.0.1</version>

--- a/lighty-modules/lighty-jetty-server/src/main/java/io/lighty/server/LightyServerBuilder.java
+++ b/lighty-modules/lighty-jetty-server/src/main/java/io/lighty/server/LightyServerBuilder.java
@@ -138,7 +138,9 @@ public class LightyServerBuilder {
         this.filters.forEach((filterHolder, path) -> {
             ch.addFilter(filterHolder, path, EnumSet.of(DispatcherType.REQUEST));
         });
-        ch.setEventListeners(this.listeners);
+        EventListener[] array = new EventListener[this.listeners.size()];
+        array = this.listeners.toArray(array);
+        ch.setEventListeners(array);
         this.parameters.forEach(ch::setInitParameter);
     }
 }


### PR DESCRIPTION
Remove dependency overrides which are not needed any more because we are pulling fixed version from odlparent.

ID: 83