### PR TITLE
Move maven.compiler.release to minimal parent

### DIFF
--- a/lighty-core/lighty-minimal-parent/pom.xml
+++ b/lighty-core/lighty-minimal-parent/pom.xml
@@ -22,6 +22,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>21</maven.compiler.release>
     </properties>
 
     <dependencyManagement>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -28,7 +28,6 @@
     </description>
 
     <properties>
-        <maven.compiler.release>21</maven.compiler.release>
         <!-- Overrides Spring Boot slf4j and log4j2 dependency version -->
         <slf4j.version>2.0.16</slf4j.version>
         <log4j2.version>2.24.2</log4j2.version>


### PR DESCRIPTION
Move maven.compiler.release property from lighty-parent to lighty-minimal-parent.

Since Java version used is something basic to set this change will free users of minimal parent to specify it on their own.