### PR TITLE
Align Pekko and support libs versions

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -212,22 +212,22 @@
             <dependency>
                 <groupId>org.apache.pekko</groupId>
                 <artifactId>pekko-management_2.13</artifactId>
-                <version>1.1.0</version>
+                <version>1.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.pekko</groupId>
                 <artifactId>pekko-management-cluster-http_2.13</artifactId>
-                <version>1.1.0</version>
+                <version>1.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.pekko</groupId>
                 <artifactId>pekko-management-cluster-bootstrap_2.13</artifactId>
-                <version>1.1.0</version>
+                <version>1.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.pekko</groupId>
                 <artifactId>pekko-discovery-kubernetes-api_2.13</artifactId>
-                <version>1.1.0</version>
+                <version>1.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.json</groupId>


### PR DESCRIPTION
Align Pekko and support libs versions. For Pekko 1.0.3 we use we have to use support libs versions 1.0.0 as per docs:

yes:
https://pekko.apache.org/docs/pekko-management/1.0.0/pekko-management.html no:
https://pekko.apache.org/docs/pekko-management/1.1.0/pekko-management.html

yes:
https://pekko.apache.org/docs/pekko-management/1.0.0/cluster-http-management.html no:
https://pekko.apache.org/docs/pekko-management/1.1.0/cluster-http-management.html

yes:
https://pekko.apache.org/docs/pekko-management/1.0.0/bootstrap/index.html no:
https://pekko.apache.org/docs/pekko-management/1.1.0/bootstrap/index.html

yes:
https://pekko.apache.org/docs/pekko-management/1.0.0/kubernetes-deployment/forming-a-cluster.html no:
https://pekko.apache.org/docs/pekko-management/1.1.0/kubernetes-deployment/forming-a-cluster.html