### PR TITLE
Remove thread sleeps from tests

### DIFF
--- a/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerTestBase.java
+++ b/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerTestBase.java
@@ -25,7 +25,6 @@ public abstract class LightyControllerTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(LightyControllerTestBase.class);
     public static final long SHUTDOWN_TIMEOUT_MILLIS = 60_000;
-    public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 1_000;
 
     private LightyController lightyController;
 
@@ -59,7 +58,6 @@ public abstract class LightyControllerTestBase {
             LOG.info("Shutting down Lighty controller");
             try {
                 lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-                Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (Exception e) {
                 LOG.error("Shutdown of LightyController failed", e);
             }

--- a/lighty-examples/lighty-community-restconf-netconf-app/src/test/java/io/lighty/examples/controllers/restconfapp/tests/RestconfAppTest.java
+++ b/lighty-examples/lighty-community-restconf-netconf-app/src/test/java/io/lighty/examples/controllers/restconfapp/tests/RestconfAppTest.java
@@ -29,7 +29,6 @@ import org.testng.annotations.Test;
 public class RestconfAppTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(RestconfAppTest.class);
-    public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 3_000;
 
     private static Main restconfApp;
     private static RestClient restClient;
@@ -73,7 +72,6 @@ public class RestconfAppTest {
         restconfApp.shutdown();
         try {
             restClient.close();
-            Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
         } catch (Exception e) {
             LOG.error("Shutdown of restClient failed", e);
         }

--- a/lighty-examples/lighty-controller-springboot-netconf/src/test/java/io/lighty/core/controller/springboot/test/SpringBootAppTest.java
+++ b/lighty-examples/lighty-controller-springboot-netconf/src/test/java/io/lighty/core/controller/springboot/test/SpringBootAppTest.java
@@ -35,7 +35,6 @@ import java.util.Arrays;
 public class SpringBootAppTest {
 
     final private static Logger LOG = LoggerFactory.getLogger(SpringBootAppTest.class);
-    public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 1_000;
 
     private static ConfigurableApplicationContext appContext;
     private static RestClient restClient;
@@ -105,7 +104,6 @@ public class SpringBootAppTest {
         if (restClient != null) {
             try {
                 restClient.close();
-                Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (Exception e) {
                 LOG.error("Shutdown of restClient failed", e);
             }

--- a/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/CallhomePluginTest.java
+++ b/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/CallhomePluginTest.java
@@ -34,7 +34,6 @@ public class CallhomePluginTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(CallhomePluginTest.class);
     public static final long SHUTDOWN_TIMEOUT_MILLIS = 60_000;
-    public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 3_000;
 
     private LightyController lightyController;
     private CommunityRestConf restConf;
@@ -67,7 +66,6 @@ public class CallhomePluginTest {
             LOG.info("Shutting down CommunityRestConf");
             try {
                 restConf.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-                Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (InterruptedException e) {
                 LOG.error("Interrupted while shutting down CommunityRestConf", e);
             } catch (TimeoutException e) {
@@ -80,7 +78,6 @@ public class CallhomePluginTest {
             LOG.info("Shutting down LightyController");
             try {
                 lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-                Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (Exception e) {
                 LOG.error("Shutdown of LightyController failed", e);
             }

--- a/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/TopologyPluginsTest.java
+++ b/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/TopologyPluginsTest.java
@@ -62,7 +62,6 @@ public class TopologyPluginsTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(TopologyPluginsTest.class);
     public static final long SHUTDOWN_TIMEOUT_MILLIS = 60_000;
-    public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 3_000;
 
     private LightyController lightyController;
     private CommunityRestConf restConf;
@@ -110,7 +109,6 @@ public class TopologyPluginsTest {
             LOG.info("Shutting down CommunityRestConf");
             try {
                 this.restConf.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-                Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (InterruptedException e) {
                 LOG.error("Interrupted while shutting down CommunityRestConf", e);
             } catch (TimeoutException e) {
@@ -123,7 +121,6 @@ public class TopologyPluginsTest {
             LOG.info("Shutting down LightyController");
             try {
                 this.lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-                Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (Exception e) {
                 LOG.error("Shutdown of LightyController failed", e);
             }

--- a/lighty-modules/lighty-restconf-nb-community/src/test/java/io/lighty/modules/northbound/restconf/community/impl/tests/CommunityRestConfTestBase.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/test/java/io/lighty/modules/northbound/restconf/community/impl/tests/CommunityRestConfTestBase.java
@@ -33,7 +33,6 @@ public abstract class CommunityRestConfTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(CommunityRestConfTestBase.class);
     public static final long SHUTDOWN_TIMEOUT_MILLIS = 60_000;
-    public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 3_000;
 
     private LightyController lightyController;
     private CommunityRestConf communityRestConf;
@@ -79,7 +78,6 @@ public abstract class CommunityRestConfTestBase {
             LOG.info("Shutting down CommunityRestConf");
             try {
                 communityRestConf.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-                Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (InterruptedException e) {
                 LOG.error("Interrupted while shutting down CommunityRestConf ", e);
             } catch (TimeoutException e) {
@@ -93,7 +91,6 @@ public abstract class CommunityRestConfTestBase {
             LOG.info("Shutting down LightyController");
             try {
                 lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS,TimeUnit.MILLISECONDS);
-                Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (Exception e) {
                 LOG.error("Shutdown of LightyController failed", e);
             }

--- a/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyTestBase.java
+++ b/lighty-modules/lighty-swagger/src/test/java/io/lighty/swagger/SwaggerLightyTestBase.java
@@ -35,7 +35,6 @@ public abstract class SwaggerLightyTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(SwaggerLightyTestBase.class);
     public static final long SHUTDOWN_TIMEOUT_MILLIS = 60_000;
-    public static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS = 3_000;
 
     private LightyController lightyController;
     private SwaggerLighty swaggerModule;
@@ -84,7 +83,6 @@ public abstract class SwaggerLightyTestBase {
             LOG.info("Shutting down Lighty Swagger");
             try {
                 swaggerModule.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-                Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
             } catch (InterruptedException e) {
                 LOG.error("Interrupted while shutting down Lighty Swagger", e);
             } catch (TimeoutException e) {
@@ -96,7 +94,6 @@ public abstract class SwaggerLightyTestBase {
                 LOG.info("Shutting down LightyController");
                 try {
                     lightyController.shutdown().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-                    Thread.sleep(SLEEP_AFTER_SHUTDOWN_TIMEOUT_MILLIS);
                 } catch (Exception e) {
                     LOG.error("Shutdown of LightyController failed", e);
                 }


### PR DESCRIPTION
Thread sleeps were added for sync after shutdown in: https://github.com/PANTHEONtech/lighty/pull/590/commits/76fdf5deefa8265acf55cc080e13a9b5beac3fba Since then, shutdown was fixed here so sleeps should not be needed: https://github.com/PANTHEONtech/lighty/commit/aa5879c8ca3304a25ac67899f49d31d4b6651c80

ID: 76