### PR TITLE
Update broken link in README file

### DIFF
--- a/lighty-examples/lighty-controller-springboot-netconf/README.md
+++ b/lighty-examples/lighty-controller-springboot-netconf/README.md
@@ -16,7 +16,7 @@ toaster model from [ODL repository](https://github.com/YangModels/yang/blob/19fe
 ![architecture](docs/architecture.svg)
 
 ## Security
-This demo utilizes Spring's [method security](https://docs.spring.io/spring-security/site/docs/5.2.0.BUILD-SNAPSHOT/reference/htmlsingle/#jc-method) 
+This demo utilizes Spring's [method security](https://docs.spring.io/spring-security/reference/servlet/authorization/method-security.html) 
 and [jCasbin](https://github.com/casbin/jcasbin). Web layer injects spring SecurityContext so it is available for other beans in application.  
 
 * __Authentication__ is handled by internal service ``io.lighty.core.controller.springboot.services.UserAccessService`` 


### PR DESCRIPTION
The link in the README file to the Spring Security documentation was not working. This commit updates the link to the correct URL so that users can access the documentation for configuring method-level security. The new link is: https://docs.spring.io/spring-security/reference/servlet/authorization/method-security.html.

JIRA:LIGHTY-167