### PR TITLE
Remove unused import statement in file.proto

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-proto/src/main/proto/github.com/openconfig/gnoi/file/file.proto
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-proto/src/main/proto/github.com/openconfig/gnoi/file/file.proto
@@ -19,7 +19,6 @@ syntax = "proto3";
 package gnoi.file;
 
 import "github.com/openconfig/gnoi/types/types.proto";
-import "github.com/openconfig/gnoi/common/common.proto";
 
 option (types.gnoi_version) = "0.1.0";
 


### PR DESCRIPTION
The import statement for 'common.proto' in 'file.proto' was not being used in the code, so it was removed to clean up the codebase.
This was reported as a warning in maven 3.9.1

JIRA:LIGHTY-190