### PR TITLE
Bump 19.x to odlparent 13.0.11 versions

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
-                <version>13.0.10</version>
+                <version>13.0.11</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -34,49 +34,49 @@
             <dependency>
                 <groupId>org.opendaylight.aaa</groupId>
                 <artifactId>aaa-artifacts</artifactId>
-                <version>0.18.4</version>
+                <version>0.18.5</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>controller-artifacts</artifactId>
-                <version>8.0.4</version>
+                <version>8.0.5</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.infrautils</groupId>
                 <artifactId>infrautils-artifacts</artifactId>
-                <version>6.0.5</version>
+                <version>6.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.mdsal</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>12.0.4</version>
+                <version>12.0.5</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>netconf-artifacts</artifactId>
-                <version>6.0.6</version>
+                <version>6.0.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yangtools-artifacts</artifactId>
-                <version>11.0.5</version>
+                <version>11.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.bgpcep</groupId>
                 <artifactId>bgpcep-artifacts</artifactId>
-                <version>0.20.6</version>
+                <version>0.20.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -49,12 +49,12 @@
             <plugin>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yang-maven-plugin</artifactId>
-                <version>11.0.5</version>
+                <version>11.0.6</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.opendaylight.mdsal</groupId>
                         <artifactId>mdsal-binding-java-api-generator</artifactId>
-                        <version>12.0.4</version>
+                        <version>12.0.5</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -203,7 +203,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>13.0.10</version>
+                            <version>13.0.11</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -220,7 +220,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>spotbugs</artifactId>
-                            <version>13.0.10</version>
+                            <version>13.0.11</version>
                         </dependency>
                         <!-- The SpotBugs Maven plugin uses SLF4J-2 -->
                         <dependency>

--- a/lighty-modules/lighty-openapi/src/main/java/io/lighty/openapi/OpenApiLighty.java
+++ b/lighty-modules/lighty-openapi/src/main/java/io/lighty/openapi/OpenApiLighty.java
@@ -12,12 +12,14 @@ import io.lighty.core.controller.api.AbstractLightyModule;
 import io.lighty.core.controller.api.LightyServices;
 import io.lighty.modules.northbound.restconf.community.impl.config.RestConfConfiguration;
 import io.lighty.server.LightyServerBuilder;
+import java.lang.annotation.Annotation;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
+import org.opendaylight.restconf.nb.rfc8040.JaxRsNorthbound;
 import org.opendaylight.restconf.openapi.api.OpenApiService;
 import org.opendaylight.restconf.openapi.impl.OpenApiServiceImpl;
 import org.opendaylight.restconf.openapi.jaxrs.OpenApiApplication;
@@ -56,7 +58,7 @@ public class OpenApiLighty extends AbstractLightyModule {
         LOG.info("basePath: {}", basePathString);
 
         this.apiDocService = new OpenApiServiceImpl(lightyServices.getDOMSchemaService(),
-            lightyServices.getDOMMountPointService(), basePathString);
+            lightyServices.getDOMMountPointService(), new OpenApiLightyConfiguration(basePathString));
 
         OpenApiApplication apiDocApplication = new OpenApiApplication(apiDocService);
 
@@ -95,5 +97,53 @@ public class OpenApiLighty extends AbstractLightyModule {
     @VisibleForTesting
     OpenApiService getApiDocService() {
         return apiDocService;
+    }
+
+    public static final class OpenApiLightyConfiguration implements JaxRsNorthbound.Configuration {
+        private final String basePath;
+
+        private OpenApiLightyConfiguration(final String basePath) {
+            this.basePath = basePath;
+        }
+
+        @Override
+        public int maximum$_$fragment$_$length() {
+            return 0;
+        }
+
+        @Override
+        public int heartbeat$_$interval() {
+            return 10000;
+        }
+
+        @Override
+        public int idle$_$timeout() {
+            return 30000;
+        }
+
+        @Override
+        public String ping$_$executor$_$name$_$prefix() {
+            return "ping-executor";
+        }
+
+        @Override
+        public int max$_$thread$_$count() {
+            return 1;
+        }
+
+        @Override
+        public boolean use$_$sse() {
+            return true;
+        }
+
+        @Override
+        public String restconf() {
+            return basePath;
+        }
+
+        @Override
+        public Class<? extends Annotation> annotationType() {
+            return null;
+        }
     }
 }

--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/CommunityRestConf.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/CommunityRestConf.java
@@ -95,7 +95,8 @@ public class CommunityRestConf extends AbstractLightyModule {
     @Override
     protected boolean initProcedure() {
         final Stopwatch stopwatch = Stopwatch.createStarted();
-        final StreamsConfiguration streamsConfiguration = RestConfConfigUtils.getStreamsConfiguration();
+        final StreamsConfiguration streamsConfiguration = RestConfConfigUtils
+            .getStreamsConfiguration(restconfServletContextPath);
 
         LOG.info("Starting RestconfApplication with configuration {}", streamsConfiguration);
 

--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
@@ -169,7 +169,9 @@ public final class RestConfConfigUtils {
         return new RestConfConfiguration();
     }
 
-    public static StreamsConfiguration getStreamsConfiguration() {
-        return new StreamsConfiguration(MAXIMUM_FRAGMENT_LENGTH, IDLE_TIMEOUT, HEARTBEAT_INTERVAL, USE_SSE);
+    public static StreamsConfiguration getStreamsConfiguration(final String restconfServletContextPath) {
+        // we use, for example "/rests" as restconfServletContextPath but NETCONF expects just "rests" as basePath
+        final var basePath = restconfServletContextPath.substring(1);
+        return new StreamsConfiguration(MAXIMUM_FRAGMENT_LENGTH, IDLE_TIMEOUT, HEARTBEAT_INTERVAL, USE_SSE, basePath);
     }
 }


### PR DESCRIPTION
After this is merged, please close: https://github.com/PANTHEONtech/lighty/pull/1812

- odlparent-13.0.11
- infrautils-6.0.6
- yangtools-11.0.6
- mdsal-12.0.5
- controller-8.0.5
- aaa-0.18.5
- netconf-6.0.7
- bgpcep-0.20.7