### PR TITLE
Set correct List key type in gNMI simulator

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/resources/additional/models/gnmi-test-model.yang
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/resources/additional/models/gnmi-test-model.yang
@@ -5,6 +5,8 @@ module gnmi-test-model {
   prefix "gtm";
 
   import openconfig-extensions { prefix oc-ext; }
+  import openconfig-inet-types { prefix inet; }
+  import openconfig-aaa-types { prefix types; }
 
   oc-ext:openconfig-version "1.0.0";
 
@@ -23,6 +25,35 @@ module gnmi-test-model {
         leaf nc-leaf {
             type string;
         }
+    }
+    list multiple-key-list {
+      key "number leafref-key identityref-key union-key";
+      leaf number {
+        type inet:as-number;
+      }
+      leaf leafref-key {
+        type leafref {
+          path "../number";
+        }
+      }
+      leaf identityref-key {
+        type identityref {
+          base "types:SYSTEM_DEFINED_ROLES";
+        }
+      }
+      leaf union-key {
+          type union {
+            type int32;
+            type enumeration {
+              enum "unbounded";
+            }
+          }
+        }
+      container inner-container {
+        leaf inner-data {
+          type string;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Previously, the List key was always set as a String for YangInstanceIdentifier generated from gNMI path. This prevented data from being merged into the datastore, as this type of key was not found in the datastore.

This commit addresses the issue by setting the correct value defined in the typeDefinition QName.

JIRA: LIGHTY-285
Signed-off-by: Peter Suna <peter.suna@pantheon.tech>
Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit 78ae7fdb76dd1e70115d137e6f60667679679de0)