### PR TITLE
Bump Netty to 4.1.94

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -22,6 +22,15 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- FIXME remove this when ODL bumps to at least 4.1.94.Final -->
+            <!-- FIX for https://github.com/netty/netty/security/advisories/GHSA-6mjq-h674-j845 -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.94.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>


### PR DESCRIPTION
https://netty.io/news/2023/06/19/4-1-94-Final.html

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit 342529f37c91cf7a735e220a768332c53d5af4dd)