### PR TITLE
Bump actions-setup-minikube to 2.14.0

### DIFF
--- a/.github/workflows/test-lighty-app.yml
+++ b/.github/workflows/test-lighty-app.yml
@@ -38,10 +38,10 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.13.0
+        uses: manusa/actions-setup-minikube@v2.14.0
         with:
-          minikube version: 'v1.28.0'
-          kubernetes version: 'v1.25.4'
+          minikube version: 'v1.35.0'
+          kubernetes version: 'v1.33.0'
           github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Start Minikube cluster
         run: minikube start


### PR DESCRIPTION
Use the latest minikube setup and bump minikube
and kubernetes accordingly.
https://github.com/manusa/actions-setup-minikube/releases/tag/v2.14.0

JIRA: LIGHTY-367