### PR TITLE
Bump Akka to 2.6.20

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -157,57 +157,57 @@
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-remote_2.13</artifactId>
-                <version>2.6.19</version>
+                <version>2.6.20</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-slf4j_2.13</artifactId>
-                <version>2.6.19</version>
+                <version>2.6.20</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-cluster_2.13</artifactId>
-                <version>2.6.19</version>
+                <version>2.6.20</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-discovery_2.13</artifactId>
-                <version>2.6.19</version>
+                <version>2.6.20</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-protobuf_2.13</artifactId>
-                <version>2.6.19</version>
+                <version>2.6.20</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-coordination_2.13</artifactId>
-                <version>2.6.19</version>
+                <version>2.6.20</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-distributed-data_2.13</artifactId>
-                <version>2.6.19</version>
+                <version>2.6.20</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-cluster-tools_2.13</artifactId>
-                <version>2.6.19</version>
+                <version>2.6.20</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-cluster-sharding_2.13</artifactId>
-                <version>2.6.19</version>
+                <version>2.6.20</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-actor_2.13</artifactId>
-                <version>2.6.19</version>
+                <version>2.6.20</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-stream_2.13</artifactId>
-                <version>2.6.19</version>
+                <version>2.6.20</version>
             </dependency>
             <dependency>
                 <groupId>com.lightbend.akka.management</groupId>


### PR DESCRIPTION
https://akka.io/blog/news/2022/09/06/akka-2.6.20-released