### PR TITLE
Revert "add default akka discovery method to fix failing tests"

### DIFF
--- a/lighty-resources/singlenode-configuration/src/main/resources/singlenode/akka-default.conf
+++ b/lighty-resources/singlenode-configuration/src/main/resources/singlenode/akka-default.conf
@@ -12,10 +12,6 @@ akka {
     provider = "akka.cluster.ClusterActorRefProvider"
   }
 
-  discovery {
-    method = akka-dns
-  }
-
   cluster {
     # Remove ".tcp" when using artery.
     seed-nodes = ["akka://opendaylight-cluster-data@127.0.0.1:2550"]


### PR DESCRIPTION
This reverts commit bc870afdac28c7fad365b6612edabab50e92f171.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>