### PR TITLE
Bump protobuf-java-util

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
@@ -22,7 +22,7 @@
     <version>16.4.0-SNAPSHOT</version>
 
     <properties>
-        <protobuf.version>3.22.0</protobuf.version>
+        <protobuf.version>3.22.1</protobuf.version>
         <grpc.version>1.54.0</grpc.version>
     </properties>
 


### PR DESCRIPTION
Bump protobuf-java-util from 3.22.0 to 3.22.1

See this package in Maven Repository:
https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java-util/

JIRA:LIGHTY-187
Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
(cherry picked from commit 3acaf0bf9588fd0a68f6322bc79188013f99ad90)