### PR TITLE
[16.x] Fix override method call in constructor of ConfigurableParameters

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/device/connection/ConfigurableParameters.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/device/connection/ConfigurableParameters.java
@@ -14,6 +14,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.force.capabilities.rev210702.ForceCapabilities;
+import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.force.capabilities.rev210702.force.yang.models.ForceCapability;
 import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.topology.rev210316.gnmi.connection.parameters.ExtensionsParameters;
 import org.opendaylight.yang.gen.v1.urn.lighty.gnmi.topology.rev210316.gnmi.connection.parameters.extensions.parameters.GnmiParameters;
 
@@ -69,10 +70,14 @@ public class ConfigurableParameters {
                 .map(Entry::getValue)
                 .map(model -> Gnmi.ModelData.newBuilder()
                     .setName(model.getName())
-                    .setVersion(model.getVersion().getValue()).build())
+                    .setVersion(getVersion(model)).build())
                 .collect(Collectors.toList()));
         }
         return Optional.empty();
+    }
+
+    private String getVersion(ForceCapability model) {
+        return model.getVersion().getValue();
     }
 
     public Optional<Boolean> getUseModelNamePrefix() {


### PR DESCRIPTION
This is a fix for: https://github.com/PANTHEONtech/lighty/pull/1285

The constructor of the ConfigurableParameters class was calling an
overridable method, getVersion, which resulted in a warning message.
To fix this issue, the getVersion method was made private.

This commit ensures that the class adheres to best practices for writing
constructors and avoids any potential issues that could arise from calling
an overridable method in a constructor.

JIRA:LIGHTY-183