### PR TITLE
Remove unnecessary log4j2 path argument 

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/README.md
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/README.md
@@ -26,8 +26,8 @@ To build and start the RCgNMI application in your local environment, follow thes
 3. Start the application by running it's _.jar_ file:    
    `java -jar lighty-rcgnmi-app-<version>.jar`
 
-4. To start the application with a custom lighty.io configuration, use the argument _-c_ and for a custom initial log4j configuration, use argument _-l_:  
-   `java -jar lighty-rcgnmi-app-<version>.jar -c /path/to/config-file -l /path/to/log4j-config-file`  
+4. To start the application with a custom lighty.io configuration, use the argument _`-c`:
+   `java -jar lighty-rcgnmi-app-<version>.jar -c /path/to/config-file`
 
    To extend lighty modules time-out use `"modules": {"moduleTimeoutSeconds": SECONDS },` property inside JSON configuration. This property increases the time after which the exception is thrown if the module is not successfully initialized by then (Default 60).
    Example configuration files are located on following folder [example-config](lighty-rcgnmi-app/src/main/resources/example-config).
@@ -429,6 +429,12 @@ For example, if your initial json data contains node in gNMI topology:
 }
 ```
 and the gNMI device is running, the connection should be established upon startup. For testing purposes, you can use [lighty-gnmi-device-simulator](https://github.com/PANTHEONtech/lighty-netconf-simulator) as a gNMI device.
+
+## Setup Logging
+Default logging configuration may be overwritten by JVM option
+```-Dlog4j.configurationFile=path/to/log4j2.xml```
+
+Content of ```log4j2.xml``` is described [here](https://logging.apache.org/log4j/2.x/manual/configuration.html).
 
 ## Update logger with JMX
 Java Management Extensions is a tool enabled by default, which makes it easy to change the runtime

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/deployment.yaml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/deployment.yaml
@@ -21,8 +21,7 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.name }}:{{ .Values.image.version }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: [ "-c","{{ .Values.lighty.configDirectoryName }}/{{ .Values.lighty.configFilename }}",
-                  "-l","{{ .Values.lighty.configDirectoryName }}/{{ .Values.lighty.loggerConfigFilename }}"]
+          args: [ "-c","{{ .Values.lighty.configDirectoryName }}/{{ .Values.lighty.configFilename }}"]
           volumeMounts:
             - name: config-volume
               mountPath: {{ .Values.lighty.workdir }}/{{ .Values.lighty.configDirectoryName }}
@@ -68,10 +67,12 @@ spec:
                       -Dcom.sun.management.jmxremote.local.only=false
                       -Dcom.sun.management.jmxremote.port={{ .Values.lighty.jmx.jmxPort }}
                       -Dcom.sun.management.jmxremote.rmi.port={{ .Values.lighty.jmx.jmxPort }}
-                      -Djava.rmi.server.hostname=127.0.0.1"
+                      -Djava.rmi.server.hostname=127.0.0.1
+                      -Dlog4j.configurationFile={{ .Values.lighty.configDirectoryName }}/{{ .Values.lighty.loggerConfigFilename }}"
             {{ else }}
             - name: JAVA_OPTS
-              value: "-Dlog4j2.disable.jmx=true"
+              value: "-Dlog4j2.disable.jmx=true
+                      -Dlog4j.configurationFile={{ .Values.lighty.configDirectoryName }}/{{ .Values.lighty.loggerConfigFilename }}"
             {{- end }}
           ports:
             # akka remoting

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/Arguments.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/Arguments.java
@@ -16,15 +16,7 @@ public class Arguments {
             + " (If absent, the default will be used)")
     private String configPath;
 
-    @Parameter(names = {"-l", "--logger-config-path"}, description = "Path to custom xml log4j properties file. "
-            + " (If absent, will look on classpath for it")
-    private String loggerPath;
-
     public String getConfigPath() {
         return configPath;
-    }
-
-    public String getLoggerPath() {
-        return loggerPath;
     }
 }

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/RCgNMIApp.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/src/main/java/io/lighty/applications/rcgnmi/app/RCgNMIApp.java
@@ -17,12 +17,9 @@ import io.lighty.applications.rcgnmi.module.RcGnmiAppModuleConfigUtils;
 import io.lighty.core.common.models.YangModuleUtils;
 import io.lighty.core.controller.impl.config.ConfigurationException;
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.ExecutorService;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.LoggerContext;
 import org.eclipse.jdt.annotation.Nullable;
 import org.opendaylight.yangtools.util.concurrent.SpecialExecutors;
 import org.opendaylight.yangtools.yang.parser.stmt.reactor.CrossSourceStatementReactor;
@@ -58,11 +55,6 @@ public class RCgNMIApp {
                 .addObject(arguments)
                 .build()
                 .parse(args);
-        if (arguments.getLoggerPath() != null) {
-            LOG.debug("Argument for custom logging settings path is present: {} ", arguments.getLoggerPath());
-            ((LoggerContext) LogManager.getContext(false)).setConfigLocation(URI.create(arguments.getLoggerPath()));
-            LOG.info("Custom logger properties loaded successfully");
-        }
         try {
             if (arguments.getConfigPath() != null) {
                 final Path configPath = Paths.get(arguments.getConfigPath());

--- a/lighty-applications/lighty-rnc-app-aggregator/README.md
+++ b/lighty-applications/lighty-rnc-app-aggregator/README.md
@@ -34,8 +34,8 @@ To build and start the lighty.io RNC application in the local environment, follo
 3. Start the application by running it's _.jar_ file:  
    `java -jar lighty-rnc-app-<version>.jar`
    
-4. To start the application with custom lighty configuration, use arg -c and for custom initial log4j configuration use argument -l:  
-   `java -jar lighty-rnc-app-<version>.jar -c /path/to/config-file -l /path/to/log4j-config-file`  
+4. To start the application with custom lighty configuration, use arg `-c`:
+   `java -jar lighty-rnc-app-<version>.jar -c /path/to/config-file`
 
    To extend lighty modules time-out use `"modules": { "moduleTimeoutSeconds": SECONDS },` property inside JSON configuration. This property increases the time after which the exception is thrown if the module is not successfully initialized by then (Default 60).
    Example configuration files are located on following folder [example-config](lighty-rnc-app-docker/example-config).
@@ -177,6 +177,13 @@ For example, if your initial json data contains node in netconf topology:
 and the device is running, the connection should be established upon startup.
 For testing purposes, you can use [lighty-netconf-simulator](https://github.com/PANTHEONtech/lighty-netconf-simulator)
 as a netconf device.
+
+## Setup Logging
+Default logging configuration may be overwritten by JVM option
+```-Dlog4j.configurationFile=path/to/log4j2.xml```
+
+Content of ```log4j2.xml``` is described [here](https://logging.apache.org/log4j/2.x/manual/configuration.html).
+
 
 ## Update logger with JMX
 Java Management Extensions is a tool enabled by default which makes it easy to change runtime

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/deployment.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/deployment.yaml
@@ -21,8 +21,7 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.name }}:{{ .Values.image.version }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: [ "-c","{{ .Values.lighty.configDirectoryName }}/{{ .Values.lighty.configFilename }}",
-                  "-l","{{ .Values.lighty.configDirectoryName }}/{{ .Values.lighty.loggerConfigFilename }}"]
+          args: [ "-c","{{ .Values.lighty.configDirectoryName }}/{{ .Values.lighty.configFilename }}"]
           volumeMounts:
             - name: config-volume
               mountPath: {{ .Values.lighty.workdir }}/{{ .Values.lighty.configDirectoryName }}
@@ -70,10 +69,12 @@ spec:
                       -Dcom.sun.management.jmxremote.local.only=false
                       -Dcom.sun.management.jmxremote.port={{ .Values.lighty.jmx.jmxPort }}
                       -Dcom.sun.management.jmxremote.rmi.port={{ .Values.lighty.jmx.jmxPort }}
-                      -Djava.rmi.server.hostname=127.0.0.1"
+                      -Djava.rmi.server.hostname=127.0.0.1
+                      -Dlog4j.configurationFile={{ .Values.lighty.configDirectoryName }}/{{ .Values.lighty.loggerConfigFilename }}"
             {{ else }}
             - name: JAVA_OPTS
-              value: "-Dlog4j2.disable.jmx=true"
+              value: "-Dlog4j2.disable.jmx=true
+                      -Dlog4j.configurationFile={{ .Values.lighty.configDirectoryName }}/{{ .Values.lighty.loggerConfigFilename }}"
             {{- end }}
           ports:
             # akka remoting

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Arguments.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Arguments.java
@@ -8,25 +8,13 @@
 package io.lighty.applications.rnc.app;
 
 import com.beust.jcommander.Parameter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class Arguments {
-    private static final Logger LOG = LoggerFactory.getLogger(Arguments.class);
     @Parameter(names = {"-c", "--config-path"}, description = "Path to Lighty json config file. "
             + " (If absent, the default will be used)")
     private String configPath;
 
-    @Parameter(names = {"-l", "--logger-config-path"}, description = "Path to custom xml log4j properties file. "
-            + " (If absent, will look on classpath for it")
-    private String loggerPath;
-
     public String getConfigPath() {
         return configPath;
     }
-
-    public String getLoggerPath() {
-        return loggerPath;
-    }
-
 }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Main.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/src/main/java/io/lighty/applications/rnc/app/Main.java
@@ -16,11 +16,8 @@ import io.lighty.applications.rnc.module.config.RncLightyModuleConfigUtils;
 import io.lighty.applications.rnc.module.config.RncLightyModuleConfiguration;
 import io.lighty.core.common.models.YangModuleUtils;
 import io.lighty.core.controller.impl.config.ConfigurationException;
-import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.LoggerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,11 +50,6 @@ public class Main {
                 .addObject(arguments)
                 .build()
                 .parse(args);
-        if (arguments.getLoggerPath() != null) {
-            LOG.debug("Argument for custom logging settings path is present: {} ", arguments.getLoggerPath());
-            ((LoggerContext) LogManager.getContext(false)).setConfigLocation(URI.create(arguments.getLoggerPath()));
-            LOG.info("Custom logger properties loaded successfully");
-        }
 
         try {
             if (arguments.getConfigPath() != null) {

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/main/Arguments.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/main/Arguments.java
@@ -16,15 +16,7 @@ public class Arguments {
             + " (If absent, the default will be used)")
     private String configPath;
 
-    @Parameter(names = {"-l", "--logger-config-path"}, description = "Path to custom xml log4j properties file. "
-            + " (If absent, will look on classpath for it")
-    private String loggerPath;
-
     public String getConfigPath() {
         return configPath;
-    }
-
-    public String getLoggerPath() {
-        return loggerPath;
     }
 }

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/main/GnmiSimulatorApp.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/main/GnmiSimulatorApp.java
@@ -14,11 +14,8 @@ import io.lighty.modules.gnmi.simulatordevice.impl.SimulatedGnmiDevice;
 import io.lighty.modules.gnmi.simulatordevice.utils.EffectiveModelContextBuilder.EffectiveModelContextBuilderException;
 import io.lighty.modules.gnmi.simulatordevice.utils.GnmiSimulatorConfUtils;
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.LoggerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,13 +38,6 @@ public class GnmiSimulatorApp {
             .addObject(arguments)
             .build()
             .parse(args);
-
-        if (arguments.getLoggerPath() != null) {
-            LOG.debug("Argument for custom logging settings path is present: {} ", arguments.getLoggerPath());
-            ((LoggerContext) LogManager.getContext(false)).setConfigLocation(URI.create(arguments.getLoggerPath()));
-            LOG.info("Custom logger properties loaded successfully");
-        }
-
         final GnmiSimulatorConfiguration gnmiSimulatorConfiguration;
 
         try {


### PR DESCRIPTION
Remove log4j path argument from example application, since this can be setup with Java option.