### PR TITLE
Provide RpcConsumerRegistry to LightyServices

### DIFF
--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/LightyServices.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/LightyServices.java
@@ -23,6 +23,7 @@ import org.opendaylight.mdsal.binding.api.DataBroker;
 import org.opendaylight.mdsal.binding.api.MountPointService;
 import org.opendaylight.mdsal.binding.api.NotificationPublishService;
 import org.opendaylight.mdsal.binding.api.NotificationService;
+import org.opendaylight.mdsal.binding.api.RpcConsumerRegistry;
 import org.opendaylight.mdsal.binding.api.RpcProviderService;
 import org.opendaylight.mdsal.binding.dom.adapter.ConstantAdapterContext;
 import org.opendaylight.mdsal.binding.dom.codec.api.BindingCodecTreeFactory;
@@ -130,5 +131,7 @@ public interface LightyServices extends LightyModuleRegistryService {
     ActionProviderService getActionProviderService();
 
     ActionService getActionService();
+
+    RpcConsumerRegistry getRpcConsumerRegistry();
 
 }

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
@@ -79,6 +79,7 @@ import org.opendaylight.mdsal.binding.api.DataBroker;
 import org.opendaylight.mdsal.binding.api.MountPointService;
 import org.opendaylight.mdsal.binding.api.NotificationPublishService;
 import org.opendaylight.mdsal.binding.api.NotificationService;
+import org.opendaylight.mdsal.binding.api.RpcConsumerRegistry;
 import org.opendaylight.mdsal.binding.api.RpcProviderService;
 import org.opendaylight.mdsal.binding.dom.adapter.BindingAdapterFactory;
 import org.opendaylight.mdsal.binding.dom.adapter.BindingDOMMountPointServiceAdapter;
@@ -196,6 +197,7 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
     private AkkaManagement akkaManagement;
     private Optional<ClusteringHandler> clusteringHandler;
     private Optional<InitialConfigData> initialConfigData;
+    private RpcConsumerRegistry rpcConsumerRegistry;
 
 
     public LightyControllerImpl(final ExecutorService executorService, final Config actorSystemConfig,
@@ -306,6 +308,7 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
         this.actionProviderService = this.bindingAdapterFactory.createActionProviderService(
                 this.domActionProviderService);
         this.actionService = bindingAdapterFactory.createActionService(this.domActionService);
+        rpcConsumerRegistry = bindingAdapterFactory.createRpcConsumerRegistry(domRpcRouter.getRpcService());
 
         this.rpcProviderService = new BindingDOMRpcProviderServiceAdapter(this.codec,
                 this.domRpcRouter.getRpcProviderService());
@@ -662,6 +665,11 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
     @Override
     public ActionProviderService getActionProviderService() {
         return actionProviderService;
+    }
+
+    @Override
+    public RpcConsumerRegistry getRpcConsumerRegistry() {
+        return rpcConsumerRegistry;
     }
 
     @Override


### PR DESCRIPTION
Due to MDSAL RpcService to Rpc<?,?> migration, RpcService instance is extracted from RpcConsumerRegistry. We want to have RpcConsumerRegistry available in LightyServices to easily access it anywhere.

Fixes #1775

Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit 6a0a3979fff3fa064d0bec64d9f72f4bb04ce72b)