### PR TITLE
Update Dockerfile maven version

### DIFF
--- a/.github/workflows/lighty-rnc-app/simulator/Dockerfile
+++ b/.github/workflows/lighty-rnc-app/simulator/Dockerfile
@@ -2,12 +2,13 @@ FROM alpine/git as clone
 WORKDIR /netconf-simulator
 RUN git clone https://github.com/PANTHEONtech/lighty-netconf-simulator.git -b 16.2.0
 
-FROM maven:3.8-jdk-11-slim as build
+FROM maven:3.8.5-openjdk-17-slim as build
 WORKDIR /lighty-netconf-simulator
 COPY --from=clone /netconf-simulator/lighty-netconf-simulator /lighty-netconf-simulator
 RUN mvn -B install -DskipTests
 
-FROM openjdk:11-jre-slim
+FROM alpine:latest
+RUN apk add openjdk17-jre
 WORKDIR /lighty-netconf-simulator
 COPY --from=build /lighty-netconf-simulator/examples/devices/lighty-network-topology-device/target/ /lighty-netconf-simulator/target
 


### PR DESCRIPTION
Lighty 17.x uses java version 17

JIRA: LIGHTY-96
Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
(cherry picked from commit 19998506bbbf97e5f4d241aa820350f414c75ebc)