### PR TITLE
Use java 21 to run netconf-simulator

### DIFF
--- a/.github/workflows/lighty-rnc-app/simulator/Dockerfile
+++ b/.github/workflows/lighty-rnc-app/simulator/Dockerfile
@@ -7,13 +7,13 @@ RUN apk add git
 WORKDIR /netconf-simulator
 RUN git clone https://github.com/PANTHEONtech/lighty-netconf-simulator.git -b $SIMULATOR_VERSION
 
-FROM maven:3.9-eclipse-temurin-17-alpine as build
+FROM maven:3.9-eclipse-temurin-21-alpine as build
 ARG SIMULATOR_VERSION
 WORKDIR /lighty-netconf-simulator
 COPY --from=clone /netconf-simulator/lighty-netconf-simulator /lighty-netconf-simulator
 RUN mvn -B install -DskipTests
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:21
 ARG SIMULATOR_VERSION
 WORKDIR /lighty-netconf-simulator
 COPY --from=build /lighty-netconf-simulator/examples/devices/lighty-network-topology-device/target/ /lighty-netconf-simulator/target


### PR DESCRIPTION
Make Dockerfile use java 21 since it is required after scandium.

JIRA: LIGHTY-336