### PR TITLE
Remove redundant workarounds for calcium integration

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -294,18 +294,4 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
-    <repositories>
-        <!-- TODO: Remove when will be available OFP ans Serviceutils release  -->
-        <repository>
-            <id>opendaylight-snapshot</id>
-            <name>opendaylight-snapshot</name>
-            <url>https://nexus.opendaylight.org/content/repositories/opendaylight.snapshot/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 </project>

--- a/lighty-core/lighty-codecs-util/pom.xml
+++ b/lighty-core/lighty-codecs-util/pom.xml
@@ -69,18 +69,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <repositories>
-        <!-- TODO: Remove when will be available OFP ans Serviceutils release  -->
-        <repository>
-            <id>opendaylight-snapshot</id>
-            <name>opendaylight-snapshot</name>
-            <url>https://nexus.opendaylight.org/content/repositories/opendaylight.snapshot/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 </project>


### PR DESCRIPTION
We no longer need snapshot repository link as well as workaround for NETCONF-1285.