### PR TITLE
Bump slf4j to 1.7.36

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -100,12 +100,12 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.35</version>
+                <version>1.7.36</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-reload4j</artifactId>
-                <version>1.7.35</version>
+                <version>1.7.36</version>
             </dependency>
             <dependency>
                 <groupId>com.google.inject</groupId>


### PR DESCRIPTION
https://www.slf4j.org/news.html#2022-02-08%20-ReleaseOfSLF4J1.7.36