### PR TITLE
[17.x] Add github-token to all workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,16 +60,19 @@ jobs:
   lighty_rnc_app_test:
     uses: ./.github/workflows/test-lighty-app.yml
     with:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
       app-name: lighty-rnc-app
       test-script-file: ${GITHUB_WORKSPACE}/.github/workflows/lighty-rnc-app/tests-lighty-rnc-app.sh
   lighty_rcgnmi_app_test:
     uses: ./.github/workflows/test-lighty-app.yml
     with:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
       app-name: lighty-rcgnmi-app
       test-script-file: ${GITHUB_WORKSPACE}/.github/workflows/lighty-rcgnmi-app/tests-lighty-rcgnmi-app.sh
   lighty_rnc_cluster_app_test:
     uses: ./.github/workflows/test-lighty-app.yml
     with:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
       app-name: lighty-rnc-app
       test-script-file: ${GITHUB_WORKSPACE}/.github/workflows/lighty-rnc-app/test-lighty-rnc-app-cluster.sh
       override-helm-values: lighty.replicaCount=3,lighty.akka.isSingleNode=false,nodePort.useNodePort=false,lighty.moduleTimeOut=120,resources=null


### PR DESCRIPTION
Our workflows were failing due to API rate limit being exceeded. Authenticated requests get a higher rate limit, so adding github-token should resolve this issue.

https://docs.github.com/en/rest/search?apiVersion=2022-11-28#rate-limit