### PR TITLE
Sync dependencies with odlparent 13.0.6

### DIFF
--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -134,7 +134,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.10</version>
+                    <version>0.8.11</version>
                     <executions>
                         <execution>
                             <id>jacoco-prepare-agent</id>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -171,7 +171,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.6.0</version>
                     <configuration combine.children="append">
                         <!-- Keep things quiet except for warnings/errors -->
                         <quiet>true</quiet>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -193,7 +193,7 @@
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
                             <!-- This should match the dependency management on com.puppycrawl.tools:checkstyle above -->
-                            <version>10.12.3</version>
+                            <version>10.12.4</version>
                         </dependency>
                         <dependency>
                             <groupId>com.github.sevntu-checkstyle</groupId>

--- a/lighty-examples/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/lighty-controller-springboot-netconf/pom.xml
@@ -102,7 +102,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.10</version>
+                <version>0.8.11</version>
                 <executions>
                     <execution>
                         <id>jacoco-prepare-agent</id>


### PR DESCRIPTION
https://github.com/opendaylight/odlparent/blob/master/docs/NEWS.rst#version-1306

[Comparing v13.0.4...v13.0.6 · opendaylight/odlparent](https://github.com/opendaylight/odlparent/compare/v13.0.4...v13.0.6)