### PR TITLE
Bump spring-boot-dependencies

### DIFF
--- a/lighty-core/lighty-controller-spring-di/pom.xml
+++ b/lighty-core/lighty-controller-spring-di/pom.xml
@@ -27,7 +27,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.0.4</version>
+                <version>3.0.5</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-examples/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/lighty-controller-springboot-netconf/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.4</version>
+        <version>3.0.5</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
Bump spring-boot-dependencies which upgrades
org.springframework:spring-expression to solve:
https://www.cve.org/CVERecord?id=CVE-2023-20861
https://www.cve.org/CVERecord?id=CVE-2023-20860
https://www.cve.org/CVERecord?id=CVE-2023-28708

JIRA:LIGHTY-186