### PR TITLE
Rename swagger to openapi in configuration

### DIFF
--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/example-config/configuration.json
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/example-config/configuration.json
@@ -63,7 +63,7 @@
       "keyStoreFilePath":"keystore/lightyio.jks",
       "trustKeyStorePassword":"8pgETwat",
       "trustKeyStoreFilePath":"keystore/lightyio.jks",
-      "enableSwagger": false
+      "enableOpenApi": false
     },
     "netconf-northbound":{
         "connectionTimeout":20000,

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/configmaps.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/configmaps.yaml
@@ -71,7 +71,7 @@ data:
             "keyStoreFilePath": "{{ .Values.lighty.server.keyStoreDirectory }}/{{ .Values.lighty.server.keyStoreFileName }}",
             "trustKeyStorePassword": {{ .Values.lighty.server.trustKeyStorePassword | quote }},
             "trustKeyStoreFilePath": "{{ .Values.lighty.server.trustKeyStoreDirectory }}/{{ .Values.lighty.server.trustKeyStoreFileName }}",
-            "enableSwagger": {{ .Values.lighty.server.enableSwagger }}
+            "enableOpenApi": {{ .Values.lighty.server.enableOpenApi }}
         },
         "netconf-northbound":{
             "connectionTimeout":20000,

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/values.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/values.yaml
@@ -33,7 +33,7 @@ lighty:
     trustKeyStorePassword: "8pgETwat"
     trustKeyStoreDirectory: "keystore"
     trustKeyStoreFileName: "lightyio.jks"
-    enableSwagger: false
+    enableOpenApi: false
 
   jmx:
     # Port on which JMX server in image is listening, should be same as defined in dockerfile

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/RncLightyModule.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/RncLightyModule.java
@@ -81,7 +81,7 @@ public class RncLightyModule {
                 startAndWaitLightyModule(this.aaaLighty);
             }
 
-            if (rncModuleConfig.getServerConfig().isEnableSwagger()) {
+            if (rncModuleConfig.getServerConfig().isEnableOpenApi()) {
                 this.swagger = initSwaggerLighty(this.rncModuleConfig.getRestconfConfig(),
                                                  this.jettyServerBuilder,
                                                  this.lightyController.getServices());
@@ -172,7 +172,7 @@ public class RncLightyModule {
     public boolean close() {
         LOG.info("Stopping RNC lighty.io application...");
         boolean success = true;
-        if (rncModuleConfig.getServerConfig().isEnableSwagger() && this.swagger != null) {
+        if (rncModuleConfig.getServerConfig().isEnableOpenApi() && this.swagger != null) {
             success &= swagger.shutdown(lightyModuleTimeout, DEFAULT_LIGHTY_MODULE_TIME_UNIT);
         }
         if (this.rncModuleConfig.getAaaConfig().isEnableAAA() && this.aaaLighty != null) {

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/java/io/lighty/applications/rnc/module/OpenApiTest.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/java/io/lighty/applications/rnc/module/OpenApiTest.java
@@ -46,7 +46,7 @@ public class OpenApiTest {
     @BeforeClass
     public void startUp() throws Exception {
         final var configPath = Paths.get(Objects.requireNonNull(this.getClass()
-                .getResource("/swagger_config.json")).toURI());
+                .getResource("/openapi_config.json")).toURI());
         rncModule = new RncLightyModule(RncLightyModuleConfigUtils.loadConfigFromFile(configPath));
         assertTrue(rncModule.initModules());
     }

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/openapi_config.json
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/openapi_config.json
@@ -72,6 +72,6 @@
       "restconfServletContextPath":"/restconf"
     },
     "lighty-server" : {
-      "enableSwagger": true
+      "enableOpenApi": true
     }
 }

--- a/lighty-modules/lighty-jetty-server/src/main/java/io/lighty/server/config/LightyServerConfig.java
+++ b/lighty-modules/lighty-jetty-server/src/main/java/io/lighty/server/config/LightyServerConfig.java
@@ -20,7 +20,7 @@ public class LightyServerConfig {
     private boolean useHttps = false;
     private boolean useHttp2 = false;
     private boolean needClientAuth = false;
-    private boolean enableSwagger = false;
+    private boolean enableOpenApi = false;
 
     public void setSecurityConfig(final SecurityConfig securityConfig) {
         this.securityConfig = securityConfig;
@@ -86,12 +86,12 @@ public class LightyServerConfig {
         this.needClientAuth = needClientAuth;
     }
 
-    public boolean isEnableSwagger() {
-        return enableSwagger;
+    public boolean isEnableOpenApi() {
+        return enableOpenApi;
     }
 
-    public void setEnableSwagger(boolean enableSwagger) {
-        this.enableSwagger = enableSwagger;
+    public void setEnableOpenApi(boolean enableOpenApi) {
+        this.enableOpenApi = enableOpenApi;
     }
 
     public boolean isUseHttp2() {

--- a/lighty-modules/lighty-jetty-server/src/test/resources/httpsConfig.json
+++ b/lighty-modules/lighty-jetty-server/src/test/resources/httpsConfig.json
@@ -2,6 +2,6 @@
   "lighty-server": {
     "useHttps": true,
     "needClientAuth": true,
-    "enableSwagger": true
+    "enableOpenApi": true
   }
 }


### PR DESCRIPTION
Rename swagger to openapi in configuration so that it can be renamed
in readme files and in parameters/variables after

JIRA: LIGHTY-225