### PR TITLE
Drop support for version 16

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,15 +7,15 @@ Lighty.io version contains 3 numbers representing MAJOR.MINOR.PATCH (X.Y.Z) leve
 MAJOR number is mapped to major OpenDaylight release
 | Lighty.io | OpenDaylight    |
 |-----------|-----------------|
+| 18.Y.Z    | Argon (18)      |
 | 17.Y.Z    | Chlorine (17)   |
-| 16.Y.Z    | Sulfur (16)     |
 | ...       |                 |
 
 MINOR number is mapped to OpenDaylight service release (SR1, SR2, SR3, ..)
 | Lighty.io | OpenDaylight    |
 |-----------|-----------------|
-| 17.1.Z    | Chlorine SR1    |
-| 17.2.Z    | Chlorine SR2    |
+| 18.1.Z    | Argon SR1       |
+| 18.2.Z    | Argon SR2       |
 | ...       |                 |
 
 PATCH number represents Lighty.io release, usually security & bug fixes.


### PR DESCRIPTION
With the release of Lighty.io 18
we drop support for version 16.

JIRA:LIGHTY-196
Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
(cherry picked from commit 89f23c39044fc13bad4d87abfddac4651b7a4498)