### PR TITLE
Increase sleep after shutdown timeout

### DIFF
--- a/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/api/LightyModuleTest.java
+++ b/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/api/LightyModuleTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 public class LightyModuleTest {
     private static long MAX_INIT_TIMEOUT = 15000L;
     private static long MAX_SHUTDOWN_TIMEOUT = 15000L;
-    private static long SLEEP_AFTER_SHUTDOWN_TIMEOUT = 200L;
+    private static long SLEEP_AFTER_SHUTDOWN_TIMEOUT = 800L;
     private ExecutorService executorService;
     private LightyModule moduleUnderTest;
 


### PR DESCRIPTION
This timeout caused tests to be unreliable an inconsistent.

JIRA: LIGHTY-299