### PR TITLE
Bump upstreams to odlparent 13.1.3

### DIFF
--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/example-config/configuration.json
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/example-config/configuration.json
@@ -41,7 +41,7 @@
                 { "usedBy": "RESTCONF", "name": "instance-identifier-patch-module", "revision": "2015-11-21", "nameSpace": "instance:identifier:patch:module"},
                 { "usedBy": "RESTCONF/NETCONF", "name": "ietf-yang-library", "revision": "2019-01-04", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library"},
                 { "usedBy": "NETCONF", "name": "netconf-keystore", "revision": "2017-10-17", "nameSpace": "urn:opendaylight:netconf:keystore"},
-                { "usedBy": "NETCONF", "name": "netconf-node-topology", "revision": "2022-12-25", "nameSpace": "urn:opendaylight:netconf-node-topology"},
+                { "usedBy": "NETCONF", "name": "netconf-node-topology", "revision": "2024-02-23", "nameSpace": "urn:opendaylight:netconf-node-topology"},
                 { "usedBy": "NETCONF", "name":"ietf-netconf", "revision":"2011-06-01", "nameSpace":"urn:ietf:params:xml:ns:netconf:base:1.0"},
                 { "usedBy": "AAA", "name": "aaa-cert-mdsal", "revision":"2016-03-21", "nameSpace":"urn:opendaylight:yang:aaa:cert:mdsal"},
                 { "usedBy": "AAA", "name": "aaa", "revision": "2016-12-14", "nameSpace": "urn:opendaylight:params:xml:ns:yang:aaa"},

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/configmaps.yaml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-helm/helm/lighty-rnc-app-helm/templates/configmaps.yaml
@@ -48,7 +48,7 @@ data:
                   { "usedBy": "RESTCONF", "name": "instance-identifier-patch-module", "revision": "2015-11-21", "nameSpace": "instance:identifier:patch:module"},
                   { "usedBy": "RESTCONF/NETCONF", "name": "ietf-yang-library", "revision": "2019-01-04", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library"},
                   { "usedBy": "NETCONF", "name": "netconf-keystore", "revision": "2017-10-17", "nameSpace": "urn:opendaylight:netconf:keystore"},
-                  { "usedBy": "NETCONF", "name": "netconf-node-topology", "revision": "2022-12-25", "nameSpace": "urn:opendaylight:netconf-node-topology"},
+                  { "usedBy": "NETCONF", "name": "netconf-node-topology", "revision": "2024-02-23", "nameSpace": "urn:opendaylight:netconf-node-topology"},
                   { "usedBy": "NETCONF", "name":"ietf-netconf", "revision":"2011-06-01", "nameSpace":"urn:ietf:params:xml:ns:netconf:base:1.0"},
                   { "usedBy": "AAA", "name": "aaa-cert-mdsal", "revision":"2016-03-21", "nameSpace":"urn:opendaylight:yang:aaa:cert:mdsal"},
                   { "usedBy": "AAA", "name": "aaa", "revision": "2016-12-14", "nameSpace": "urn:opendaylight:params:xml:ns:yang:aaa"},

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/config.json
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/config.json
@@ -37,7 +37,7 @@
                 { "usedBy": "RESTCONF", "name": "instance-identifier-patch-module", "revision": "2015-11-21", "nameSpace": "instance:identifier:patch:module"},
                 { "usedBy": "RESTCONF/NETCONF", "name": "ietf-yang-library", "revision": "2019-01-04", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library"},
                 { "usedBy": "NETCONF", "name": "netconf-keystore", "revision": "2017-10-17", "nameSpace": "urn:opendaylight:netconf:keystore"},
-                { "usedBy": "NETCONF", "name": "netconf-node-topology", "revision": "2022-12-25", "nameSpace": "urn:opendaylight:netconf-node-topology"},
+                { "usedBy": "NETCONF", "name": "netconf-node-topology", "revision": "2024-02-23", "nameSpace": "urn:opendaylight:netconf-node-topology"},
                 { "usedBy": "NETCONF", "name":"ietf-netconf", "revision":"2011-06-01", "nameSpace":"urn:ietf:params:xml:ns:netconf:base:1.0"},
                 { "usedBy": "AAA", "name": "aaa", "revision": "2016-12-14", "nameSpace": "urn:opendaylight:params:xml:ns:yang:aaa"},
                 { "usedBy": "AAA", "name": "aaa-cert-mdsal", "revision":"2016-03-21", "nameSpace":"urn:opendaylight:yang:aaa:cert:mdsal"},

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/http2Config.json
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/http2Config.json
@@ -34,7 +34,7 @@
         { "usedBy": "RESTCONF", "name": "instance-identifier-patch-module", "revision": "2015-11-21", "nameSpace": "instance:identifier:patch:module"},
         { "usedBy": "RESTCONF/NETCONF", "name": "ietf-yang-library", "revision": "2019-01-04", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library"},
         { "usedBy": "NETCONF", "name": "netconf-keystore", "revision": "2017-10-17", "nameSpace": "urn:opendaylight:netconf:keystore"},
-        { "usedBy": "NETCONF", "name": "netconf-node-topology", "revision": "2022-12-25", "nameSpace": "urn:opendaylight:netconf-node-topology"},
+        { "usedBy": "NETCONF", "name": "netconf-node-topology", "revision": "2024-02-23", "nameSpace": "urn:opendaylight:netconf-node-topology"},
         { "usedBy": "NETCONF", "name":"ietf-netconf", "revision":"2011-06-01", "nameSpace":"urn:ietf:params:xml:ns:netconf:base:1.0"},
         { "usedBy": "AAA", "name": "aaa-cert-mdsal", "revision":"2016-03-21", "nameSpace":"urn:opendaylight:yang:aaa:cert:mdsal"},
         { "usedBy": "AAA", "name": "aaa", "revision": "2016-12-14", "nameSpace": "urn:opendaylight:params:xml:ns:yang:aaa"},

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/httpsConfig.json
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/httpsConfig.json
@@ -34,7 +34,7 @@
         { "usedBy": "RESTCONF", "name": "instance-identifier-patch-module", "revision": "2015-11-21", "nameSpace": "instance:identifier:patch:module"},
         { "usedBy": "RESTCONF/NETCONF", "name": "ietf-yang-library", "revision": "2019-01-04", "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-yang-library"},
         { "usedBy": "NETCONF", "name": "netconf-keystore", "revision": "2017-10-17", "nameSpace": "urn:opendaylight:netconf:keystore"},
-        { "usedBy": "NETCONF", "name": "netconf-node-topology", "revision": "2022-12-25", "nameSpace": "urn:opendaylight:netconf-node-topology"},
+        { "usedBy": "NETCONF", "name": "netconf-node-topology", "revision": "2024-02-23", "nameSpace": "urn:opendaylight:netconf-node-topology"},
         { "usedBy": "NETCONF", "name":"ietf-netconf", "revision":"2011-06-01", "nameSpace":"urn:ietf:params:xml:ns:netconf:base:1.0"},
         { "usedBy": "AAA", "name": "aaa-cert-mdsal", "revision":"2016-03-21", "nameSpace":"urn:opendaylight:yang:aaa:cert:mdsal"},
         { "usedBy": "AAA", "name": "aaa", "revision": "2016-12-14", "nameSpace": "urn:opendaylight:params:xml:ns:yang:aaa"},

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/openapi_config.json
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/resources/openapi_config.json
@@ -54,7 +54,7 @@
                 { "nameSpace": "urn:opendaylight:params:xml:ns:yang:controller:inmemory-datastore-provider", "name": "opendaylight-inmemory-datastore-provider", "revision": "2014-06-17" },
                 { "nameSpace": "urn:ietf:params:xml:ns:yang:iana-afn-safi", "name": "iana-afn-safi", "revision": "2013-07-04" },
                 { "nameSpace": "urn:opendaylight:params:xml:ns:yang:controller:md:sal:binding:impl", "name": "opendaylight-sal-binding-broker-impl", "revision": "2013-10-28" },
-                { "nameSpace": "urn:opendaylight:netconf-node-topology", "name": "netconf-node-topology", "revision": "2022-12-25" },
+                { "nameSpace": "urn:opendaylight:netconf-node-topology", "name": "netconf-node-topology", "revision": "2024-02-23" },
                 { "nameSpace": "urn:ietf:params:xml:ns:yang:ietf-restconf", "name": "ietf-restconf", "revision": "2017-01-26" },
                 { "nameSpace": "urn:ietf:params:xml:ns:netmod:notification", "name": "nc-notifications", "revision": "2008-07-14" },
                 { "nameSpace": "urn:opendaylight:l2:types", "name": "opendaylight-l2-types", "revision": "2013-08-27" },

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
-                <version>13.0.11</version>
+                <version>13.1.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -34,49 +34,49 @@
             <dependency>
                 <groupId>org.opendaylight.aaa</groupId>
                 <artifactId>aaa-artifacts</artifactId>
-                <version>0.18.5</version>
+                <version>0.18.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>controller-artifacts</artifactId>
-                <version>8.0.5</version>
+                <version>8.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.infrautils</groupId>
                 <artifactId>infrautils-artifacts</artifactId>
-                <version>6.0.6</version>
+                <version>6.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.mdsal</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>12.0.5</version>
+                <version>12.0.6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>netconf-artifacts</artifactId>
-                <version>6.0.7</version>
+                <version>6.0.8</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yangtools-artifacts</artifactId>
-                <version>11.0.6</version>
+                <version>11.0.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.bgpcep</groupId>
                 <artifactId>bgpcep-artifacts</artifactId>
-                <version>0.20.7</version>
+                <version>0.20.8</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -49,12 +49,12 @@
             <plugin>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yang-maven-plugin</artifactId>
-                <version>11.0.6</version>
+                <version>11.0.7</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.opendaylight.mdsal</groupId>
                         <artifactId>mdsal-binding-java-api-generator</artifactId>
-                        <version>12.0.5</version>
+                        <version>12.0.6</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -203,7 +203,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>13.0.11</version>
+                            <version>13.1.3</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -220,7 +220,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>spotbugs</artifactId>
-                            <version>13.0.11</version>
+                            <version>13.1.3</version>
                         </dependency>
                         <!-- The SpotBugs Maven plugin uses SLF4J-2 -->
                         <dependency>

--- a/lighty-examples/lighty-community-restconf-actions-app/src/main/assembly/resources/sampleConfigSingleNode.json
+++ b/lighty-examples/lighty-community-restconf-actions-app/src/main/assembly/resources/sampleConfigSingleNode.json
@@ -41,8 +41,8 @@
                 { "usedBy":"RESTCONF","name":"subscribe-to-notification","revision":"2016-10-28","nameSpace":"subscribe:to:notification"},
                 { "usedBy":"RESTCONF", "name": "instance-identifier-patch-module", "revision": "2015-11-21", "nameSpace": "instance:identifier:patch:module"},
                 { "usedBy":"NETCONF","name":"netconf-keystore","revision":"2017-10-17","nameSpace":"urn:opendaylight:netconf:keystore"},
-                { "usedBy":"NETCONF","name":"netconf-node-topology","revision":"2022-12-25","nameSpace":"urn:opendaylight:netconf-node-topology"},
-                { "usedBy":"NETCONF","name":"netconf-node-optional","revision":"2022-12-25","nameSpace":"urn:opendaylight:netconf-node-optional"},
+                { "usedBy":"NETCONF","name":"netconf-node-topology","revision":"2024-02-23","nameSpace":"urn:opendaylight:netconf-node-topology"},
+                { "usedBy":"NETCONF","name":"netconf-node-optional","revision":"2024-02-23","nameSpace":"urn:opendaylight:netconf-node-optional"},
                 { "usedBy":"NETCONF","name":"ietf-netconf","revision":"2011-06-01","nameSpace":"urn:ietf:params:xml:ns:netconf:base:1.0"},
                 { "usedBy":"NETCONF_ACTION","name":"example-data-center","revision":"2018-08-07","nameSpace":"urn:example:data-center"}
             ]

--- a/lighty-examples/lighty-community-restconf-netconf-app/src/main/assembly/resources/sampleConfigSingleNode.json
+++ b/lighty-examples/lighty-community-restconf-netconf-app/src/main/assembly/resources/sampleConfigSingleNode.json
@@ -41,8 +41,8 @@
                 { "usedBy":"RESTCONF","name":"subscribe-to-notification","revision":"2016-10-28","nameSpace":"subscribe:to:notification"},
                 { "usedBy":"RESTCONF", "name": "instance-identifier-patch-module", "revision": "2015-11-21", "nameSpace": "instance:identifier:patch:module"},
                 { "usedBy":"NETCONF","name":"netconf-keystore","revision":"2017-10-17","nameSpace":"urn:opendaylight:netconf:keystore"},
-                { "usedBy":"NETCONF","name":"netconf-node-topology","revision":"2022-12-25","nameSpace":"urn:opendaylight:netconf-node-topology"},
-                { "usedBy":"NETCONF","name":"netconf-node-optional","revision":"2022-12-25","nameSpace":"urn:opendaylight:netconf-node-optional"},
+                { "usedBy":"NETCONF","name":"netconf-node-topology","revision":"2024-02-23","nameSpace":"urn:opendaylight:netconf-node-topology"},
+                { "usedBy":"NETCONF","name":"netconf-node-optional","revision":"2024-02-23","nameSpace":"urn:opendaylight:netconf-node-optional"},
                 { "usedBy":"NETCONF","name":"ietf-netconf","revision":"2011-06-01","nameSpace":"urn:ietf:params:xml:ns:netconf:base:1.0"}
             ]
         }

--- a/lighty-examples/lighty-controller-springboot-netconf/src/main/java/io/lighty/core/controller/springboot/rest/NetconfDeviceRestService.java
+++ b/lighty-examples/lighty-controller-springboot-netconf/src/main/java/io/lighty/core/controller/springboot/rest/NetconfDeviceRestService.java
@@ -30,8 +30,8 @@ import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.inet.types.
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.inet.types.rev130715.IpAddress;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.inet.types.rev130715.Ipv4Address;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.inet.types.rev130715.PortNumber;
-import org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.device.rev240118.credentials.credentials.LoginPasswordBuilder;
-import org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.node.topology.rev221225.NetconfNodeBuilder;
+import org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.device.rev240223.credentials.credentials.LoginPasswordBuilder;
+import org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.node.topology.rev240223.NetconfNodeBuilder;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.NetworkTopology;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.NodeId;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.TopologyId;

--- a/lighty-examples/lighty-controller-springboot-netconf/src/main/java/io/lighty/core/controller/springboot/rest/dto/NetconfDeviceResponse.java
+++ b/lighty-examples/lighty-controller-springboot-netconf/src/main/java/io/lighty/core/controller/springboot/rest/dto/NetconfDeviceResponse.java
@@ -10,8 +10,8 @@ package io.lighty.core.controller.springboot.rest.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.device.rev240118.ConnectionOper.ConnectionStatus;
-import org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.node.topology.rev221225.NetconfNode;
+import org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.device.rev240223.ConnectionOper.ConnectionStatus;
+import org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.node.topology.rev240223.NetconfNode;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.network.topology.topology.Node;
 
 public class NetconfDeviceResponse {

--- a/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/TopologyPluginsTest.java
+++ b/lighty-modules/integration-tests/src/test/java/io/lighty/modules/southbound/netconf/tests/TopologyPluginsTest.java
@@ -38,10 +38,10 @@ import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.inet.types.
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.inet.types.rev130715.IpAddress;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.inet.types.rev130715.Ipv4Address;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.inet.types.rev130715.PortNumber;
-import org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.device.rev240118.credentials.Credentials;
-import org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.device.rev240118.credentials.credentials.LoginPasswordBuilder;
-import org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.node.topology.rev221225.NetconfNode;
-import org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.node.topology.rev221225.NetconfNodeBuilder;
+import org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.device.rev240223.credentials.Credentials;
+import org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.device.rev240223.credentials.credentials.LoginPasswordBuilder;
+import org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.node.topology.rev240223.NetconfNode;
+import org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.node.topology.rev240223.NetconfNodeBuilder;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.NetworkTopology;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.NodeId;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.TopologyId;

--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/util/NetconfConfigUtils.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/util/NetconfConfigUtils.java
@@ -47,7 +47,7 @@ public final class NetconfConfigUtils {
     public static final Set<YangModuleInfo> NETCONF_TOPOLOGY_MODELS = Set.of(
             org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.keystore.rev171017
                     .$YangModuleInfoImpl.getInstance(),
-            org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.node.topology.rev221225
+            org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.node.topology.rev240223
                     .$YangModuleInfoImpl.getInstance(),
             org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.node.optional.rev221225
                     .$YangModuleInfoImpl.getInstance(),

--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/util/NetconfUtils.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/util/NetconfUtils.java
@@ -31,7 +31,7 @@ import org.opendaylight.netconf.client.mdsal.impl.NetconfMessageTransformUtil;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.netconf.base._1._0.rev110601.copy.config.input.target.ConfigTarget;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.netconf.base._1._0.rev110601.edit.config.input.EditContent;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.netconf.base._1._0.rev110601.get.config.input.source.ConfigSource;
-import org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.node.topology.rev221225.network.topology.topology.topology.types.TopologyNetconf;
+import org.opendaylight.yang.gen.v1.urn.opendaylight.netconf.node.topology.rev240223.network.topology.topology.topology.types.TopologyNetconf;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.NetworkTopology;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.NodeId;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.TopologyId;

--- a/lighty-modules/lighty-netconf-sb/src/main/resources/sampleConfigCluster.json
+++ b/lighty-modules/lighty-netconf-sb/src/main/resources/sampleConfigCluster.json
@@ -29,8 +29,8 @@
                 { "usedBy":"CONTROLLER","name":"distributed-datastore-provider","revision":"2014-06-12","nameSpace":"urn:opendaylight:params:xml:ns:yang:controller:config:distributed-datastore-provider"},
                 { "usedBy":"CONTROLLER","name":"odl-entity-owners","nameSpace":"urn:opendaylight:params:xml:ns:yang:controller:entity-owners"},
                 { "usedBy":"NETCONF","name":"netconf-keystore","revision":"2017-10-17","nameSpace":"urn:opendaylight:netconf:keystore"},
-                { "usedBy":"NETCONF","name":"netconf-node-topology","revision":"2022-12-25","nameSpace":"urn:opendaylight:netconf-node-topology"},
-                { "usedBy":"NETCONF","name":"netconf-node-optional","revision":"2022-12-25","nameSpace":"urn:opendaylight:netconf-node-optional"},
+                { "usedBy":"NETCONF","name":"netconf-node-topology","revision":"2024-02-23","nameSpace":"urn:opendaylight:netconf-node-topology"},
+                { "usedBy":"NETCONF","name":"netconf-node-optional","revision":"2024-02-23","nameSpace":"urn:opendaylight:netconf-node-optional"},
                 { "usedBy":"NETCONF","name":"ietf-netconf","revision":"2011-06-01","nameSpace":"urn:ietf:params:xml:ns:netconf:base:1.0"},
                 { "usedBy":"CLUSTER","name": "netconf-clustered-topology-config","revision":"2017-04-19","nameSpace":"urn:opendaylight:netconf:topology:singleton:config" }
             ]

--- a/lighty-modules/lighty-netconf-sb/src/main/resources/sampleConfigSingleNode.json
+++ b/lighty-modules/lighty-netconf-sb/src/main/resources/sampleConfigSingleNode.json
@@ -29,8 +29,8 @@
                 { "usedBy":"CONTROLLER","name":"distributed-datastore-provider","revision": "2014-06-12","nameSpace":"urn:opendaylight:params:xml:ns:yang:controller:config:distributed-datastore-provider"},
                 { "usedBy":"CONTROLLER","name":"odl-entity-owners","nameSpace":"urn:opendaylight:params:xml:ns:yang:controller:entity-owners"},
                 { "usedBy":"NETCONF","name":"netconf-keystore","revision":"2017-10-17","nameSpace":"urn:opendaylight:netconf:keystore"},
-                { "usedBy":"NETCONF","name":"netconf-node-topology","revision":"2022-12-25","nameSpace":"urn:opendaylight:netconf-node-topology"},
-                { "usedBy":"NETCONF","name":"netconf-node-optional","revision":"2022-12-25","nameSpace":"urn:opendaylight:netconf-node-optional"},
+                { "usedBy":"NETCONF","name":"netconf-node-topology","revision":"2024-02-23","nameSpace":"urn:opendaylight:netconf-node-topology"},
+                { "usedBy":"NETCONF","name":"netconf-node-optional","revision":"2024-02-23","nameSpace":"urn:opendaylight:netconf-node-optional"},
                 { "usedBy":"NETCONF","name":"ietf-netconf","revision":"2011-06-01","nameSpace":"urn:ietf:params:xml:ns:netconf:base:1.0"}
             ]
         }


### PR DESCRIPTION
Adopt:
- odlparent-13.1.3
- infrautils-6.0.9
- yangtools-11.0.7
- mdsal-12.0.6
- controller-8.0.6
- aaa-0.18.6
- netconf-6.0.8
- bgpcep-0.20.8
