### PR TITLE
Add Java 17 support to lighty-controller-springboot

### DIFF
--- a/lighty-examples/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/lighty-controller-springboot-netconf/pom.xml
@@ -25,6 +25,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Added <maven.compiler.release>17</maven.compiler.release> to ensure compatibility with Java 17 features, as the parent specifies Java version to 1.8 in spring-boot-starter-parent.

JIRA:LIGHTY-171
Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
(cherry picked from commit ae0e1af4c70bd2f40110e65bdfd647a453eeda17)