### PR TITLE
Add notifications to CommunityRestConf

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
@@ -110,7 +110,7 @@ public class RcGnmiAppModule {
 
     private CommunityRestConf initRestconf(final RestConfConfiguration config, final LightyServices services) {
         final RestConfConfiguration conf = RestConfConfigUtils.getRestConfConfiguration(config, services);
-        return CommunityRestConfBuilder.from(conf).build();
+        return CommunityRestConfBuilder.from(conf).withScheduledThreadPool(services.getScheduledThreadPool()).build();
     }
 
     private GnmiSouthboundModule initGnmiModule(final LightyServices services,

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/RncLightyModule.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/main/java/io/lighty/applications/rnc/module/RncLightyModule.java
@@ -131,6 +131,7 @@ public class RncLightyModule {
 
         return CommunityRestConfBuilder.from(restConfConfiguration)
             .withLightyServer(jettyServerBuilder)
+            .withScheduledThreadPool(services.getScheduledThreadPool())
             .build();
     }
 

--- a/lighty-examples/lighty-bgp-community-restconf-app/src/main/java/io/lighty/examples/controllers/bgpapp/Main.java
+++ b/lighty-examples/lighty-bgp-community-restconf-app/src/main/java/io/lighty/examples/controllers/bgpapp/Main.java
@@ -111,6 +111,7 @@ public class Main {
 
         restconf = CommunityRestConfBuilder
                 .from(RestConfConfigUtils.getRestConfConfiguration(restConfConfiguration, controller.getServices()))
+                .withScheduledThreadPool(controller.getServices().getScheduledThreadPool())
                 .build();
         Preconditions.checkState(startLightyModule(restconf,  modulesConfig.getModuleTimeoutSeconds()),
                 "Unable to start restconf module");

--- a/lighty-examples/lighty-community-aaa-restconf-app/src/main/java/io/lighty/kit/examples/community/aaa/restconf/Main.java
+++ b/lighty-examples/lighty-community-aaa-restconf-app/src/main/java/io/lighty/kit/examples/community/aaa/restconf/Main.java
@@ -114,6 +114,7 @@ public final class Main {
                 .from(RestConfConfigUtils.getRestConfConfiguration(restconfConfiguration,
                     this.lightyController.getServices()))
                 .withLightyServer(jettyServerBuilder)
+                .withScheduledThreadPool(this.lightyController.getServices().getScheduledThreadPool())
                 .build();
         final boolean restconfStartOk = this.restconf.start()
                 .get(modulesConfig.getModuleTimeoutSeconds(), TimeUnit.SECONDS);

--- a/lighty-examples/lighty-community-restconf-actions-app/src/main/java/io/lighty/examples/controllers/actions/Main.java
+++ b/lighty-examples/lighty-community-restconf-actions-app/src/main/java/io/lighty/examples/controllers/actions/Main.java
@@ -68,7 +68,7 @@ public class Main {
     }
 
     @SuppressWarnings("IllegalCatch")
-    @SuppressFBWarnings("SLF4J_SIGN_ONLY_FORMAT")
+    @SuppressFBWarnings({"SLF4J_SIGN_ONLY_FORMAT", "REC_CATCH_EXCEPTION"})
     public void start(String[] args, boolean registerShutdownHook) {
         final Stopwatch stopwatch = Stopwatch.createStarted();
         LOG.info(".__  .__       .__     __              .__           _________________    _______");
@@ -158,6 +158,7 @@ public class Main {
                 .from(RestConfConfigUtils.getRestConfConfiguration(restconfConfiguration,
                     this.lightyController.getServices()))
                 .withLightyServer(jettyServerBuilder)
+                .withScheduledThreadPool(lightyController.getServices().getScheduledThreadPool())
                 .build();
 
         //3. start openApi and RestConf server

--- a/lighty-examples/lighty-community-restconf-netconf-app/src/main/java/io/lighty/examples/controllers/restconfapp/Main.java
+++ b/lighty-examples/lighty-community-restconf-netconf-app/src/main/java/io/lighty/examples/controllers/restconfapp/Main.java
@@ -133,6 +133,10 @@ public class Main {
         throws ConfigurationException, ExecutionException, InterruptedException, TimeoutException,
                ModuleStartupException {
 
+        //FIXME remove this after paths NETCONF-1218 is resolved.
+        restconfConfiguration.setRestconfServletContextPath("/rests");
+        restconfConfiguration.setHttpPort(8181);
+
         //1. initialize and start Lighty controller (MD-SAL, Controller, YangTools, Akka)
         LightyControllerBuilder lightyControllerBuilder = new LightyControllerBuilder();
         this.lightyController = lightyControllerBuilder.from(controllerConfiguration).build();

--- a/lighty-examples/lighty-community-restconf-netconf-app/src/main/java/io/lighty/examples/controllers/restconfapp/Main.java
+++ b/lighty-examples/lighty-community-restconf-netconf-app/src/main/java/io/lighty/examples/controllers/restconfapp/Main.java
@@ -149,6 +149,7 @@ public class Main {
                 .from(RestConfConfigUtils.getRestConfConfiguration(restconfConfiguration,
                     this.lightyController.getServices()))
                 .withLightyServer(jettyServerBuilder)
+                .withScheduledThreadPool(lightyController.getServices().getScheduledThreadPool())
                 .build();
 
         //3. start openApi and RestConf server

--- a/lighty-examples/lighty-community-restconf-netconf-app/src/test/java/io/lighty/examples/controllers/restconfapp/tests/RestconfAppTest.java
+++ b/lighty-examples/lighty-community-restconf-netconf-app/src/test/java/io/lighty/examples/controllers/restconfapp/tests/RestconfAppTest.java
@@ -37,7 +37,7 @@ public class RestconfAppTest {
     public static void init() {
         restconfApp = new Main();
         restconfApp.start();
-        restClient = new RestClient("http://localhost:8888/");
+        restClient = new RestClient("http://localhost:8181/");
     }
 
     /**
@@ -46,7 +46,7 @@ public class RestconfAppTest {
     @Test
     public void simpleApplicationTest() throws IOException, InterruptedException {
         HttpResponse<String> operations;
-        restClient.POST("restconf/data/network-topology:network-topology/topology=topology-netconf",
+        restClient.POST("rests/data/network-topology:network-topology/topology=topology-netconf",
             """
                     {
                         "netconf-topology:node": [
@@ -56,11 +56,11 @@ public class RestconfAppTest {
                         ]
                     }""");
 
-        operations = restClient.GET("restconf/operations");
+        operations = restClient.GET("rests/operations");
         Assert.assertEquals(operations.statusCode(), 200);
-        operations = restClient.GET("restconf/data/network-topology:network-topology?content=config");
+        operations = restClient.GET("rests/data/network-topology:network-topology?content=config");
         Assert.assertEquals(operations.statusCode(), 200);
-        operations = restClient.GET("restconf/data/network-topology:network-topology?content=nonconfig");
+        operations = restClient.GET("rests/data/network-topology:network-topology?content=nonconfig");
         Assert.assertEquals(operations.statusCode(), 200);
     }
 

--- a/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/LightyTestUtils.java
+++ b/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/LightyTestUtils.java
@@ -69,6 +69,7 @@ public final class LightyTestUtils {
             final CommunityRestConf communityRestConf = CommunityRestConfBuilder
                     .from(RestConfConfigUtils.getRestConfConfiguration(restConfConfiguration,
                             services))
+                    .withScheduledThreadPool(services.getScheduledThreadPool())
                     .build();
 
             LOG.info("Starting CommunityRestConf");

--- a/lighty-modules/lighty-restconf-nb-community/pom.xml
+++ b/lighty-modules/lighty-restconf-nb-community/pom.xml
@@ -53,6 +53,10 @@
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-sse</artifactId>
+        </dependency>
 
         <!--Tests-->
         <dependency>

--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/CommunityRestConfBuilder.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/CommunityRestConfBuilder.java
@@ -9,6 +9,7 @@ package io.lighty.modules.northbound.restconf.community.impl;
 
 import io.lighty.modules.northbound.restconf.community.impl.config.RestConfConfiguration;
 import io.lighty.server.LightyServerBuilder;
+import org.opendaylight.controller.config.threadpool.ScheduledThreadPool;
 
 /**
  * Builder for {@link CommunityRestConf}.
@@ -17,6 +18,7 @@ public final class CommunityRestConfBuilder {
 
     private RestConfConfiguration restconfConfiguration = null;
     private LightyServerBuilder lightyServerBuilder = null;
+    private ScheduledThreadPool threadPool = null;
 
 
     private CommunityRestConfBuilder(final RestConfConfiguration configuration) {
@@ -45,6 +47,17 @@ public final class CommunityRestConfBuilder {
     }
 
     /**
+     * Add ScheduledThreadPool.
+     *
+     * @param pool input scheduledThreadPool.
+     * @return instance of {@link CommunityRestConfBuilder}.
+     */
+    public CommunityRestConfBuilder withScheduledThreadPool(final ScheduledThreadPool pool) {
+        this.threadPool = pool;
+        return this;
+    }
+
+    /**
      * Build new {@link CommunityRestConf} instance from {@link CommunityRestConfBuilder}.
      * @return instance of CommunityRestConf.
      */
@@ -55,6 +68,6 @@ public final class CommunityRestConfBuilder {
             this.restconfConfiguration.getDomMountPointService(),
             this.restconfConfiguration.getDomSchemaService(),
             this.restconfConfiguration.getInetAddress(), this.restconfConfiguration.getHttpPort(),
-            this.restconfConfiguration.getRestconfServletContextPath(), this.lightyServerBuilder);
+            this.restconfConfiguration.getRestconfServletContextPath(), this.lightyServerBuilder, this.threadPool);
     }
 }

--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
@@ -40,8 +40,9 @@ public final class RestConfConfigUtils {
             org.opendaylight.yang.gen.v1.subscribe.to.notification.rev161028
                     .$YangModuleInfoImpl.getInstance(),
             org.opendaylight.yang.gen.v1.instance.identifier.patch.module.rev151121
-                    .$YangModuleInfoImpl.getInstance()
-            );
+                    .$YangModuleInfoImpl.getInstance(),
+            org.opendaylight.yang.gen.v1.urn.opendaylight.device.notification.rev221106
+                     .$YangModuleInfoImpl.getInstance());
     public static final int MAXIMUM_FRAGMENT_LENGTH = 0;
     public static final int IDLE_TIMEOUT =  30000;
     public static final int HEARTBEAT_INTERVAL = 10000;


### PR DESCRIPTION
This PR adds support for listening on device notifications over SSE into` CommunityRestConf` module.

The functionality requires that application configuration is using base path set to `rests` as is OpenDaylight default due to https://jira.opendaylight.org/browse/NETCONF-1218.

When correctly configured all applications based on `CommunityRestConf` can be used for notifications listening. For now we recommends to use `lighty-community-restconf-netconf-app`.