### PR TITLE
Fix configuration path assertion

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/test/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModuleConfigUtilsTest.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/test/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModuleConfigUtilsTest.java
@@ -36,7 +36,7 @@ public class RcGnmiAppModuleConfigUtilsTest {
         final RestConfConfiguration restconfConfig = rcGnmiAppConfiguration.getRestconfConfig();
         assertEquals(restconfConfig.getInetAddress().getCanonicalHostName(), "0.0.0.1");
         assertEquals(restconfConfig.getHttpPort(), 8181);
-        assertEquals(restconfConfig.getRestconfServletContextPath(), "/rests");
+        assertEquals(restconfConfig.getRestconfServletContextPath(), "rests");
         // Assert gnmi config
         final GnmiConfiguration gnmiConfiguration = rcGnmiAppConfiguration.getGnmiConfiguration();
         Assertions.assertEquals(5, gnmiConfiguration.getInitialYangsPaths().size());
@@ -66,7 +66,7 @@ public class RcGnmiAppModuleConfigUtilsTest {
         final RestConfConfiguration restconfConfig = rcGnmiAppConfiguration.getRestconfConfig();
         assertEquals(restconfConfig.getInetAddress().getCanonicalHostName(), "0.0.0.0");
         assertEquals(restconfConfig.getHttpPort(), 8888);
-        assertEquals(restconfConfig.getRestconfServletContextPath(), "/restconf");
+        assertEquals(restconfConfig.getRestconfServletContextPath(), "restconf");
         // Assert gnmi config
         final GnmiConfiguration gnmiConfiguration = rcGnmiAppConfiguration.getGnmiConfiguration();
         Assertions.assertTrue(gnmiConfiguration.getInitialYangsPaths().isEmpty());
@@ -96,7 +96,7 @@ public class RcGnmiAppModuleConfigUtilsTest {
         final RestConfConfiguration restconfConfig = rcGnmiAppConfiguration.getRestconfConfig();
         assertEquals(restconfConfig.getInetAddress().getCanonicalHostName(), "0.0.0.0");
         assertEquals(restconfConfig.getHttpPort(), 8888);
-        assertEquals(restconfConfig.getRestconfServletContextPath(), "/restconf");
+        assertEquals(restconfConfig.getRestconfServletContextPath(), "restconf");
         // Assert gnmi config
         final GnmiConfiguration gnmiConfiguration = rcGnmiAppConfiguration.getGnmiConfiguration();
         Assertions.assertTrue(gnmiConfiguration.getInitialYangsPaths().isEmpty());

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/java/io/lighty/applications/rnc/module/config/RncLightyModuleConfigUtilsTest.java
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/src/test/java/io/lighty/applications/rnc/module/config/RncLightyModuleConfigUtilsTest.java
@@ -30,7 +30,7 @@ public class RncLightyModuleConfigUtilsTest {
         final var restconfConfig = rncConfig.getRestconfConfig();
         assertEquals(restconfConfig.getInetAddress().getCanonicalHostName(), "0.0.0.1");
         assertEquals(restconfConfig.getHttpPort(), 8181);
-        assertEquals(restconfConfig.getRestconfServletContextPath(), "/rests");
+        assertEquals(restconfConfig.getRestconfServletContextPath(), "rests");
 
         // Test Server configuration
         final var serverConfig = rncConfig.getServerConfig();
@@ -80,7 +80,7 @@ public class RncLightyModuleConfigUtilsTest {
         final var restconfConfig = rncConfig.getRestconfConfig();
         assertEquals(restconfConfig.getInetAddress().getCanonicalHostName(), "localhost");
         assertEquals(restconfConfig.getHttpPort(), 8888);
-        assertEquals(restconfConfig.getRestconfServletContextPath(), "/restconf");
+        assertEquals(restconfConfig.getRestconfServletContextPath(), "restconf");
 
         // Test Server configuration
         final var serverConfig = rncConfig.getServerConfig();


### PR DESCRIPTION
JaxRsEndpoint expects to be provided with path without slash (/), before JaxRs rework this did not matter. Now tests have to be modified to match this.

JIRA: LIGHTY-375