### PR TITLE
Add timeout to shutdown

### DIFF
--- a/lighty-core/lighty-controller-guice-di/src/test/java/io/lighty/core/controller/guice/tests/GuiceDITest.java
+++ b/lighty-core/lighty-controller-guice-di/src/test/java/io/lighty/core/controller/guice/tests/GuiceDITest.java
@@ -18,6 +18,7 @@ import io.lighty.core.controller.impl.config.ConfigurationException;
 import io.lighty.core.controller.impl.config.ControllerConfiguration;
 import io.lighty.core.controller.impl.util.ControllerConfigUtils;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
@@ -50,7 +51,7 @@ public class GuiceDITest {
     public void shutdown() {
         try {
             if (lightyController != null) {
-                lightyController.shutdown().get();
+                lightyController.shutdown(60, TimeUnit.SECONDS);
             }
         } catch (Exception e) {
             LOG.error("Shutdown of LightyController failed", e);

--- a/lighty-core/lighty-controller-spring-di/src/test/java/io/lighty/core/controller/spring/LightyCoreSpringConfigurationTest.java
+++ b/lighty-core/lighty-controller-spring-di/src/test/java/io/lighty/core/controller/spring/LightyCoreSpringConfigurationTest.java
@@ -18,6 +18,7 @@ import io.lighty.core.controller.impl.config.ConfigurationException;
 import io.lighty.core.controller.impl.util.ControllerConfigUtils;
 import java.util.Collections;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.opendaylight.controller.cluster.ActorSystemProvider;
 import org.opendaylight.controller.cluster.datastore.DistributedDataStoreInterface;
@@ -198,7 +199,7 @@ public class LightyCoreSpringConfigurationTest extends AbstractJUnit4SpringConte
         public void shutdownLightyController(LightyController lightyController) throws LightyLaunchException {
             try {
                 LOG.info("Shutting down LightyController ...");
-                lightyController.shutdown().get();
+                lightyController.shutdown(60, TimeUnit.SECONDS);
             } catch (Exception e) {
                 throw new LightyLaunchException("Could not shutdown LightyController", e);
             }

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/AbstractLightyModule.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/AbstractLightyModule.java
@@ -217,7 +217,8 @@ public abstract class AbstractLightyModule implements LightyModule {
      * @param duration duration to wait for shutdown to complete
      * @param unit {@link TimeUnit} of {@code duration}
      * @return {@code boolean} indicating shutdown sucess
-     * @deprecated Use {@code shutdown()} or {@code shutdown(duration, unit)} instead in case you want blocking shutdown.
+     * @deprecated Use {@code shutdown()} or {@code shutdown(duration, unit)} instead in case you want
+     *     blocking shutdown.
      */
     @Deprecated(forRemoval = true)
     public final boolean shutdownBlocking(final long duration, final TimeUnit unit) {

--- a/lighty-modules/lighty-aaa-aggregator/lighty-aaa/src/test/java/io/lighty/aaa/ShiroInitializationTest.java
+++ b/lighty-modules/lighty-aaa-aggregator/lighty-aaa/src/test/java/io/lighty/aaa/ShiroInitializationTest.java
@@ -18,7 +18,7 @@ import io.lighty.aaa.util.AAAConfigUtils;
 import io.lighty.server.LightyServerBuilder;
 import java.net.InetSocketAddress;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opendaylight.aaa.api.CredentialAuth;
@@ -81,11 +81,11 @@ public class ShiroInitializationTest {
     }
 
     @AfterMethod
-    public void tearDown() throws ExecutionException, InterruptedException {
+    public void tearDown() {
         if (aaaLighty != null) {
             // Stop the object and ensure that stopping was successful
             assertTrue(aaaLighty.stopProcedure());
-            assertTrue(aaaLighty.shutdown().get());
+            assertTrue(aaaLighty.shutdown(60, TimeUnit.SECONDS));
         }
     }
 


### PR DESCRIPTION
Add timeout to all shutdown calls in test classes.

JIRA: LIGHTY-299
Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit b65dd3daee1734c26ee419e181c8a6f4a52a3097)