### PR TITLE
Switch to maven:3.8-eclipse-temurin-17-alpine

### DIFF
--- a/.github/workflows/lighty-rnc-app/simulator/Dockerfile
+++ b/.github/workflows/lighty-rnc-app/simulator/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine/git as clone
 WORKDIR /netconf-simulator
 RUN git clone https://github.com/PANTHEONtech/lighty-netconf-simulator.git -b 17.0.1
 
-FROM maven:3.8.5-openjdk-17-slim as build
+FROM maven:3.8-eclipse-temurin-17-alpine as build
 WORKDIR /lighty-netconf-simulator
 COPY --from=clone /netconf-simulator/lighty-netconf-simulator /lighty-netconf-simulator
 RUN mvn -B install -DskipTests


### PR DESCRIPTION
Temurin contains more recent versions of Java and maven.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>