### PR TITLE
Enable Split-Brain Resolver

### DIFF
--- a/lighty-resources/singlenode-configuration/src/main/resources/singlenode/factory-akka-default.conf
+++ b/lighty-resources/singlenode-configuration/src/main/resources/singlenode/factory-akka-default.conf
@@ -127,6 +127,13 @@ akka {
     use-dispatcher = cluster-dispatcher
 
     failure-detector.acceptable-heartbeat-pause = 3 s
+
+    downing-provider-class = "akka.cluster.sbr.SplitBrainResolverProvider"
+
+    split-brain-resolver {
+      active-strategy = keep-majority
+      stable-after = 7s
+    }
   }
 
   persistence {


### PR DESCRIPTION
Split-Brain Resolver was added to ODL controller as a provider for handling dead nodes. https://github.com/opendaylight/controller/commit/58e85a6f7c26366affdc65477b817826bedfe6a7

JIRA: LIGHTY-141