### PR TITLE
Bump simulator to 18.0.0

### DIFF
--- a/.github/workflows/lighty-rnc-app/simulator/Dockerfile
+++ b/.github/workflows/lighty-rnc-app/simulator/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.16.2 as clone
 RUN apk add git
 WORKDIR /netconf-simulator
-RUN git clone https://github.com/PANTHEONtech/lighty-netconf-simulator.git -b 17.2.0
+RUN git clone https://github.com/PANTHEONtech/lighty-netconf-simulator.git -b 18.0.0
 
 FROM maven:3.8-eclipse-temurin-17-alpine as build
 WORKDIR /lighty-netconf-simulator
@@ -14,4 +14,4 @@ COPY --from=build /lighty-netconf-simulator/examples/devices/lighty-network-topo
 
 EXPOSE 17380
 
-ENTRYPOINT ["java", "-jar", "/lighty-netconf-simulator/target/lighty-network-topology-device-17.2.0.jar"]
+ENTRYPOINT ["java", "-jar", "/lighty-netconf-simulator/target/lighty-network-topology-device-18.0.0.jar"]


### PR DESCRIPTION
Use the latest simulator 18.0.0.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit 0e9a0891b2365198f122215afaa80133cba86e11)