### PR TITLE
Call countDown() on blocking shutdown only

### DIFF
--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/AbstractLightyModule.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/AbstractLightyModule.java
@@ -166,7 +166,6 @@ public abstract class AbstractLightyModule implements LightyModule {
             synchronized (AbstractLightyModule.this) {
                 LOG.debug("Starting shutdown procedure of LightyModule {}.", this.getClass().getSimpleName());
                 final boolean stopResult = stopProcedure();
-                this.shutdownLatch.countDown();
                 this.running = false;
                 LOG.info("LightyModule {} shutdown complete.", this.getClass().getSimpleName());
                 return stopResult;
@@ -191,6 +190,7 @@ public abstract class AbstractLightyModule implements LightyModule {
     @Override
     public final boolean shutdown(final long duration, final TimeUnit unit) {
         try {
+            shutdownLatch.countDown();
             final var stopSuccess = shutdown().get(duration, unit);
             if (stopSuccess) {
                 LOG.info("LightyModule {} stopped successfully!", getClass().getSimpleName());


### PR DESCRIPTION
Call shutdownLatch.countDown() on blocking shutdown only, not in asynchronous shutdown() method.

JIRA: LIGHTY-299
Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit 61e67ea490f73000d4e827367259b962e8e0e993)