### PR TITLE
Remove actor provider from default akka

### DIFF
--- a/lighty-resources/singlenode-configuration/src/main/resources/singlenode/akka-default.conf
+++ b/lighty-resources/singlenode-configuration/src/main/resources/singlenode/akka-default.conf
@@ -8,10 +8,6 @@ akka {
     }
   }
 
-  actor {
-    provider = "akka.cluster.ClusterActorRefProvider"
-  }
-
   cluster {
     # Remove ".tcp" when using artery.
     seed-nodes = ["akka://opendaylight-cluster-data@127.0.0.1:2550"]


### PR DESCRIPTION
Actor provider is already present inside factory-akka. This is also the way it was done in:
https://github.com/opendaylight/controller/commit/6e76bb44514ea79524f46ff283ea0d0d4ad8c7f8#diff-467a4f05761d358151851421d1371861f8f0f561915088b6271d229ac70a0e7a

JIRA:LIGHTY-173
Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
(cherry picked from commit e9336644da7f341ee38e7ae15456e2da648bb7e1)