### PR TITLE
Bump jetty to 9.4.58.v20250814

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -30,6 +30,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- FIXME remove this when ODL bumps to newer jetty -->
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-server</artifactId>
+                <version>9.4.58.v20250814</version>
+            </dependency>
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>


### PR DESCRIPTION
Override jetty version to 9.4.58.v20250814

JIRA: LIGHTY-365

(cherry picked from commit 5151ff5a150b34abee43b66309112f33ac2681d0)