### PR TITLE
Bump testng to 7.10.2

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -100,7 +100,7 @@
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>7.10.1</version>
+                <version>7.10.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
https://github.com/testng-team/testng/releases/tag/7.10.2

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit 1780357d167181f32ad767fa01c3d5c696f7f695)