### PR TITLE
Use jetty-bom to override dependency version.

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -33,8 +33,10 @@
             <!-- FIXME remove this when ODL bumps to newer jetty -->
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-server</artifactId>
+                <artifactId>jetty-bom</artifactId>
                 <version>9.4.58.v20250814</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>


### PR DESCRIPTION
Overriding only the jetty-server dependency can lead to version mismatches with other Jetty artifacts used in the project, such as http2-server, jetty-alpn-server, and jetty-alpn-java-server.

To ensure all related Jetty dependencies use the same version, it is a best practice to import the Jetty Bill of Materials (BOM). This will manage the versions for all Jetty artifacts consistently.