### PR TITLE
Bump third-party dependencies

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -100,7 +100,7 @@
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>7.7.0</version>
+                <version>7.7.1</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -123,13 +123,13 @@
             <dependency>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-annotations</artifactId>
-                <version>4.5.3</version>
+                <version>4.7.3</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.8.2</version>
+                <version>5.9.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <!-- Overrides Spring Boot slf4j and log4j2 dependency version -->
-        <slf4j.version>2.0.0</slf4j.version>
+        <slf4j.version>2.0.6</slf4j.version>
         <log4j2.version>2.19.0</log4j2.version>
     </properties>
 
@@ -193,12 +193,12 @@
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
                             <!-- This should match the dependency management on com.puppycrawl.tools:checkstyle above -->
-                            <version>10.3.3</version>
+                            <version>10.4</version>
                         </dependency>
                         <dependency>
                             <groupId>com.github.sevntu-checkstyle</groupId>
                             <artifactId>sevntu-checks</artifactId>
-                            <version>1.42.0</version>
+                            <version>1.43.0</version>
                         </dependency>
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>


### PR DESCRIPTION
slf4j: 2.0.0 -> 2.0.6
testng: 7.7.0 -> 7.7.1
spotbugs-annotations: 4.5.3 -> 4.7.3
junit-bom: 5.8.2 -> 5.9.2
checkstyle: 10.3.3 -> 10.4
sevntu: 1.42.0 -> 1.43.0

JIRA: LIGHTY-146