### PR TITLE
Update actions/cache to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,14 +26,14 @@ jobs:
           java-version: 17
           distribution: 'temurin'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         if: ${{ env.SONAR_TOKEN != 0 }}
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/publish-docker-helm.yml
+++ b/.github/workflows/publish-docker-helm.yml
@@ -55,7 +55,7 @@ jobs:
           java-version: 17
           distribution: 'temurin'
       - name: Cache Maven packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/publish-rcgnmi.yml
+++ b/.github/workflows/publish-rcgnmi.yml
@@ -43,7 +43,7 @@ jobs:
           java-version: 17
           distribution: 'temurin'
       - name: Cache Maven packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/publish-rnc.yml
+++ b/.github/workflows/publish-rnc.yml
@@ -43,7 +43,7 @@ jobs:
           java-version: 17
           distribution: 'temurin'
       - name: Cache Maven packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/test-lighty-app.yml
+++ b/.github/workflows/test-lighty-app.yml
@@ -28,7 +28,7 @@ jobs:
           java-version: 17
           distribution: 'temurin'
       - name: Cache Maven packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
Update these deprecated actions to latest v4 version: https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/ https://github.com/actions/cache/blob/main/examples.md#java---maven

JIRA: LIGHTY-344
Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
(cherry picked from commit 855d912966460b878f89aa1183c8d78978d50a9d)