### PR TITLE
Fix inconsistent dependency versions

### DIFF
--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -49,12 +49,12 @@
             <plugin>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yang-maven-plugin</artifactId>
-                <version>14.0.11</version>
+                <version>14.0.14</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.opendaylight.yangtools</groupId>
                         <artifactId>binding-codegen</artifactId>
-                        <version>14.0.11</version>
+                        <version>14.0.14</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -202,7 +202,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>14.0.8</version>
+                            <version>14.1.0</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -219,7 +219,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>spotbugs</artifactId>
-                            <version>14.0.8</version>
+                            <version>14.1.0</version>
                         </dependency>
                         <!-- The SpotBugs Maven plugin uses SLF4J-2 -->
                         <dependency>


### PR DESCRIPTION
Use the versions which are in dependency-versions across the entire project.