### PR TITLE
Bump plugins

### DIFF
--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -193,7 +193,7 @@
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
                             <!-- This should match the dependency management on com.puppycrawl.tools:checkstyle above -->
-                            <version>10.4</version>
+                            <version>10.6.0</version>
                         </dependency>
                         <dependency>
                             <groupId>com.github.sevntu-checkstyle</groupId>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
@@ -63,7 +63,7 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.7.0</version>
+                <version>1.7.1</version>
             </extension>
         </extensions>
         <plugins>


### PR DESCRIPTION
- Bump checkstyle plugin from 10.4 to 10.6.0.
  https://checkstyle.org/releasenotes.html#Release_10.6.0

- Bump os-maven-plugin from 1.7.0 to 1.7.1.
  https://github.com/trustin/os-maven-plugin/releases/tag/os-maven-plugin-1.7.1