### PR TITLE
Add possibility to change base path

### DIFF
--- a/lighty-modules/lighty-openapi/src/main/java/io/lighty/openapi/OpenApiLighty.java
+++ b/lighty-modules/lighty-openapi/src/main/java/io/lighty/openapi/OpenApiLighty.java
@@ -56,7 +56,7 @@ public class OpenApiLighty extends AbstractLightyModule {
         LOG.info("basePath: {}", basePathString);
 
         this.apiDocService = new OpenApiServiceImpl(lightyServices.getDOMSchemaService(),
-            lightyServices.getDOMMountPointService());
+            lightyServices.getDOMMountPointService(), basePathString);
 
         OpenApiApplication apiDocApplication = new OpenApiApplication(apiDocService);
 


### PR DESCRIPTION
We have lost possibility to apply base path from lighty.io configuration to swagger in:
https://github.com/PANTHEONtech/lighty/commit/16c0b4ac
Now the issue is fixed as part of NETCONF 6.0.0 and 5.0.7.

JIRA: LIGHTY-236