### PR TITLE
Allow Lighty to get restconf path from configuration

### DIFF
--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/CommunityRestConf.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/CommunityRestConf.java
@@ -46,6 +46,7 @@ public class CommunityRestConf extends AbstractLightyModule {
     private final DOMActionService domActionService;
     private final DOMSchemaService domSchemaService;
     private final InetAddress inetAddress;
+    private final String restconfServletContextPath;
     private final int httpPort;
     private AbstractLightyWebServer jettyServer;
     private LightyJettyServerProvider lightyServerBuilder;
@@ -59,6 +60,7 @@ public class CommunityRestConf extends AbstractLightyModule {
             final DOMSchemaService domSchemaService,
             final InetAddress inetAddress,
             final int httpPort,
+            final String restconfServletContextPath,
             final LightyJettyServerProvider serverBuilder,
             final WebContextSecurer webContextSecurer) {
         this.domDataBroker = domDataBroker;
@@ -70,21 +72,25 @@ public class CommunityRestConf extends AbstractLightyModule {
         this.domSchemaService = domSchemaService;
         this.inetAddress = inetAddress;
         this.httpPort = httpPort;
+        this.restconfServletContextPath = restconfServletContextPath;
         this.webContextSecurer = (webContextSecurer == null) ? new LightyWebContextSecurer() : webContextSecurer;
     }
 
     public CommunityRestConf(final DOMDataBroker domDataBroker, final DOMRpcService domRpcService,
             final DOMNotificationService domNotificationService, final DOMActionService domActionService,
             final DOMMountPointService domMountPointService, final DOMSchemaService domSchemaService,
-            final InetAddress inetAddress, final int httpPort, final WebContextSecurer webContextSecurer) {
+            final InetAddress inetAddress, final int httpPort,
+            final String restconfServletContextPath, final WebContextSecurer webContextSecurer) {
         this(domDataBroker, domRpcService, domNotificationService, domActionService,
-                domMountPointService, domSchemaService, inetAddress, httpPort, null, webContextSecurer);
+                domMountPointService, domSchemaService, inetAddress, httpPort,
+                restconfServletContextPath,null, webContextSecurer);
     }
 
     @Override
     protected boolean initProcedure() throws ServletException {
         final Stopwatch stopwatch = Stopwatch.createStarted();
-        final JaxRsEndpointConfiguration streamsConfiguration = RestConfConfigUtils.getStreamsConfiguration();
+        final JaxRsEndpointConfiguration streamsConfiguration =
+            RestConfConfigUtils.getStreamsConfiguration(restconfServletContextPath);
 
         LOG.info("Starting RestconfApplication with configuration {}", streamsConfiguration);
 

--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/CommunityRestConfBuilder.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/CommunityRestConfBuilder.java
@@ -78,6 +78,7 @@ public final class CommunityRestConfBuilder {
             restconfConfiguration.getDomSchemaService(),
             restconfConfiguration.getInetAddress(),
             restconfConfiguration.getHttpPort(),
+            restconfConfiguration.getRestconfServletContextPath(),
             lightyServerBuilder,
             webContextSecurer
         );

--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/config/RestConfConfiguration.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/config/RestConfConfiguration.java
@@ -132,7 +132,8 @@ public class RestConfConfiguration {
     }
 
     public String getRestconfServletContextPath() {
-        return this.restconfServletContextPath;
+        return restconfServletContextPath.startsWith("/")
+            ? this.restconfServletContextPath.substring(1) : this.restconfServletContextPath;
     }
 
     public void setRestconfServletContextPath(final String restconfServletContextPath) {

--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
@@ -170,9 +170,8 @@ public final class RestConfConfigUtils {
         return new RestConfConfiguration();
     }
 
-    public static JaxRsEndpointConfiguration getStreamsConfiguration() {
+    public static JaxRsEndpointConfiguration getStreamsConfiguration(final String restconfPath) {
         return new JaxRsEndpointConfiguration(ErrorTagMapping.RFC8040, PrettyPrintParam.FALSE,
-            Uint16.valueOf(MAXIMUM_FRAGMENT_LENGTH), Uint32.valueOf(HEARTBEAT_INTERVAL),
-            RESTCONF_CONFIG_ROOT_ELEMENT_NAME);
+            Uint16.valueOf(MAXIMUM_FRAGMENT_LENGTH), Uint32.valueOf(HEARTBEAT_INTERVAL), restconfPath);
     }
 }


### PR DESCRIPTION
RESTCONF_CONFIG_ROOT_ELEMENT_NAME was hard-coded to be /restconf and the logic to apply different endpoint is no longer present after JaxRS rework.

JIRA: LIGHTY-375