### PR TITLE
Sync with odlparent 12.0.5 versions

### DIFF
--- a/lighty-core/lighty-minimal-parent/pom.xml
+++ b/lighty-core/lighty-minimal-parent/pom.xml
@@ -48,7 +48,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -193,7 +193,7 @@
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
                             <!-- This should match the dependency management on com.puppycrawl.tools:checkstyle above -->
-                            <version>10.8.1</version>
+                            <version>10.9.3</version>
                         </dependency>
                         <dependency>
                             <groupId>com.github.sevntu-checkstyle</groupId>
@@ -210,7 +210,7 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>4.7.3.2</version>
+                    <version>4.7.3.4</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.github.spotbugs</groupId>


### PR DESCRIPTION
https://docs.opendaylight.org/projects/odlparent/en/latest/NEWS.html#version-12-0-5

Adopt:
-checkstyle-10.9.3
-maven-enforcer-plugin-3.3.0
-spotbugs-maven-plugin-4.7.3.4

JIRA:LIGHTY-241