### PR TITLE
Bump lighty.io simulator to 16.3.0

### DIFF
--- a/.github/workflows/lighty-rnc-app/simulator/Dockerfile
+++ b/.github/workflows/lighty-rnc-app/simulator/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git as clone
 WORKDIR /netconf-simulator
-RUN git clone https://github.com/PANTHEONtech/lighty-netconf-simulator.git -b 16.2.0
+RUN git clone https://github.com/PANTHEONtech/lighty-netconf-simulator.git -b 16.3.0
 
 FROM maven:3.8-jdk-11-slim as build
 WORKDIR /lighty-netconf-simulator
@@ -13,4 +13,4 @@ COPY --from=build /lighty-netconf-simulator/examples/devices/lighty-network-topo
 
 EXPOSE 17380
 
-ENTRYPOINT ["java", "-jar", "/lighty-netconf-simulator/target/lighty-network-topology-device-16.2.0.jar"]
+ENTRYPOINT ["java", "-jar", "/lighty-netconf-simulator/target/lighty-network-topology-device-16.3.0.jar"]


### PR DESCRIPTION
Use the latest simulator in 16.x branch.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>