### PR TITLE
Mark mockito-inline as test dependency

### DIFF
--- a/lighty-modules/lighty-netconf-sb/pom.xml
+++ b/lighty-modules/lighty-netconf-sb/pom.xml
@@ -73,6 +73,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.lighty.resources</groupId>


### PR DESCRIPTION
mockito-inline is used during tests, mark its dependency scope to test.