### PR TITLE
Introduce variable to store simulator version

### DIFF
--- a/.github/workflows/lighty-rnc-app/simulator/Dockerfile
+++ b/.github/workflows/lighty-rnc-app/simulator/Dockerfile
@@ -1,17 +1,25 @@
+ARG SIMULATOR_VERSION="18.2.0"
+
 FROM alpine:3.18.3 as clone
+
+ARG SIMULATOR_VERSION
 RUN apk add git
 WORKDIR /netconf-simulator
-RUN git clone https://github.com/PANTHEONtech/lighty-netconf-simulator.git -b 18.2.0
+RUN git clone https://github.com/PANTHEONtech/lighty-netconf-simulator.git -b $SIMULATOR_VERSION
 
 FROM maven:3.8-eclipse-temurin-17-alpine as build
+ARG SIMULATOR_VERSION
 WORKDIR /lighty-netconf-simulator
 COPY --from=clone /netconf-simulator/lighty-netconf-simulator /lighty-netconf-simulator
 RUN mvn -B install -DskipTests
 
 FROM eclipse-temurin:17-jre-alpine
+ARG SIMULATOR_VERSION
 WORKDIR /lighty-netconf-simulator
 COPY --from=build /lighty-netconf-simulator/examples/devices/lighty-network-topology-device/target/ /lighty-netconf-simulator/target
 
 EXPOSE 17380
 
-ENTRYPOINT ["java", "-jar", "/lighty-netconf-simulator/target/lighty-network-topology-device-18.2.0.jar"]
+ENV APP_PATH="/lighty-netconf-simulator/target/lighty-network-topology-device-$SIMULATOR_VERSION.jar"
+ENTRYPOINT java -jar $APP_PATH
+


### PR DESCRIPTION
Introduce an ARG (argument) in the Dockerfile to store the simulator version as a variable. The default version is set to "18.2.0," and it can be customized during the image build process using the --build-arg flag.

JIRA:LIGHTY-260