### PR TITLE
Set sonar.java.source to Java 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Maven test + SonarCloud
         if: ${{ env.SONAR_TOKEN != 0 }}
         run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
-          -Dsonar.java.source=1.11
+          -Dsonar.java.source=17
           -Dsonar.projectKey=${{ env.SONAR_PROJECT_KEY }}
           -Dsonar.organization=${{ env.SONAR_ORGANIZATION }}
           -Dsonar.host.url=https://sonarcloud.io


### PR DESCRIPTION
We are using Java 17. Set sonar sources to 17.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit ac9998db3cbc4732513647daa3d8fcf1f46e2480)