### PR TITLE
Bump simulator to 17.0.1

### DIFF
--- a/.github/workflows/lighty-rnc-app/simulator/Dockerfile
+++ b/.github/workflows/lighty-rnc-app/simulator/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git as clone
 WORKDIR /netconf-simulator
-RUN git clone https://github.com/PANTHEONtech/lighty-netconf-simulator.git -b 17.0.x
+RUN git clone https://github.com/PANTHEONtech/lighty-netconf-simulator.git -b 17.0.1
 
 FROM maven:3.8.5-openjdk-17-slim as build
 WORKDIR /lighty-netconf-simulator
@@ -14,4 +14,4 @@ COPY --from=build /lighty-netconf-simulator/examples/devices/lighty-network-topo
 
 EXPOSE 17380
 
-ENTRYPOINT ["java", "-jar", "/lighty-netconf-simulator/target/lighty-network-topology-device-17.0.1-SNAPSHOT.jar"]
+ENTRYPOINT ["java", "-jar", "/lighty-netconf-simulator/target/lighty-network-topology-device-17.0.1.jar"]


### PR DESCRIPTION
Bump simulator to the latest 17.0.1 version.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>