### PR TITLE
[21.x] Bump actions-setup-minikube

### DIFF
--- a/.github/workflows/test-lighty-app.yml
+++ b/.github/workflows/test-lighty-app.yml
@@ -38,7 +38,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.7.2
+        uses: manusa/actions-setup-minikube@v2.13.0
         with:
           minikube version: 'v1.28.0'
           kubernetes version: 'v1.25.4'


### PR DESCRIPTION
This action only supports Ubuntu 18, 20 and 22. We are using latest version of ubuntu making this action incompatible.

JIRA: LIGHTY-352
Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
(cherry picked from commit 8626db9aa29e2417cb37b4c75aaae60255e79bce)