### PR TITLE
Use eclipse-temurin:17-jre-alpine

### DIFF
--- a/.github/workflows/lighty-rnc-app/simulator/Dockerfile
+++ b/.github/workflows/lighty-rnc-app/simulator/Dockerfile
@@ -8,8 +8,7 @@ WORKDIR /lighty-netconf-simulator
 COPY --from=clone /netconf-simulator/lighty-netconf-simulator /lighty-netconf-simulator
 RUN mvn -B install -DskipTests
 
-FROM alpine:3.16.2
-RUN apk add openjdk17-jre
+FROM eclipse-temurin:17-jre-alpine
 WORKDIR /lighty-netconf-simulator
 COPY --from=build /lighty-netconf-simulator/examples/devices/lighty-network-topology-device/target/ /lighty-netconf-simulator/target
 

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/src/main/docker/Dockerfile
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/src/main/docker/Dockerfile
@@ -1,6 +1,4 @@
-FROM alpine:3.16.2
-
-RUN apk add openjdk17-jre-headless
+FROM eclipse-temurin:17-jre-alpine
 
 WORKDIR /lighty-rcgnmi
 

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/src/main/docker/Dockerfile
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/src/main/docker/Dockerfile
@@ -1,6 +1,4 @@
-FROM alpine:3.16.2
-
-RUN apk add openjdk17-jre-headless
+FROM eclipse-temurin:17-jre-alpine
 
 WORKDIR /lighty-rnc
 


### PR DESCRIPTION
Use eclipse-temurin:17-jre-alpine

Use preinstalled Eclipse Temurin 17-jre-alpine image instead of
installing Java JRE into pure alpine.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>