### PR TITLE
Bump alpine to 3.21.2

### DIFF
--- a/.github/workflows/lighty-rnc-app/simulator/Dockerfile
+++ b/.github/workflows/lighty-rnc-app/simulator/Dockerfile
@@ -1,6 +1,6 @@
 ARG SIMULATOR_VERSION="21.1.0"
 
-FROM alpine:3.20.3 as clone
+FROM alpine:3.21.2 as clone
 
 ARG SIMULATOR_VERSION
 RUN apk add git


### PR DESCRIPTION
https://alpinelinux.org/posts/Alpine-3.18.11-3.19.6-3.20.5-3.21.2-released.html

Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
(cherry picked from commit ea8491a8e5b7bcac7a28d2bfe416bcdf639b2bd2)