### PR TITLE
Bump maven to 3.9.x

### DIFF
--- a/.github/workflows/lighty-rnc-app/simulator/Dockerfile
+++ b/.github/workflows/lighty-rnc-app/simulator/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add git
 WORKDIR /netconf-simulator
 RUN git clone https://github.com/PANTHEONtech/lighty-netconf-simulator.git -b $SIMULATOR_VERSION
 
-FROM maven:3.8-eclipse-temurin-17-alpine as build
+FROM maven:3.9-eclipse-temurin-17-alpine as build
 ARG SIMULATOR_VERSION
 WORKDIR /lighty-netconf-simulator
 COPY --from=clone /netconf-simulator/lighty-netconf-simulator /lighty-netconf-simulator


### PR DESCRIPTION
https://hub.docker.com/layers/library/maven/3.9-eclipse-temurin-17-alpine/images/sha256-6a5243d49d7d4913f842646891fdc037085d763a4d2fb5e5c2aac5f787cf401e

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit 4a65830201c0fafabf842d83565b775eec3c0fc8)