### PR TITLE
Set Docker driver in Minikube setup on GitHub Actions

### DIFF
--- a/.github/workflows/test-lighty-app.yml
+++ b/.github/workflows/test-lighty-app.yml
@@ -37,6 +37,12 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
+      - name: Install bridge utils and socat
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y socat bridge-utils conntrack
+          sudo modprobe br_netfilter
+          echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-iptables
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.13.0
         with:


### PR DESCRIPTION
Minikube started failing on Ubuntu 24.04 runners due to the default none driver, which requires system-level configuration not available in GitHub-hosted environments: https://github.com/manusa/actions-setup-minikube?tab=readme-ov-file#optional-input-parameters

JIRA: LIGHTY-367

(cherry picked from commit fedbd08d73c49a834612159f6ab30f34d3af1c8c)