### PR TITLE
Bump logback to 1.3.15

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -36,6 +36,17 @@
                 <artifactId>jetty-server</artifactId>
                 <version>9.4.58.v20250814</version>
             </dependency>
+            <!-- FIXME remove this when ODL bumps to newer logback version -->
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.3.15</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>1.3.15</version>
+            </dependency>
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>


### PR DESCRIPTION
Override logback version to 1.3.15

JIRA: LIGHTY-365

(cherry picked from commit 7634f5d19499f6b10ee9495048ef7fcc49535000)