### PR TITLE
Fix incorrect time measurement in closeLightyModule function

### DIFF
--- a/lighty-examples/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/lighty-controller-springboot-netconf/pom.xml
@@ -25,6 +25,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
The previous implementation of closeLightyModule method used a Stopwatch to measure the time taken by lightyModule.shutdown() method, but it did not account for the time taken by the method to complete asynchronously.

JIRA:LIGHTY-169
Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
(cherry picked from commit 123c2ee962b84f296da781bd6f1d616c3532250f)