### PR TITLE
Manage RNC and RCGNMI docker artifacts by maven-release-plugin

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/pom.xml
@@ -21,6 +21,7 @@
         <lighty.app.name>lighty-rcgnmi-app-${project.version}</lighty.app.name>
         <lighty.app.zip>${lighty.app.name}-bin.zip</lighty.app.zip>
         <lighty.app.jar>${lighty.app.name}.jar</lighty.app.jar>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
@@ -18,6 +18,7 @@
         <lighty.app.name>lighty-rnc-app-${project.version}</lighty.app.name>
         <lighty.app.zip>${lighty.app.name}-bin.zip</lighty.app.zip>
         <lighty.app.jar>${lighty.app.name}.jar</lighty.app.jar>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <dependencies>

--- a/lighty-core/lighty-minimal-parent/pom.xml
+++ b/lighty-core/lighty-minimal-parent/pom.xml
@@ -115,9 +115,11 @@
                                 <artifactId>lighty-models-test-aggregator</artifactId>
                                 <artifactId>lighty-modules-aggregator</artifactId>
                                 <artifactId>lighty-rcgnmi-app-aggregator</artifactId>
+                                <artifactId>lighty-rcgnmi-app-docker</artifactId>
                                 <artifactId>lighty-rcgnmi-app</artifactId>
                                 <artifactId>lighty-resources-aggregator</artifactId>
                                 <artifactId>lighty-rnc-aggregator</artifactId>
+                                <artifactId>lighty-rnc-app-docker</artifactId>
                                 <artifactId>lighty-rnc-app</artifactId>
                                 <artifactId>lighty-tests-report</artifactId>
                             </excludeArtifacts>

--- a/lighty-examples/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/lighty-controller-springboot-netconf/pom.xml
@@ -137,4 +137,27 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <licenses>
+        <license>
+            <name>Eclipse Public License 1.0</name>
+            <url>https://www.eclipse.org/legal/epl-v10.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <scm>
+        <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
+        <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
+        <url>https://github.com/PANTHEONtech/lighty</url>
+        <tag>HEAD</tag>
+    </scm>
+    <developers>
+        <developer>
+            <id>rovarga</id>
+            <name>Robert Varga</name>
+            <email>robert.varga@pantheon.tech</email>
+            <organization>PANTHEON.tech s.r.o.</organization>
+            <organizationUrl>https://www.pantheon.tech</organizationUrl>
+        </developer>
+    </developers>
 </project>


### PR DESCRIPTION
This patch enables us to prepare release with just (+ adjusting documentation and READMEs):
```
mvn clean -Darguments=-DskipTests release:prepare -P docker
mvn clean -Darguments=-DskipTests release:perform -P docker
```