### PR TITLE
Deprecate LightyModule#startBlocking

### DIFF
--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/AbstractLightyModule.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/AbstractLightyModule.java
@@ -139,7 +139,9 @@ public abstract class AbstractLightyModule implements LightyModule {
      * Start and block until shutdown is requested.
      * @param initFinishCallback callback that will be called after start is completed.
      * @throws InterruptedException thrown in case module initialization fails.
+     * @deprecated Use @{@code start.get()} instead in case you want blocking start.
      */
+    @Deprecated(forRemoval = true)
     public void startBlocking(final Consumer<Boolean> initFinishCallback) throws InterruptedException {
         Futures.addCallback(start(), new FutureCallback<Boolean>() {
             @Override

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/LightyModule.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/LightyModule.java
@@ -30,7 +30,9 @@ public interface LightyModule {
      * Start and block until shutdown is requested.
      *
      * @throws InterruptedException thrown in case module initialization fails.
+     * @deprecated Use @{@code start.get()} instead in case you want blocking start.
      */
+    @Deprecated(forRemoval = true)
     void startBlocking() throws InterruptedException;
 
     /**

--- a/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/api/LightyModuleTest.java
+++ b/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/api/LightyModuleTest.java
@@ -7,13 +7,9 @@
  */
 package io.lighty.core.controller.api;
 
-import com.google.common.util.concurrent.SettableFuture;
 import io.lighty.core.controller.impl.LightyControllerBuilder;
 import io.lighty.core.controller.impl.util.ControllerConfigUtils;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -26,7 +22,6 @@ import org.testng.annotations.Test;
 public class LightyModuleTest {
     private static final long MAX_INIT_TIMEOUT = 15000L;
     private static final long MAX_SHUTDOWN_TIMEOUT = 15000L;
-    private static final long SLEEP_AFTER_SHUTDOWN_TIMEOUT = 800L;
 
     private ExecutorService executorService;
     private LightyModule moduleUnderTest;
@@ -83,63 +78,5 @@ public class LightyModuleTest {
         this.moduleUnderTest = getModuleUnderTest(getExecutorService());
         this.moduleUnderTest.shutdown(MAX_SHUTDOWN_TIMEOUT, TimeUnit.MILLISECONDS);
         Mockito.verify(executorService, Mockito.times(0)).execute(Mockito.any());
-    }
-
-    @Test
-    public void testStartBlocking_and_shutdown() throws Exception {
-        this.moduleUnderTest = getModuleUnderTest(getExecutorService());
-        startStopBlocking(this.moduleUnderTest instanceof AbstractLightyModule);
-    }
-
-    @Test
-    public void testStartStopBlocking() throws Exception {
-        this.moduleUnderTest = getModuleUnderTest(getExecutorService());
-        startStopBlocking(false);
-    }
-
-    private void startStopBlocking(final boolean isAbstract) throws Exception {
-        Future<Boolean> startBlockingFuture;
-        if (isAbstract) {
-            startBlockingFuture = startBlockingOnLightyModuleAbstractClass();
-        } else {
-            startBlockingFuture = startBlockingOnLightyModuleInterface();
-        }
-        //test if thread which invokes startBlocking method is still running (it should be)
-        Assert.assertFalse(startBlockingFuture.isDone());
-
-        this.moduleUnderTest.shutdown(MAX_SHUTDOWN_TIMEOUT, TimeUnit.MILLISECONDS);
-        try {
-            //test if thread which invokes startBlocking method is done after shutdown was called
-            //(after small timeout due to synchronization);
-            startBlockingFuture.get(SLEEP_AFTER_SHUTDOWN_TIMEOUT, TimeUnit.MILLISECONDS);
-        } catch (TimeoutException e) {
-            Assert.fail("Waiting for finish of startBlocking method thread timed out. you may consider to adjust"
-                    + "timeout by overriding SLEEP_AFTER_SHUTDOWN_TIMEOUT", e);
-        }
-
-        Mockito.verify(executorService, Mockito.times(2)).execute(Mockito.any());
-    }
-
-    private Future<Boolean> startBlockingOnLightyModuleAbstractClass() throws ExecutionException, InterruptedException {
-        SettableFuture<Boolean> initDoneFuture = SettableFuture.create();
-        Future<Boolean> startFuture = Executors.newSingleThreadExecutor().submit(() -> {
-            ((AbstractLightyModule)this.moduleUnderTest).startBlocking(initDoneFuture::set);
-            return true;
-        });
-        try {
-            initDoneFuture.get(MAX_INIT_TIMEOUT, TimeUnit.MILLISECONDS);
-        } catch (TimeoutException e) {
-            Assert.fail("Init timed out.", e);
-        }
-        return startFuture;
-    }
-
-    private Future<Boolean> startBlockingOnLightyModuleInterface() throws InterruptedException {
-        Future<Boolean> startFuture = Executors.newSingleThreadExecutor().submit(() -> {
-            this.moduleUnderTest.startBlocking();
-            return true;
-        });
-        Thread.sleep(MAX_INIT_TIMEOUT);
-        return startFuture;
     }
 }


### PR DESCRIPTION
Deprecate practically unused LightyModule#startBlocking method which helps us to get rid of CountDownLatch in AbstractLightyModule.

This method seems to be mixing concepts of using Future and CountDownLatch synchronisation tools. IMO there is no need to block start method.

Additionally, there were some unusual usages in tests. They were trying to invoke a blocking call and wrap its result into Future.

JIRA: LIGHTY-299
Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit 187f7f6d4e628bf4ae103d0e3dcb1459e56308bd)