### PR TITLE
Adopt odlparent 11.0.7 versions

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -34,7 +34,7 @@
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
-                <version>11.0.6</version>
+                <version>11.0.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -43,49 +43,49 @@
             <dependency>
                 <groupId>org.opendaylight.aaa</groupId>
                 <artifactId>aaa-artifacts</artifactId>
-                <version>0.16.9</version>
+                <version>0.16.10</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>controller-artifacts</artifactId>
-                <version>6.0.9</version>
+                <version>6.0.10</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.infrautils</groupId>
                 <artifactId>infrautils-artifacts</artifactId>
-                <version>4.0.6</version>
+                <version>4.0.8</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.mdsal</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>10.0.8</version>
+                <version>10.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>netconf-artifacts</artifactId>
-                <version>4.0.8</version>
+                <version>4.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yangtools-artifacts</artifactId>
-                <version>9.0.8</version>
+                <version>9.0.10</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.bgpcep</groupId>
                 <artifactId>bgpcep-artifacts</artifactId>
-                <version>0.18.8</version>
+                <version>0.18.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -49,12 +49,12 @@
             <plugin>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yang-maven-plugin</artifactId>
-                <version>9.0.8</version>
+                <version>9.0.10</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.opendaylight.mdsal</groupId>
                         <artifactId>mdsal-binding-java-api-generator</artifactId>
-                        <version>10.0.8</version>
+                        <version>10.0.9</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -203,7 +203,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>11.0.6</version>
+                            <version>11.0.7</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -220,7 +220,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>spotbugs</artifactId>
-                            <version>11.0.6</version>
+                            <version>11.0.7</version>
                         </dependency>
                         <!-- The SpotBugs Maven plugin uses SLF4J-2 -->
                         <dependency>


### PR DESCRIPTION
Adopt:
- odlparent-11.0.7
- infrautils-4.0.8
- yangtools-9.0.10
- mdsal-10.0.9
- controller-6.0.10
- aaa-0.16.10
- netconf-4.0.9
- bgpcep-0.18.9

JIRA: LIGHTY-270