### PR TITLE
Close TopologyManager in NetconfClusteredTopologyPlugin

### DIFF
--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfClusteredTopologyPlugin.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfClusteredTopologyPlugin.java
@@ -43,6 +43,8 @@ public class NetconfClusteredTopologyPlugin extends AbstractLightyModule impleme
     private final Integer writeTxIdleTimeout;
     private final AAAEncryptionService encryptionService;
 
+    private NetconfTopologyManager topology;
+
     public NetconfClusteredTopologyPlugin(final LightyServices lightyServices, final String topologyId,
             final NetconfClientDispatcher clientDispatcher, final Integer writeTxIdleTimeout,
             final ExecutorService executorService, final AAAEncryptionService encryptionService) {
@@ -69,7 +71,7 @@ public class NetconfClusteredTopologyPlugin extends AbstractLightyModule impleme
         }
         final SchemaResourceManager schemaResourceManager
                 = new DefaultSchemaResourceManager(lightyServices.getYangParserFactory());
-        NetconfTopologyManager topology = new NetconfTopologyManager(defaultBaseNetconfSchemas,
+        topology = new NetconfTopologyManager(defaultBaseNetconfSchemas,
                 lightyServices.getBindingDataBroker(),
                 lightyServices.getDOMRpcProviderService(), lightyServices.getDOMActionProviderService(),
                 lightyServices.getClusterSingletonServiceProvider(), lightyServices.getScheduledThreadPool(),
@@ -83,6 +85,9 @@ public class NetconfClusteredTopologyPlugin extends AbstractLightyModule impleme
 
     @Override
     protected boolean stopProcedure() {
+        if (topology != null) {
+            topology.close();
+        }
         return true;
     }
 


### PR DESCRIPTION
Close NetconfTopologyManager in NetconfClusteredTopologyPlugin when stopProcedure is called.

JIRA: LIGHTY-90
Signed-off-by: Peter Suna <peter.suna@pantheon.tech>
(cherry picked from commit ee61c2344ee76afd2362aca96c672027ba806f4d)

Cherry-pick of https://github.com/PANTHEONtech/lighty/pull/1130