### PR TITLE
Run tests in single thread

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         run: mvn install -DskipTests=true -B -V -Psource-quality
       - name: Maven test + SonarCloud
         if: ${{ env.SONAR_TOKEN != 0 }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+        run: mvn -T1 -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
           -Dsonar.java.source=21
           -Dsonar.projectKey=${{ env.SONAR_PROJECT_KEY }}
           -Dsonar.organization=${{ env.SONAR_ORGANIZATION }}
@@ -55,7 +55,7 @@ jobs:
           -Dsonar.coverage.exclusions=**/lighty-codecs/**/*
       - name: Maven test no SonarCloud
         if: ${{ env.SONAR_TOKEN == 0 }}
-        run: mvn -B verify
+        run: mvn -T1 -B verify
       - name: Upload surefire test results
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Run test during build in single thread to avoid
"address already in use" issues which can be caused by parallel test execution.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit a80868f18e2dacc226e47690c869c00c41b2c1cd)