### PR TITLE
Add documentation for JMX Logger extension

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/deployment.yaml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/templates/deployment.yaml
@@ -60,6 +60,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            {{- if .Values.lighty.jmx.enableJmxRemoting }}
+            - name: JAVA_OPTS
+              value: "-Dcom.sun.management.jmxremote
+                      -Dcom.sun.management.jmxremote.authenticate=false
+                      -Dcom.sun.management.jmxremote.ssl=false
+                      -Dcom.sun.management.jmxremote.local.only=false
+                      -Dcom.sun.management.jmxremote.port={{ .Values.lighty.jmx.jmxPort }}
+                      -Dcom.sun.management.jmxremote.rmi.port={{ .Values.lighty.jmx.jmxPort }}
+                      -Djava.rmi.server.hostname=127.0.0.1"
+            {{ else }}
+            - name: JAVA_OPTS
+              value: "-Dlog4j2.disable.jmx=true"
+            {{- end }}
           ports:
             # akka remoting
             - name: remoting
@@ -75,6 +88,12 @@ spec:
             - name: restconf
               containerPort: {{ .Values.lighty.restconf.restconfPort }}
               protocol: TCP
+              {{- if .Values.lighty.jmx.enableJmxRemoting }}
+              # JMX port on which JMX server is listening
+            - name: jmx
+              containerPort: {{ .Values.lighty.jmx.jmxPort }}
+              protocol: TCP
+              {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/values.yaml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-helm/helm/lighty-rcgnmi-app-helm/values.yaml
@@ -22,6 +22,12 @@ lighty:
   restconf:
     restconfPort: 8888
 
+  jmx:
+    # Port on which JMX server in image is listening, should be same as defined in dockerfile
+    # If true, allow remote connections to JMX server running in container image, useful for debugging
+    enableJmxRemoting: true
+    jmxPort: 1099
+
   akka:
     # If true, overrides akka cluster configuration with default single-node
     isSingleNode: true

--- a/lighty-applications/lighty-rnc-app-aggregator/README.md
+++ b/lighty-applications/lighty-rnc-app-aggregator/README.md
@@ -177,3 +177,56 @@ For example, if your initial json data contains node in netconf topology:
 and the device is running, the connection should be established upon startup.
 For testing purposes, you can use [lighty-netconf-simulator](https://github.com/PANTHEONtech/lighty-netconf-simulator)
 as a netconf device.
+
+## Update logger with JMX
+Java Management Extensions is a tool enabled by default which makes it easy to change runtime
+configuration of the application. Among other options, we use [log4j2](https://logging.apache.org/log4j/2.0/manual/jmx.html)
+which has build in option to change logging behaviour during runtime via JMX client which can be connected to running lighty instance.
+1. Start the application (see previous sections)
+2. Connect the JXM client
+  We recommend using `jconsole` because it is part of the standard Java JRE.  
+  The command for connecting jconsole to JMX server is:  
+    `jconsole <ip-of-running-lighty>:<JMX-port>`, the default JMX-port is 1099.
+      
+This approach works only if the application is running locally.  
+  
+If you want to connect the JMX client to the application running remotely or containerized (k8s deployment or/and docker),
+you need to start the application using the following JAVA_OPTS:
+```
+JAVA_OPTS = -Dcom.sun.management.jmxremote
+             -Dcom.sun.management.jmxremote.authenticate=false
+             -Dcom.sun.management.jmxremote.ssl=false
+             -Dcom.sun.management.jmxremote.local.only=false
+             -Dcom.sun.management.jmxremote.port=<JMX_PORT>
+             -Dcom.sun.management.jmxremote.rmi.port=<JMX_PORT>
+             -Djava.rmi.server.hostname=127.0.0.1
+```
+Then run `java $JAVA_OPTS -jar lighty-rnc-app-<version> ...`
+
+If you want to completely disable logger JMX option run application with following JAVA_OPTS
+`java -Dlog4j2.disable.jmx=true -jar lighty-rnc-app-<version> ...`
+
+### Connecting JMX client to application running in docker
+1. If we want to be able to connect the JMX, we need to start the app with JAVA_OPTS, as described in the
+ previous chapter.
+ In Docker, the most convenient way to do this is to create env.file and run the docker run with `--env-file env.file` argument
+ The env.file must contain the definition of the described JAVA_OPTS environment variable.
+ We also need to publish the container JMX_PORT to host, this is done via `-p <JMX_PORT>:<JMX_PORT>` argument.
+ So the docker run command becomes:  
+  `docker run -it --name lighty-rnc --env-file env.file -p <JMX_PORT>:<JMX_PORT> ...`
+ The rest of the command stays the same as explained in previous chapters.
+ 2. Connect the JMX client via the command `jconsole <ip-of-container>:<JMX_PORT>`.
+ 
+### Connecting a JMX client to the application, deployed in kubernetes
+Once you have deployed the application via our provided helm chart, in which you enabled jmxRemoting,
+you just need to forward the JMX port of the pod, in which the instance of the application you want to debug, is running.
+In Kubernetes, this is done via `kubectl port-forward` command.
+1. Forward the pod's JMX port, run `kubectl port-forward <name-of-the-pod> <JMX_PORT>`
+2. Connect JMX client, run `jconsole <pod-ip>:<JMX-port>`
+
+### Update Logger level in runtime with JMX
+After successful connection, JMX client to lighty app is possible to update logger information in runtime.
+[Log4j2 JMX](https://logging.apache.org/log4j/2.0/manual/jmx.html) provides more configuration but, for this example we show how to change logger lever.
+1) Open `MBeans` window and chose `org.apache.logging.log4j2`
+3) Chose from dropdown  `loggers` than `StatusLogger` and `level`
+4) By double-clicking on level value, can be updated to desire [state](https://logging.apache.org/log4j/2.x/manual/customloglevels.html).

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/deployment.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/deployment.yaml
@@ -62,6 +62,19 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            {{- if .Values.lighty.jmx.enableJmxRemoting }}
+            - name: JAVA_OPTS
+              value: "-Dcom.sun.management.jmxremote
+                      -Dcom.sun.management.jmxremote.authenticate=false
+                      -Dcom.sun.management.jmxremote.ssl=false
+                      -Dcom.sun.management.jmxremote.local.only=false
+                      -Dcom.sun.management.jmxremote.port={{ .Values.lighty.jmx.jmxPort }}
+                      -Dcom.sun.management.jmxremote.rmi.port={{ .Values.lighty.jmx.jmxPort }}
+                      -Djava.rmi.server.hostname=127.0.0.1"
+            {{ else }}
+            - name: JAVA_OPTS
+              value: "-Dlog4j2.disable.jmx=true"
+            {{- end }}
           ports:
             # akka remoting
             - name: remoting
@@ -77,6 +90,12 @@ spec:
             - name: restconf
               containerPort: {{ .Values.lighty.restconf.restconfPort }}
               protocol: TCP
+              {{- if .Values.lighty.jmx.enableJmxRemoting }}
+              # JMX port on which JMX server is listening
+            - name: jmx
+              containerPort: {{ .Values.lighty.jmx.jmxPort }}
+              protocol: TCP
+              {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/values.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/values.yaml
@@ -35,6 +35,12 @@ lighty:
     trustKeyStoreFileName: "lightyio.jks"
     enableSwagger: false
 
+  jmx:
+    # Port on which JMX server in image is listening, should be same as defined in dockerfile
+    # If true, allow remote connections to JMX server running in container image, useful for debugging
+    enableJmxRemoting: true
+    jmxPort: 1099
+
   akka:
     # If true, overrides akka cluster configuration with default single-node
     isSingleNode: true

--- a/lighty-examples/README.md
+++ b/lighty-examples/README.md
@@ -43,4 +43,40 @@ Step #4 is optional.
 lighty.io supports development of two basic controller types:
 * __Standalone controller__ - runs in own JVM as micro service
 * __Embedded controller__ - runs with other application components in single JVM
- 
+
+## Update logger with JMX
+Java Management Extensions is a tool enabled by default which makes it easy to change runtime
+configuration of the application. Among other options, we use [log4j2](https://logging.apache.org/log4j/2.0/manual/jmx.html)
+which has built in option to change logging behaviour during runtime via JMX client which can be connected to the running lighty instance.
+1. Start the lighty example application
+2. Connect the JXM client
+   We recommend using `jconsole` because it is part of the standard Java JRE.
+   The command for connecting jconsole to JMX server is:
+   `jconsole <ip-of-running-lighty>:<JMX-port>`, the default JMX-port is 1099.
+
+This approach works only if the application is running locally.
+
+If you want to connect the JMX client to the application running remotely or containerized (k8s deployment or/and docker),
+you need to start the application using the following JAVA_OPTS:
+```
+JAVA_OPTS = -Dcom.sun.management.jmxremote
+             -Dcom.sun.management.jmxremote.authenticate=false
+             -Dcom.sun.management.jmxremote.ssl=false
+             -Dcom.sun.management.jmxremote.local.only=false
+             -Dcom.sun.management.jmxremote.port=<JMX_PORT>
+             -Dcom.sun.management.jmxremote.rmi.port=<JMX_PORT>
+             -Djava.rmi.server.hostname=127.0.0.1
+```
+Then run `java $JAVA_OPTS -jar lighty-rnc-app-<version> ...`
+
+If you want to completely disable logger JMX option, run application with following JAVA_OPTS
+`java -Dlog4j2.disable.jmx=true -jar lighty-rnc-app-<version> ...`
+
+### Update Logger level in runtime with JMX
+After successful start of lighty example application is possible to update logger information in runtime.
+[Log4j2 JMX](https://logging.apache.org/log4j/2.0/manual/jmx.html) provides more configuration but, for this example, we show how to change logger lever.
+1) Start `jconsole` (part of the standard Java JRE)
+2) Chose lighty example application in local process application
+3) Open `MBeans` window and chose `org.apache.logging.log4j2`
+4) Chose from dropdown  `loggers` than `StatusLogger` and `level`
+5) By double-clicking on level value, can be updated to desire [state](https://logging.apache.org/log4j/2.x/manual/customloglevels.html).


### PR DESCRIPTION
Add documentation how to use JMX with lighty application. After bumping to log4j2 JMX functionality is enabled by default:
https://logging.apache.org/log4j/log4j-2.5/manual/jmx.html