### PR TITLE
Remove log4j-config from maven deploy

### DIFF
--- a/lighty-resources/log4j2-config/pom.xml
+++ b/lighty-resources/log4j2-config/pom.xml
@@ -21,5 +21,7 @@
 
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
     </properties>
 </project>


### PR DESCRIPTION
Remove log42-config from maven release deploy.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>