### PR TITLE
Add missing jaxb-runtime dependency

### DIFF
--- a/lighty-modules/lighty-restconf-nb-community/pom.xml
+++ b/lighty-modules/lighty-restconf-nb-community/pom.xml
@@ -49,6 +49,10 @@
             <groupId>org.glassfish.jersey.inject</groupId>
             <artifactId>jersey-hk2</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+        </dependency>
 
         <!--Tests-->
         <dependency>


### PR DESCRIPTION
A warning message was shown because this dependency was missing: 
WARNING: JAXBContext implementation could not be found. WADL feature is disabled

LIGHTY - 91

Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>