### PR TITLE
Add cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 lighty-models/**/java/org/opendaylight/yang/gen/**/*
 
 bin/
+cache/
 dist
 .idea
 .classpath


### PR DESCRIPTION
When device is connected, a cache directory is created to contain its YANG models. This directory remains as unintentional git change, so lets ignore it.

JIRA: LIGHTY-246
Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
(cherry picked from commit 39acef6ef19dc32f48852b5671f8854fa8ab314c)