### PR TITLE
Cleanup GCM cipher instantiating

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModule.java
@@ -35,7 +35,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
@@ -192,13 +191,6 @@ public class RcGnmiAppModule {
                 = new SecretKeySpec(keyFactory.generateSecret(keySpec).getEncoded(), encrySrvConfig.getEncryptType());
         final GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(encrySrvConfig.getAuthTagLength(),
                 encryptionKeySalt);
-
-        final Cipher encryptCipher = Cipher.getInstance(encrySrvConfig.getCipherTransforms());
-        encryptCipher.init(Cipher.ENCRYPT_MODE, key, gcmParameterSpec);
-
-        final Cipher decryptCipher = Cipher.getInstance(encrySrvConfig.getCipherTransforms());
-        decryptCipher.init(Cipher.DECRYPT_MODE, key, gcmParameterSpec);
-
         return new AAAEncryptionServiceImpl(gcmParameterSpec, encrySrvConfig.getCipherTransforms(), key);
     }
 

--- a/lighty-modules/lighty-aaa-aggregator/lighty-aaa-encryption-service/src/main/java/io/lighty/aaa/encrypt/service/impl/AAAEncryptionServiceImpl.java
+++ b/lighty-modules/lighty-aaa-aggregator/lighty-aaa-encryption-service/src/main/java/io/lighty/aaa/encrypt/service/impl/AAAEncryptionServiceImpl.java
@@ -14,7 +14,6 @@ import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
@@ -33,14 +32,13 @@ public class AAAEncryptionServiceImpl implements AAAEncryptionService {
     private final SecretKey key;
     private final byte[] iv;
     private final int tagLength;
-    final SecureRandom random;
 
-    public AAAEncryptionServiceImpl(GCMParameterSpec gcmParameterSpec, String cipherTransforms, SecretKey key) {
+    public AAAEncryptionServiceImpl(final GCMParameterSpec gcmParameterSpec, final String cipherTransforms,
+            final SecretKey key) {
         this.iv = gcmParameterSpec.getIV();
         this.tagLength = gcmParameterSpec.getTLen();
         this.cipherTransforms = cipherTransforms;
         this.key = key;
-        this.random = new SecureRandom();
     }
 
     @Override
@@ -111,5 +109,4 @@ public class AAAEncryptionServiceImpl implements AAAEncryptionService {
         cipher.init(mode, key, new GCMParameterSpec(tagLength, localIv));
         return cipher;
     }
-
 }

--- a/lighty-modules/lighty-aaa-aggregator/lighty-aaa/src/main/java/io/lighty/aaa/config/CertificateManagerConfig.java
+++ b/lighty-modules/lighty-aaa-aggregator/lighty-aaa/src/main/java/io/lighty/aaa/config/CertificateManagerConfig.java
@@ -81,14 +81,12 @@ public final class CertificateManagerConfig {
             final SecretKeyFactory keyFactory = SecretKeyFactory.getInstance(encrySrvConfig.getEncryptMethod());
             final KeySpec keySpec = new PBEKeySpec(encrySrvConfig.getEncryptKey().toCharArray(), encryptionKeySalt,
                     encrySrvConfig.getEncryptIterationCount(), encrySrvConfig.getEncryptKeyLength());
-            SecretKey key = new SecretKeySpec(keyFactory.generateSecret(keySpec).getEncoded(),
+            final SecretKey key = new SecretKeySpec(keyFactory.generateSecret(keySpec).getEncoded(),
                     encrySrvConfig.getEncryptType());
-            GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(encrySrvConfig.getAuthTagLength(),
+            final GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(encrySrvConfig.getAuthTagLength(),
                 encryptionKeySalt);
-
             final AAAEncryptionService encryptionSrv = new AAAEncryptionServiceImpl(gcmParameterSpec,
                 encrySrvConfig.getCipherTransforms(), key);
-
             return new CertificateManagerService(rpcProviderService, bindingDataBroker, encryptionSrv,
                     aaaCertServiceConfig);
         } catch (InvalidKeySpecException

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/java/io/lighty/gnmi/southbound/device/KeystoreGnmiSecurityTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/java/io/lighty/gnmi/southbound/device/KeystoreGnmiSecurityTest.java
@@ -46,7 +46,6 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
@@ -467,13 +466,6 @@ public class KeystoreGnmiSecurityTest {
                 encrySrvConfig.getEncryptType());
         final GCMParameterSpec ivParameterSpec = new GCMParameterSpec(encrySrvConfig.getAuthTagLength(),
                 encryptionKeySalt);
-
-        final Cipher encryptCipher = Cipher.getInstance(encrySrvConfig.getCipherTransforms());
-        encryptCipher.init(Cipher.ENCRYPT_MODE, key, ivParameterSpec);
-
-        final Cipher decryptCipher = Cipher.getInstance(encrySrvConfig.getCipherTransforms());
-        decryptCipher.init(Cipher.DECRYPT_MODE, key, ivParameterSpec);
-
         return new AAAEncryptionServiceImpl(ivParameterSpec, encrySrvConfig.getCipherTransforms(), key);
     }
 

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/java/io/lighty/gnmi/southbound/lightymodule/GnmiSouthBoundModuleTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-sb/src/test/java/io/lighty/gnmi/southbound/lightymodule/GnmiSouthBoundModuleTest.java
@@ -16,8 +16,6 @@ import io.lighty.core.controller.impl.LightyControllerBuilder;
 import io.lighty.core.controller.impl.util.ControllerConfigUtils;
 import io.lighty.gnmi.southbound.lightymodule.config.GnmiConfiguration;
 import io.lighty.gnmi.southbound.lightymodule.util.GnmiConfigUtils;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
@@ -25,7 +23,6 @@ import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.GCMParameterSpec;
@@ -69,8 +66,8 @@ public class GnmiSouthBoundModuleTest {
         Assertions.assertTrue(services.shutdown(MODULE_TIMEOUT, MODULE_TIME_UNIT));
     }
 
-    private static AAAEncryptionServiceImpl createEncryptionService() throws NoSuchPaddingException,
-            NoSuchAlgorithmException, InvalidKeySpecException, InvalidAlgorithmParameterException, InvalidKeyException {
+    private static AAAEncryptionServiceImpl createEncryptionService()
+            throws NoSuchAlgorithmException, InvalidKeySpecException {
         final AaaEncryptServiceConfig encrySrvConfig = getDefaultAaaEncryptServiceConfig();
         final byte[] encryptionKeySalt = Base64.getDecoder().decode(encrySrvConfig.getEncryptSalt());
         final SecretKeyFactory keyFactory = SecretKeyFactory.getInstance(encrySrvConfig.getEncryptMethod());
@@ -80,7 +77,6 @@ public class GnmiSouthBoundModuleTest {
                 = new SecretKeySpec(keyFactory.generateSecret(keySpec).getEncoded(), encrySrvConfig.getEncryptType());
         final GCMParameterSpec ivParameterSpec = new GCMParameterSpec(encrySrvConfig.getAuthTagLength(),
                 encryptionKeySalt);
-
         return new AAAEncryptionServiceImpl(ivParameterSpec, encrySrvConfig.getCipherTransforms(), key);
     }
 

--- a/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/GnmiWithoutRestconfTest.java
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-test/src/test/java/io/lighty/modules/gnmi/test/gnmi/GnmiWithoutRestconfTest.java
@@ -44,7 +44,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
@@ -500,8 +499,8 @@ public class GnmiWithoutRestconfTest {
                 .build();
     }
 
-    private static AAAEncryptionServiceImpl createEncryptionService() throws NoSuchPaddingException,
-            NoSuchAlgorithmException, InvalidKeySpecException, InvalidAlgorithmParameterException, InvalidKeyException {
+    private static AAAEncryptionServiceImpl createEncryptionService()
+            throws NoSuchAlgorithmException, InvalidKeySpecException {
         final AaaEncryptServiceConfig encrySrvConfig = getDefaultAaaEncryptServiceConfig();
         final byte[] encryptionKeySalt = Base64.getDecoder().decode(encrySrvConfig.getEncryptSalt());
         final SecretKeyFactory keyFactory = SecretKeyFactory.getInstance(encrySrvConfig.getEncryptMethod());
@@ -511,13 +510,6 @@ public class GnmiWithoutRestconfTest {
                 = new SecretKeySpec(keyFactory.generateSecret(keySpec).getEncoded(), encrySrvConfig.getEncryptType());
         final GCMParameterSpec ivParameterSpec = new GCMParameterSpec(encrySrvConfig.getAuthTagLength(),
             encryptionKeySalt);
-
-        final Cipher encryptCipher = Cipher.getInstance(encrySrvConfig.getCipherTransforms());
-        encryptCipher.init(Cipher.ENCRYPT_MODE, key, ivParameterSpec);
-
-        final Cipher decryptCipher = Cipher.getInstance(encrySrvConfig.getCipherTransforms());
-        decryptCipher.init(Cipher.DECRYPT_MODE, key, ivParameterSpec);
-
         return new AAAEncryptionServiceImpl(ivParameterSpec, encrySrvConfig.getCipherTransforms(), key);
     }
 

--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/util/NetconfConfigUtils.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/util/NetconfConfigUtils.java
@@ -17,16 +17,12 @@ import io.lighty.modules.southbound.netconf.impl.config.NetconfConfiguration;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.util.Base64;
 import java.util.Set;
-import javax.crypto.Cipher;
-import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.GCMParameterSpec;
@@ -174,21 +170,12 @@ public final class NetconfConfigUtils {
             final SecretKeyFactory keyFactory = SecretKeyFactory.getInstance(encrySrvConfig.getEncryptMethod());
             final KeySpec keySpec = new PBEKeySpec(encrySrvConfig.getEncryptKey().toCharArray(), encryptionKeySalt,
                     encrySrvConfig.getEncryptIterationCount(), encrySrvConfig.getEncryptKeyLength());
-            SecretKey key = new SecretKeySpec(keyFactory.generateSecret(keySpec).getEncoded(),
+            final SecretKey key = new SecretKeySpec(keyFactory.generateSecret(keySpec).getEncoded(),
                     encrySrvConfig.getEncryptType());
-            GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(encrySrvConfig.getAuthTagLength(),
+            final GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(encrySrvConfig.getAuthTagLength(),
                     encryptionKeySalt);
-
-            Cipher encryptCipher = Cipher.getInstance(encrySrvConfig.getCipherTransforms());
-            encryptCipher.init(Cipher.ENCRYPT_MODE, key, gcmParameterSpec);
-
-            Cipher decryptCipher = Cipher.getInstance(encrySrvConfig.getCipherTransforms());
-            decryptCipher.init(Cipher.DECRYPT_MODE, key, gcmParameterSpec);
-
             return new AAAEncryptionServiceImpl(gcmParameterSpec, encrySrvConfig.getCipherTransforms(), key);
-
-        } catch (NoSuchAlgorithmException | InvalidKeySpecException | NoSuchPaddingException
-                | InvalidAlgorithmParameterException | InvalidKeyException e) {
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
             throw new ConfigurationException(e);
         }
     }


### PR DESCRIPTION
Now we are creating ciphers in AAAEncryptionServiceImpl thus remove ciphers initialization from other places.

Additionally, remove not used random and clean code a bit.

JIRA: LIGHTY-193