### PR TITLE
Bump org.json to 20220924

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -232,7 +232,7 @@
             <dependency>
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
-                <version>20220320</version>
+                <version>20220924</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
The major change here is that the code is in public domain.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>