### PR TITLE
Increase module timeouts

### DIFF
--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/LightyModule.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/LightyModule.java
@@ -27,13 +27,6 @@ public interface LightyModule {
     ListenableFuture<Boolean> start();
 
     /**
-     * Start and block until shutdown is requested.
-     *
-     * @throws InterruptedException thrown in case module initialization fails.
-     */
-    void startBlocking() throws InterruptedException;
-
-    /**
      * Shutdown module.
      *
      * @return true if module shutdown was successful, false or exception otherwise.

--- a/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/api/LightyModuleTest.java
+++ b/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/api/LightyModuleTest.java
@@ -7,13 +7,9 @@
  */
 package io.lighty.core.controller.api;
 
-import com.google.common.util.concurrent.SettableFuture;
 import io.lighty.core.controller.impl.LightyControllerBuilder;
 import io.lighty.core.controller.impl.util.ControllerConfigUtils;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -26,7 +22,6 @@ import org.testng.annotations.Test;
 public class LightyModuleTest {
     private static final long MAX_INIT_TIMEOUT = 15000L;
     private static final long MAX_SHUTDOWN_TIMEOUT = 15000L;
-    private static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT = 800L;
 
     private ExecutorService executorService;
     private LightyModule moduleUnderTest;
@@ -83,63 +78,5 @@ public class LightyModuleTest {
         this.moduleUnderTest = getModuleUnderTest(getExecutorService());
         this.moduleUnderTest.shutdown(MAX_SHUTDOWN_TIMEOUT, TimeUnit.MILLISECONDS);
         Mockito.verify(executorService, Mockito.times(0)).execute(Mockito.any());
-    }
-
-    @Test
-    public void testStartBlocking_and_shutdown() throws Exception {
-        this.moduleUnderTest = getModuleUnderTest(getExecutorService());
-        startStopBlocking(this.moduleUnderTest instanceof AbstractLightyModule);
-    }
-
-    @Test
-    public void testStartStopBlocking() throws Exception {
-        this.moduleUnderTest = getModuleUnderTest(getExecutorService());
-        startStopBlocking(false);
-    }
-
-    private void startStopBlocking(final boolean isAbstract) throws Exception {
-        Future<Boolean> startBlockingFuture;
-        if (isAbstract) {
-            startBlockingFuture = startBlockingOnLightyModuleAbstractClass();
-        } else {
-            startBlockingFuture = startBlockingOnLightyModuleInterface();
-        }
-        //test if thread which invokes startBlocking method is still running (it should be)
-        Assert.assertFalse(startBlockingFuture.isDone());
-
-        this.moduleUnderTest.shutdown(MAX_SHUTDOWN_TIMEOUT, TimeUnit.MILLISECONDS);
-        try {
-            //test if thread which invokes startBlocking method is done after shutdown was called
-            //(after small timeout due to synchronization);
-            startBlockingFuture.get(SLEEP_AFTER_SHUTDOWN_TIMEOUT, TimeUnit.MILLISECONDS);
-        } catch (TimeoutException e) {
-            Assert.fail("Waiting for finish of startBlocking method thread timed out. you may consider to adjust"
-                    + "timeout by overriding SLEEP_AFTER_SHUTDOWN_TIMEOUT", e);
-        }
-
-        Mockito.verify(executorService, Mockito.times(2)).execute(Mockito.any());
-    }
-
-    private Future<Boolean> startBlockingOnLightyModuleAbstractClass() throws ExecutionException, InterruptedException {
-        SettableFuture<Boolean> initDoneFuture = SettableFuture.create();
-        Future<Boolean> startFuture = Executors.newSingleThreadExecutor().submit(() -> {
-            ((AbstractLightyModule)this.moduleUnderTest).startBlocking(initDoneFuture::set);
-            return true;
-        });
-        try {
-            initDoneFuture.get(MAX_INIT_TIMEOUT, TimeUnit.MILLISECONDS);
-        } catch (TimeoutException e) {
-            Assert.fail("Init timed out.", e);
-        }
-        return startFuture;
-    }
-
-    private Future<Boolean> startBlockingOnLightyModuleInterface() throws InterruptedException {
-        Future<Boolean> startFuture = Executors.newSingleThreadExecutor().submit(() -> {
-            this.moduleUnderTest.startBlocking();
-            return true;
-        });
-        Thread.sleep(MAX_INIT_TIMEOUT);
-        return startFuture;
     }
 }

--- a/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/util/FileToDatastoreUtilsTest.java
+++ b/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/util/FileToDatastoreUtilsTest.java
@@ -40,7 +40,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class FileToDatastoreUtilsTest {
-
     private static final String INITIAL_CONTAINER_PATH = "/data/container-value-1.json";
     private static final String CASE_CONTAINER_PATH = "/data/case-container-value.json";
     private static final String OVERRIDE_CONTAINER_PATH = "/data/container-value-2.xml";
@@ -69,7 +68,7 @@ public class FileToDatastoreUtilsTest {
             NodeIdentifier.create(SampleContainer.QNAME),
             NodeIdentifier.create(YangModuleInfoImpl.qnameOf("value")));
 
-    private static final long TIMEOUT_MILLIS = 20_000;
+    private static final long TIMEOUT_MILLIS = 60_000;
 
     private LightyController lightyController;
     private DataBroker dataBroker;
@@ -85,8 +84,8 @@ public class FileToDatastoreUtilsTest {
     }
 
     @AfterClass
-    public void tearDown() throws Exception {
-        assertTrue(lightyController.shutdown().get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
+    public void tearDown() {
+        assertTrue(lightyController.shutdown(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
     }
 
     @Test


### PR DESCRIPTION
Increase module timeouts

Increase timeout for start/shutdown in FileToDatastoreUtilsTest
in order to avoid timeouts during verify jobs.

60 seconds timeout corresponds with default module timeout as
set in ModulesConfig class.

JIRA: LIGHTY-299