### PR TITLE
Bump netconf to 2.0.17

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -62,7 +62,7 @@
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>netconf-artifacts</artifactId>
-                <version>2.0.16</version>
+                <version>2.0.17</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Bump netconf version from 2.0.16 to 2.0.17.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>