### PR TITLE
Bump protobuf-java to 3.23.4

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
@@ -22,7 +22,7 @@
     <version>19.0.0-SNAPSHOT</version>
 
     <properties>
-        <protobuf.version>3.23.3</protobuf.version>
+        <protobuf.version>3.23.4</protobuf.version>
         <grpc.version>1.56.0</grpc.version>
     </properties>
 


### PR DESCRIPTION
https://github.com/protocolbuffers/protobuf/releases/tag/v23.4