### PR TITLE
[16.x]Add GitHub token to actions-setup-minikube

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
         with:
           minikube version: 'v1.28.0'
           kubernetes version: 'v1.25.4'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Start Minikube cluster
         run: minikube start
       - name: Install helm v3.6.2
@@ -112,6 +113,7 @@ jobs:
         with:
           minikube version: 'v1.28.0'
           kubernetes version: 'v1.25.4'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Start Minikube cluster
         run: minikube start
       - name: Install helm v3.6.2


### PR DESCRIPTION
This action was failing due to API rate limit being exceeded. Adding github-token makes the request authenticated and thus increases the limit.

https://github.com/manusa/actions-setup-minikube#usage
JIRA: LIGHTY-140