### PR TITLE
Bump alpine to 3.16.5

### DIFF
--- a/.github/workflows/lighty-rnc-app/simulator/Dockerfile
+++ b/.github/workflows/lighty-rnc-app/simulator/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16.2 as clone
+FROM alpine:3.16.5 as clone
 RUN apk add git
 WORKDIR /netconf-simulator
 RUN git clone https://github.com/PANTHEONtech/lighty-netconf-simulator.git -b 17.2.0


### PR DESCRIPTION
Bump to newer version of alpine:
https://git.alpinelinux.org/aports/log/?h=v3.16.5

JIRA:LIGHTY-209