### PR TITLE
Revert "Bump netty to 4.1.124.Final"

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -22,14 +22,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- FIXME remove this when ODL bumps to newer netty version -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>4.1.124.Final</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <!-- FIXME remove this when ODL bumps to newer jetty -->
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
odlparent 14.1.1 uses newer version 4.2.2.Final making this commit redundant:
https://github.com/opendaylight/odlparent/blob/v14.1.1/odlparent-dependency-check/pom.xml#L99

This reverts commit 26e1fe7b