### PR TITLE
Bump alpine to 3.20.3

### DIFF
--- a/.github/workflows/lighty-rnc-app/simulator/Dockerfile
+++ b/.github/workflows/lighty-rnc-app/simulator/Dockerfile
@@ -1,6 +1,6 @@
 ARG SIMULATOR_VERSION="19.3.0"
 
-FROM alpine:3.19.1 as clone
+FROM alpine:3.20.3 as clone
 
 ARG SIMULATOR_VERSION
 RUN apk add git


### PR DESCRIPTION
https://alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit b86c63ae0d602491b5c6f43f50fb5978b8e3c42d)