### PR TITLE
Add GH token to actions-setup-minikube

### DIFF
--- a/.github/workflows/test-lighty-app.yml
+++ b/.github/workflows/test-lighty-app.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           minikube version: 'v1.28.0'
           kubernetes version: 'v1.25.4'
+          github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Start Minikube cluster
         run: minikube start
       - name: Install helm v3.6.2


### PR DESCRIPTION
Complete action configuration according to:
https://github.com/manusa/actions-setup-minikube#usage in order to prevent reaching limit of unauthorized requests.

JIRA: LIGHTY-140
Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>