### PR TITLE
Package lighty.io's BOM

### DIFF
--- a/lighty-core/lighty-bom/pom.xml
+++ b/lighty-core/lighty-bom/pom.xml
@@ -11,7 +11,7 @@
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-bom</artifactId>
     <version>22.0.0-SNAPSHOT</version>
-    <packaging>pom</packaging>
+    <packaging>bom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <url>https://github.com/PANTHEONtech/lighty</url>


### PR DESCRIPTION
Set packaging in lighty-bom to "bom" to prevent ist usage as parent with Maven 4.

"Starting from Maven 4.0, a new specific BOM packaging has been introduced. It allows defining a BOMs which are not used as parent in a project leveraging the newer 4.1.0 model, while still providing full compatibility with Maven 3.X clients and projects. This BOM packaging is translated into a more usual POM packaging at
installation / deployment time, leveraging the build/consumer POM feature from Maven 4. This thus provides full compatibility with Maven 3.x."

See: https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Management