### PR TITLE
Updated akka management versions to 1.1.4

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -235,22 +235,22 @@
             <dependency>
                 <groupId>com.lightbend.akka.management</groupId>
                 <artifactId>akka-management_2.13</artifactId>
-                <version>1.1.3</version>
+                <version>1.1.4</version>
             </dependency>
             <dependency>
                 <groupId>com.lightbend.akka.management</groupId>
                 <artifactId>akka-management-cluster-http_2.13</artifactId>
-                <version>1.1.3</version>
+                <version>1.1.4</version>
             </dependency>
             <dependency>
                 <groupId>com.lightbend.akka.management</groupId>
                 <artifactId>akka-management-cluster-bootstrap_2.13</artifactId>
-                <version>1.1.3</version>
+                <version>1.1.4</version>
             </dependency>
             <dependency>
                 <groupId>com.lightbend.akka.discovery</groupId>
                 <artifactId>akka-discovery-kubernetes-api_2.13</artifactId>
-                <version>1.1.3</version>
+                <version>1.1.4</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This commit updates the akka version from 1.1.3
to 1.1.4. The following dependencies were updated:

com.lightbend.akka.management:akka-management
com.lightbend.akka.management:akka-management-cluster-http com.lightbend.akka.management:akka-management-cluster-bootstrap com.lightbend.akka.discovery:akka-discovery-kubernetes-api

JIRA:LIGHTY-187
Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
(cherry picked from commit fcf7b8be8b9e10268ea866afaba68fbad1d77b11)