### PR TITLE
[main] Bump docker-maven-plugin to 0.45.1

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/pom.xml
@@ -94,7 +94,7 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.42.0</version>
+                <version>0.45.1</version>
                 <configuration>
                     <images>
                         <image>

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
@@ -91,7 +91,7 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.42.0</version>
+                <version>0.45.1</version>
                 <configuration>
                     <images>
                         <image>


### PR DESCRIPTION
https://github.com/fabric8io/docker-maven-plugin/releases/tag/v0.45.1