### PR TITLE
Increase module timeouts

### DIFF
--- a/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/util/FileToDatastoreUtilsTest.java
+++ b/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/util/FileToDatastoreUtilsTest.java
@@ -40,7 +40,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class FileToDatastoreUtilsTest {
-
     private static final String INITIAL_CONTAINER_PATH = "/data/container-value-1.json";
     private static final String CASE_CONTAINER_PATH = "/data/case-container-value.json";
     private static final String OVERRIDE_CONTAINER_PATH = "/data/container-value-2.xml";
@@ -69,7 +68,7 @@ public class FileToDatastoreUtilsTest {
             NodeIdentifier.create(SampleContainer.QNAME),
             NodeIdentifier.create(YangModuleInfoImpl.qnameOf("value")));
 
-    private static final long TIMEOUT_MILLIS = 20_000;
+    private static final long TIMEOUT_MILLIS = 60_000;
 
     private LightyController lightyController;
     private DataBroker dataBroker;
@@ -85,8 +84,8 @@ public class FileToDatastoreUtilsTest {
     }
 
     @AfterClass
-    public void tearDown() throws Exception {
-        assertTrue(lightyController.shutdown().get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
+    public void tearDown() {
+        assertTrue(lightyController.shutdown(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
     }
 
     @Test


### PR DESCRIPTION
Increase timeout for start/shutdown in FileToDatastoreUtilsTest in order to avoid timeouts during verify jobs.

60 seconds timeout corresponds with default module timeout as set in ModulesConfig class.

JIRA: LIGHTY-299
Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit c4d794041fa6ee3b0906f265af70a18a323bd5e4)