### PR TITLE
Bump commons-lang3 to 3.18.0

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -136,7 +136,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.17.0</version>
+                <version>3.18.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>


### PR DESCRIPTION
Dependabot has created this PR to upgrade org.apache.commons.commons-lang3 from 3.17.0 to 3.18.0.

https://commons.apache.org/proper/commons-lang/changes.html#a3.18.0


(cherry picked from commit 049cc9940a596947c10baa45ceed8fd5f6db3ffa)