### PR TITLE
Set correct Json value in gNMI simulator

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/gnmi/GnmiCrudService.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-device-simulator/src/main/java/io/lighty/modules/gnmi/simulatordevice/gnmi/GnmiCrudService.java
@@ -221,7 +221,7 @@ public class GnmiCrudService {
                     String.format("%s:%s",
                             module.getName(),
                             Iterables.getLast(identifier.getPathArguments()).getNodeType().getLocalName()), gson,
-                    lastPathArgument);
+                    lastPathArgument, context);
             node = DataConverter.nodeFromJsonString(identifier, json, context);
             // In case of list entry, point to the list itself
             resultingIdentifier = identifier.getParent();

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/mountpoint/codecs/GetResponseToNormalizedNodeCodec.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/main/java/io/lighty/gnmi/southbound/mountpoint/codecs/GetResponseToNormalizedNodeCodec.java
@@ -105,7 +105,8 @@ public class GetResponseToNormalizedNodeCodec implements BiCodec<Gnmi.GetRespons
                     if (identifier.getLastPathArgument() instanceof NodeIdentifierWithPredicates) {
                         final NodeIdentifierWithPredicates lastPathArgument
                                 = (NodeIdentifierWithPredicates) identifier.getLastPathArgument();
-                        responseJson = JsonUtils.wrapJsonWithArray(responseJson, wrapWith, gson, lastPathArgument);
+                        responseJson = JsonUtils.wrapJsonWithArray(responseJson, wrapWith, gson, lastPathArgument,
+                            schemaContextProvider.getSchemaContext());
                     } else {
                         responseJson = JsonUtils.wrapJsonWithObject(responseJson, wrapWith, gson);
                     }

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/SimulatorCrudTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/SimulatorCrudTest.java
@@ -325,6 +325,39 @@ public class SimulatorCrudTest {
     }
 
     @Test
+    public void setMultipleKeyListAsLastElementInPathTest() throws Exception {
+        final var multipleKeyPath = Gnmi.Path.newBuilder()
+            .addElem(Gnmi.PathElem.newBuilder()
+                .setName("gnmi-test-model:test-data")
+                .build())
+            .addElem(Gnmi.PathElem.newBuilder()
+                .setName("multiple-key-list")
+                .putKey("number", "10")
+                .putKey("leafref-key", "15")
+                .putKey("identityref-key", "openconfig-aaa-types:SYSTEM_DEFINED_ROLES")
+                .putKey("union-key", "5")
+                .build())
+            .build();
+        final var innerContainerUpdate = Gnmi.Update.newBuilder()
+            .setPath(multipleKeyPath)
+            .setVal(Gnmi.TypedValue.newBuilder()
+                .setJsonIetfVal(ByteString.copyFromUtf8("""
+                    {
+                      "inner-container": {
+                        "inner-data": "data"
+                      }
+                    }
+                    """))
+                .build())
+            .build();
+        final var setRequest = Gnmi.SetRequest.newBuilder().addUpdate(innerContainerUpdate).build();
+        LOG.info("Sending set request:\n{}", setRequest);
+
+        final var setResponse = sessionProvider.getGnmiSession().set(setRequest).get();
+        assertEquals("UPDATE", setResponse.getResponse(0).getOp().toString());
+    }
+
+    @Test
     public void crudComplexValueTest() throws ExecutionException, InterruptedException, IOException, JSONException {
         final Gnmi.Path path = Gnmi.Path.newBuilder()
                 .addElem(Gnmi.PathElem.newBuilder()


### PR DESCRIPTION
Utilizing Gson to convert key values from
NodeIdentifierWithPredicates may produce unexpected outcomes if the key value is not parsable by Gson's default behavior. For instance, the result for Uint8(10) would be {"value":10} instead of simply 10.

Ensure custom ODL types are correctly parsed by Gson.

JIRA: LIGHTY-285
Signed-off-by: Peter Suna <peter.suna@pantheon.tech>
(cherry picked from commit fe6b30748d311d6f23bd0b7d0ac638d6fa665631)