### PR TITLE
Close netconf topology and callhome resources

### DIFF
--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfCallhomePlugin.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfCallhomePlugin.java
@@ -31,6 +31,9 @@ public class NetconfCallhomePlugin extends AbstractLightyModule {
 
     private final IetfZeroTouchCallHomeServerProvider provider;
     private final CallHomeMountService dispatcher;
+    private final CallHomeMountStatusReporter mountStatusReporter;
+    private final NetconfTopologySchemaAssembler netconfTopologySchemaAssembler;
+    private final DefaultNetconfTimer timer;
 
     public NetconfCallhomePlugin(final LightyServices lightyServices, final String topologyId,
             final ExecutorService executorService, final String adress, final int port) {
@@ -38,17 +41,18 @@ public class NetconfCallhomePlugin extends AbstractLightyModule {
         final DefaultBaseNetconfSchemaProvider defaultBaseNetconfSchemas = new
                 DefaultBaseNetconfSchemaProvider(lightyServices.getYangParserFactory());
         final SchemaResourceManager manager = new DefaultSchemaResourceManager(lightyServices.getYangParserFactory());
-        final var mountStatusReporter = new CallHomeMountStatusReporter(
+        mountStatusReporter = new CallHomeMountStatusReporter(
                 lightyServices.getBindingDataBroker());
         final CallHomeSshAuthProvider authProvider = new CallHomeMountSshAuthProvider(
                 lightyServices.getBindingDataBroker(), mountStatusReporter);
         final var recorder = new CallHomeMountStatusReporter(lightyServices.getBindingDataBroker());
-        final NetconfTimer timer = new DefaultNetconfTimer();
+        timer = new DefaultNetconfTimer();
         final CallHomeMountService.Configuration configuration = new Configuration(adress, port);
+        netconfTopologySchemaAssembler = new NetconfTopologySchemaAssembler(1);
 
         this.dispatcher =
             new CallHomeMountService(topologyId, timer,
-                new NetconfTopologySchemaAssembler(1),
+                netconfTopologySchemaAssembler,
                 manager, defaultBaseNetconfSchemas, lightyServices.getBindingDataBroker(),
                 lightyServices.getDOMMountPointService(), new DeviceActionFactoryImpl(), configuration);
         this.provider = new IetfZeroTouchCallHomeServerProvider(timer, dispatcher, authProvider, recorder,
@@ -63,14 +67,26 @@ public class NetconfCallhomePlugin extends AbstractLightyModule {
     @SuppressWarnings("checkstyle:illegalCatch")
     @Override
     protected boolean stopProcedure() {
+        boolean success = true;
+        success &= closeResource(dispatcher);
+        success &= closeResource(provider);
+        success &= closeResource(mountStatusReporter);
+        success &= closeResource(netconfTopologySchemaAssembler);
+        success &= closeResource(timer);
+        return success;
+    }
+
+    private boolean closeResource(AutoCloseable resource) {
+        if (resource == null) {
+            return true;
+        }
         try {
-            this.dispatcher.close();
-            this.provider.close();
-        } catch (final Exception e) {
-            LOG.error("{} failed to close!", this.provider.getClass(), e);
+            resource.close();
+            return true;
+        } catch (Exception e) {
+            LOG.error("{} failed to close!", resource.getClass().getName(), e);
             return false;
         }
-        return true;
     }
 
     public static class Configuration implements CallHomeMountService.Configuration {

--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfTopologyPlugin.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfTopologyPlugin.java
@@ -37,6 +37,8 @@ public final class NetconfTopologyPlugin extends AbstractTopologyPlugin {
     private NetconfTopologyImpl netconfTopologyImpl;
     private final AAAEncryptionService encryptionService;
     private final LightyServices lightyServices;
+    private NetconfTopologySchemaAssembler assembler;
+    private DefaultNetconfTimer timer;
 
     NetconfTopologyPlugin(final LightyServices lightyServices, final String topologyId,
             final ExecutorService executorService, final AAAEncryptionService encryptionService) {
@@ -53,15 +55,16 @@ public final class NetconfTopologyPlugin extends AbstractTopologyPlugin {
         final NetconfKeystoreService service = new DefaultNetconfKeystoreService(
                 lightyServices.getBindingDataBroker(), lightyServices.getRpcProviderService(),
                 lightyServices.getClusterSingletonServiceProvider(), encryptionService);
-        final NetconfClientFactory netconfFactory = new NetconfClientFactoryImpl(new DefaultNetconfTimer());
+        timer = new DefaultNetconfTimer();
+        final NetconfClientFactory netconfFactory = new NetconfClientFactoryImpl(timer);
         final CredentialProvider credentialProvider = new DefaultCredentialProvider(service);
         final SslContextFactoryProvider factoryProvider = new DefaultSslContextFactoryProvider(service);
         final NetconfClientConfigurationBuilderFactory factory = new NetconfClientConfigurationBuilderFactoryImpl(
             encryptionService, credentialProvider, factoryProvider);
-        final NetconfTopologySchemaAssembler assembler = new NetconfTopologySchemaAssembler(1);
+        assembler = new NetconfTopologySchemaAssembler(1);
         final SchemaResourceManager schemaResourceManager =
                 new DefaultSchemaResourceManager(lightyServices.getYangParserFactory());
-        netconfTopologyImpl = new NetconfTopologyImpl(topologyId, netconfFactory, new DefaultNetconfTimer(), assembler,
+        netconfTopologyImpl = new NetconfTopologyImpl(topologyId, netconfFactory, timer, assembler,
                 schemaResourceManager, lightyServices.getBindingDataBroker(), lightyServices.getDOMMountPointService(),
                 encryptionService, factory, lightyServices.getRpcProviderService(),
                 defaultBaseNetconfSchemas, new LightyDeviceActionFactory());
@@ -70,14 +73,28 @@ public final class NetconfTopologyPlugin extends AbstractTopologyPlugin {
 
     @Override
     protected boolean stopProcedure() {
-        if (netconfTopologyImpl != null) {
-            netconfTopologyImpl.close();
-        }
-        return true;
+        boolean success = true;
+        success &= closeResource(netconfTopologyImpl);
+        success &= closeResource(assembler);
+        success &= closeResource(timer);
+        return success;
     }
 
     @Override
     public boolean isClustered() {
         return false;
+    }
+
+    private boolean closeResource(AutoCloseable resource) {
+        if (resource == null) {
+            return true;
+        }
+        try {
+            resource.close();
+            return true;
+        } catch (Exception e) {
+            LOG.error("{} failed to close!", resource.getClass().getName(), e);
+            return false;
+        }
     }
 }


### PR DESCRIPTION
As reported by sonarcloud, these resources should be properly closed.

JIRA: LIGHTY-381

(cherry picked from commit eba6a77087cd9842f47a73e544702b87ac46996c)