### PR TITLE
[16.x]Fix SpotBugs output configuration

### DIFF
--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -283,7 +283,7 @@
                             <!-- Produces XML report -->
                             <xmlOutput>true</xmlOutput>
                             <!-- Configures the directory in which the XML report is created -->
-                            <findbugsXmlOutputDirectory>${project.build.directory}/spotbugs</findbugsXmlOutputDirectory>
+                            <spotbugsXmlOutputDirectory>${project.build.directory}/spotbugs</spotbugsXmlOutputDirectory>
                         </configuration>
                         <executions>
                             <!--


### PR DESCRIPTION
This is causing a warning
when building with maven-3.9.0.

JIRA:LIGHTY-180