### PR TITLE
Sync dependencies with odlparent 12.0.8

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -136,7 +136,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.12.0</version>
+                <version>3.13.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>

--- a/lighty-core/lighty-minimal-parent/pom.xml
+++ b/lighty-core/lighty-minimal-parent/pom.xml
@@ -48,7 +48,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.4.1</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -193,7 +193,7 @@
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
                             <!-- This should match the dependency management on com.puppycrawl.tools:checkstyle above -->
-                            <version>10.12.1</version>
+                            <version>10.12.3</version>
                         </dependency>
                         <dependency>
                             <groupId>com.github.sevntu-checkstyle</groupId>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -210,7 +210,7 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>4.7.3.4</version>
+                    <version>4.7.3.6</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.github.spotbugs</groupId>

--- a/lighty-modules/lighty-aaa-aggregator/lighty-aaa/src/main/java/io/lighty/aaa/AAALighty.java
+++ b/lighty-modules/lighty-aaa-aggregator/lighty-aaa/src/main/java/io/lighty/aaa/AAALighty.java
@@ -58,7 +58,7 @@ public final class AAALighty extends AbstractLightyModule {
         return true;
     }
 
-    private static class AAAShiroProviderHandler {
+    private static final class AAAShiroProviderHandler {
 
         AAALightyShiroProvider aaaLightyShiroProvider;
 

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-connector/src/test/java/io/lighty/modules/gnmi/connector/tests/gnmi/GnmiTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-connector/src/test/java/io/lighty/modules/gnmi/connector/tests/gnmi/GnmiTest.java
@@ -210,7 +210,7 @@ public class GnmiTest {
         });
     }
 
-    private static class TestGrpcServiceImpl extends gNMIGrpc.gNMIImplBase {
+    private static final class TestGrpcServiceImpl extends gNMIGrpc.gNMIImplBase {
         private String gnmiVersion = null;
 
         @Override

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-connector/src/test/java/io/lighty/modules/gnmi/connector/tests/gnoi/GnoiTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-connector/src/test/java/io/lighty/modules/gnmi/connector/tests/gnoi/GnoiTest.java
@@ -135,7 +135,7 @@ public class GnoiTest {
         }
     }
 
-    private static class TestGnoiServiceImpl extends FileGrpc.FileImplBase {
+    private static final class TestGnoiServiceImpl extends FileGrpc.FileImplBase {
 
         @Override
         public void get(final gnoi.file.FileOuterClass.GetRequest request,


### PR DESCRIPTION
Sync third-party dependencies with odlparent 12.0.8 on 18.x branch.


https://github.com/opendaylight/odlparent/compare/v12.0.7...v12.0.8