### PR TITLE
Bump upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
         if: ${{ env.SONAR_TOKEN == 0 }}
         run: mvn -B verify
       - name: Upload surefire test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Surefire-Test-Results
           path: ~/**/surefire-reports/**/*.txt


### PR DESCRIPTION
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit f50d22e0d8224b14674e4c45bb450e1a9bacfc90)