### PR TITLE
Add possibility to change base path

### DIFF
--- a/lighty-modules/lighty-swagger/src/main/java/io/lighty/swagger/SwaggerLighty.java
+++ b/lighty-modules/lighty-swagger/src/main/java/io/lighty/swagger/SwaggerLighty.java
@@ -56,7 +56,7 @@ public class SwaggerLighty extends AbstractLightyModule {
         LOG.info("basePath: {}", basePathString);
 
         this.apiDocService = new ApiDocServiceImpl(lightyServices.getDOMSchemaService(),
-            lightyServices.getDOMMountPointService());
+            lightyServices.getDOMMountPointService(), basePathString);
 
         ApiDocApplication apiDocApplication = new ApiDocApplication(apiDocService);
 


### PR DESCRIPTION
We have lost possibility to apply base path from lighty.io configuration to swagger in: https://github.com/PANTHEONtech/lighty/commit/16c0b4ac Now the issue is fixed as part of NETCONF 6.0.0 and 5.0.7.

JIRA: LIGHTY-236
Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
(cherry picked from commit e4e1b87616bb8b58d1af9e668bf7c3a7cb221e92)