### PR TITLE
Add synchronous module shutdown

### DIFF
--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/AbstractLightyModule.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/AbstractLightyModule.java
@@ -15,6 +15,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -184,5 +185,18 @@ public abstract class AbstractLightyModule implements LightyModule {
 
         return shutdownFuture;
     }
-}
 
+    @SuppressWarnings("IllegalCatch")
+    @Override
+    public final boolean shutdown(final long duration, final TimeUnit unit) {
+        try {
+            return shutdown().get(duration, unit);
+        } catch (final InterruptedException e) {
+            LOG.error("Interrupted while shutting down {}:", getClass().getSimpleName(), e);
+            Thread.currentThread().interrupt();
+        } catch (final Exception e) {
+            LOG.error("Exception while shutting down {}:", getClass().getSimpleName(), e);
+        }
+        return false;
+    }
+}

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/LightyModule.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/LightyModule.java
@@ -8,6 +8,7 @@
 package io.lighty.core.controller.api;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This is common interface for all Lighty modules.
@@ -40,4 +41,12 @@ public interface LightyModule {
      */
     ListenableFuture<Boolean> shutdown() throws Exception;
 
+    /**
+     * Shutdown module and wait for completion for specified amount of time.
+     *
+     * @param duration duration of time to wait for completion
+     * @param unit unit of time duration
+     * @return true if module shutdown was successful in specified time, false otherwise.
+     */
+    boolean shutdown(long duration, TimeUnit unit);
 }


### PR DESCRIPTION
Add shutdown method which waits for shutdown to complete and returns success of the operation.

This method can be used to reduce ceremonials done around shutting down the modules in Lighty.io applications.

JIRA: LIGHTY-87
Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>