### PR TITLE
Switch all scripts to use Temurin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
-          distribution: 'zulu'
+          distribution: 'temurin'
       - name: Cache SonarCloud packages
         uses: actions/cache@v1
         if: ${{ env.SONAR_TOKEN != 0 }}

--- a/.github/workflows/publish-docker-helm.yml
+++ b/.github/workflows/publish-docker-helm.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
-          distribution: 'zulu'
+          distribution: 'temurin'
       - name: Cache Maven packages
         uses: actions/cache@v1
         with:

--- a/.github/workflows/publish-rcgnmi.yml
+++ b/.github/workflows/publish-rcgnmi.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
-          distribution: 'zulu'
+          distribution: 'temurin'
       - name: Cache Maven packages
         uses: actions/cache@v1
         with:

--- a/.github/workflows/publish-rnc.yml
+++ b/.github/workflows/publish-rnc.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
-          distribution: 'zulu'
+          distribution: 'temurin'
       - name: Cache Maven packages
         uses: actions/cache@v1
         with:

--- a/.github/workflows/test-lighty-app.yml
+++ b/.github/workflows/test-lighty-app.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
-          distribution: 'zulu'
+          distribution: 'temurin'
       - name: Cache Maven packages
         uses: actions/cache@v1
         with:


### PR DESCRIPTION
Use Eclipse Temurin JDK in all lighty.io scripts used by Github Actions.