### PR TITLE
Add log4j2-config to distribution management

### DIFF
--- a/lighty-resources/log4j2-config/pom.xml
+++ b/lighty-resources/log4j2-config/pom.xml
@@ -22,4 +22,15 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
     </properties>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 </project>


### PR DESCRIPTION
Distribution management section is needed for correct artifact release to maven central.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>