### PR TITLE
Remove unnecessary release SCM tag

### DIFF
--- a/lighty-examples/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/lighty-controller-springboot-netconf/pom.xml
@@ -136,8 +136,4 @@
             </plugins>
         </pluginManagement>
     </build>
-
-  <scm>
-    <tag>HEAD</tag>
-  </scm>
 </project>


### PR DESCRIPTION
Usually SCM tag in lighty-controller-springboot-netconf is automatically removed by release plugin.

Remove it manually now.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>