### PR TITLE
Bump grpc-netty to 1.68.2

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
@@ -23,7 +23,7 @@
 
     <properties>
         <protobuf.version>3.25.5</protobuf.version>
-        <grpc.version>1.67.1</grpc.version>
+        <grpc.version>1.68.2</grpc.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
https://github.com/grpc/grpc-java/releases/tag/v1.68.2 https://github.com/grpc/grpc-java/releases/tag/v1.68.1 https://github.com/grpc/grpc-java/releases/tag/v1.68.0

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit 4a026e4ff1c9a51b5732c55f5161361583d576d7)