### PR TITLE
Remove jetty-bom override

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -31,15 +31,6 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
-            <dependency>
-                <!-- Override odlparent version to fix: https://www.cve.org/CVERecord?id=CVE-2022-2048
-                     Remove when this will be fixed in upstream -->
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-bom</artifactId>
-                <version>9.4.48.v20220622</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
 
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>


### PR DESCRIPTION
odlparent version 10.0.5 contains jetty-bom version 9.4.49.v20220914 which is proven to fix CVE-2022-2048.

JIRA:LIGHTY-194
(cherry picked from commit 39b26ba4acb8ce3fe435ebcb89b1e39f9a605cd4)