### PR TITLE
Bump ODL upstreams

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/pom.xml
@@ -53,7 +53,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/pom.xml
@@ -43,7 +43,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/pom.xml
@@ -39,7 +39,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/pom.xml
@@ -53,7 +53,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
-                <version>12.0.3</version>
+                <version>12.0.5</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -34,49 +34,49 @@
             <dependency>
                 <groupId>org.opendaylight.aaa</groupId>
                 <artifactId>aaa-artifacts</artifactId>
-                <version>0.17.7</version>
+                <version>0.17.8</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>controller-artifacts</artifactId>
-                <version>7.0.4</version>
+                <version>7.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.infrautils</groupId>
                 <artifactId>infrautils-artifacts</artifactId>
-                <version>5.0.3</version>
+                <version>5.0.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.mdsal</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>11.0.7</version>
+                <version>11.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>netconf-artifacts</artifactId>
-                <version>5.0.4</version>
+                <version>5.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yangtools-artifacts</artifactId>
-                <version>10.0.4</version>
+                <version>10.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.bgpcep</groupId>
                 <artifactId>bgpcep-artifacts</artifactId>
-                <version>0.19.3</version>
+                <version>0.19.5</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -49,12 +49,12 @@
             <plugin>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yang-maven-plugin</artifactId>
-                <version>10.0.4</version>
+                <version>10.0.6</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.opendaylight.mdsal</groupId>
                         <artifactId>mdsal-binding-java-api-generator</artifactId>
-                        <version>11.0.7</version>
+                        <version>11.0.9</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/lighty-core/lighty-controller/pom.xml
+++ b/lighty-core/lighty-controller/pom.xml
@@ -202,7 +202,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -203,7 +203,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>12.0.3</version>
+                            <version>12.0.5</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -220,7 +220,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>spotbugs</artifactId>
-                            <version>12.0.3</version>
+                            <version>12.0.5</version>
                         </dependency>
                         <!-- The SpotBugs Maven plugin uses SLF4J-2 -->
                         <dependency>

--- a/lighty-modules/integration-tests/pom.xml
+++ b/lighty-modules/integration-tests/pom.xml
@@ -64,7 +64,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/lighty-modules/lighty-aaa-aggregator/lighty-aaa/pom.xml
+++ b/lighty-modules/lighty-aaa-aggregator/lighty-aaa/pom.xml
@@ -77,7 +77,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/pom.xml
@@ -83,7 +83,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/lighty-modules/lighty-netconf-sb/pom.xml
+++ b/lighty-modules/lighty-netconf-sb/pom.xml
@@ -76,7 +76,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/lighty-modules/lighty-swagger/pom.xml
+++ b/lighty-modules/lighty-swagger/pom.xml
@@ -48,7 +48,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Adopt:
- odlparent-12.0.5
- yangtools-10.0.6
- infrautils-5.0.4
- mdsal-11.0.9
- controller-7.0.6
- aaa-0.17.8
- netconf-5.0.6
- bgpcep-0.19.5

JIRA:LIGHTY-220