### PR TITLE
Logging should not be vulnerable to injection attacks

### DIFF
--- a/lighty-examples/lighty-controller-springboot-netconf/src/main/java/io/lighty/core/controller/springboot/rest/TopologyRestService.java
+++ b/lighty-examples/lighty-controller-springboot-netconf/src/main/java/io/lighty/core/controller/springboot/rest/TopologyRestService.java
@@ -9,6 +9,7 @@
 package io.lighty.core.controller.springboot.rest;
 
 import io.lighty.core.controller.springboot.utils.Utils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.opendaylight.mdsal.binding.api.DataBroker;
 import org.opendaylight.mdsal.binding.api.ReadTransaction;
 import org.opendaylight.mdsal.binding.api.WriteTransaction;
@@ -116,10 +117,10 @@ public class TopologyRestService {
 
         try {
             tx.commit().get(TIMEOUT, TimeUnit.SECONDS);
-            LOG.info("Topology {} was deleted from datastore", topologyId);
+            LOG.info("Topology {} was deleted from datastore", StringEscapeUtils.escapeJava(topologyId));
             return ResponseEntity.ok().build();
         } catch (ExecutionException | TimeoutException e) {
-            LOG.error("Could not delete topology {} from datastore", topologyId, e);
+            LOG.error("Could not delete topology {} from datastore", StringEscapeUtils.escapeJava(topologyId), e);
             return ResponseEntity.status(500).build();
         }
     }


### PR DESCRIPTION
This issue was detected by sonarcloud. Resolve it by sanitising the LOG message using StringEscapeUtils.

JIRA: LIGHTY-362
Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
(cherry picked from commit 5e19c91d4405ce8f8079033c913fc30874944b18)