### PR TITLE
Bump GPG plugin to 3.1.0

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -255,7 +255,7 @@
                       <plugin>
                           <groupId>org.apache.maven.plugins</groupId>
                           <artifactId>maven-gpg-plugin</artifactId>
-                          <version>3.0.1</version>
+                          <version>3.1.0</version>
                           <executions>
                               <execution>
                                   <id>sign-artifacts</id>

--- a/lighty-core/lighty-bom/pom.xml
+++ b/lighty-core/lighty-bom/pom.xml
@@ -264,7 +264,7 @@
                       <plugin>
                           <groupId>org.apache.maven.plugins</groupId>
                           <artifactId>maven-gpg-plugin</artifactId>
-                          <version>3.0.1</version>
+                          <version>3.1.0</version>
                           <executions>
                               <execution>
                                   <id>sign-artifacts</id>

--- a/lighty-core/lighty-minimal-parent/pom.xml
+++ b/lighty-core/lighty-minimal-parent/pom.xml
@@ -76,7 +76,7 @@
                       <plugin>
                           <groupId>org.apache.maven.plugins</groupId>
                           <artifactId>maven-gpg-plugin</artifactId>
-                          <version>3.0.1</version>
+                          <version>3.1.0</version>
                           <executions>
                               <execution>
                                   <id>sign-artifacts</id>

--- a/lighty-resources/log4j2-config/pom.xml
+++ b/lighty-resources/log4j2-config/pom.xml
@@ -32,7 +32,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.0.1</version>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
https://github.com/apache/maven-gpg-plugin/releases/tag/maven-gpg-plugin-3.1.0

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit e619dba78d07d63af15e80e2f66a380eeb2cbd00)