### PR TITLE
[16.x]Fix variable name of github token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           minikube version: 'v1.28.0'
           kubernetes version: 'v1.25.4'
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Start Minikube cluster
         run: minikube start
       - name: Install helm v3.6.2
@@ -113,7 +113,7 @@ jobs:
         with:
           minikube version: 'v1.28.0'
           kubernetes version: 'v1.25.4'
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Start Minikube cluster
         run: minikube start
       - name: Install helm v3.6.2


### PR DESCRIPTION
Change the variable name, so it is as described in: https://github.com/manusa/actions-setup-minikube#usage

JIRA: LIGHTY-140
Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>