### PR TITLE
Bump alpine to 3.17.3

### DIFF
--- a/.github/workflows/lighty-rnc-app/simulator/Dockerfile
+++ b/.github/workflows/lighty-rnc-app/simulator/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16.5 as clone
+FROM alpine:3.17.3 as clone
 RUN apk add git
 WORKDIR /netconf-simulator
 RUN git clone https://github.com/PANTHEONtech/lighty-netconf-simulator.git -b 18.0.0


### PR DESCRIPTION
Bump to newer version of alpine:
https://www.alpinelinux.org/posts/Alpine-3.17.3-released.html

JIRA:LIGHTY-209
Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
(cherry picked from commit 6d909e7927297a10b18eff99fff5966d43050d56)