### PR TITLE
Close netconf topology and callhome resources

### DIFF
--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfCallhomePlugin.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfCallhomePlugin.java
@@ -15,7 +15,6 @@ import org.opendaylight.netconf.client.mdsal.DeviceActionFactoryImpl;
 import org.opendaylight.netconf.client.mdsal.api.SchemaResourceManager;
 import org.opendaylight.netconf.client.mdsal.impl.DefaultBaseNetconfSchemaProvider;
 import org.opendaylight.netconf.client.mdsal.impl.DefaultSchemaResourceManager;
-import org.opendaylight.netconf.common.NetconfTimer;
 import org.opendaylight.netconf.common.di.DefaultNetconfTimer;
 import org.opendaylight.netconf.topology.callhome.CallHomeMountService;
 import org.opendaylight.netconf.topology.callhome.CallHomeMountSshAuthProvider;
@@ -33,6 +32,7 @@ public class NetconfCallhomePlugin extends AbstractLightyModule {
     private final CallHomeMountService dispatcher;
     private final CallHomeMountStatusReporter mountStatusReporter;
     private final NetconfTopologySchemaAssembler netconfTopologySchemaAssembler;
+    private final DefaultNetconfTimer timer;
 
     public NetconfCallhomePlugin(final LightyServices lightyServices, final String topologyId,
             final ExecutorService executorService, final String adress, final int port) {
@@ -44,7 +44,7 @@ public class NetconfCallhomePlugin extends AbstractLightyModule {
                 lightyServices.getBindingDataBroker());
         final CallHomeSshAuthProvider authProvider = new CallHomeMountSshAuthProvider(
                 lightyServices.getBindingDataBroker(), mountStatusReporter);
-        final NetconfTimer timer = new DefaultNetconfTimer();
+        timer = new DefaultNetconfTimer();
         final CallHomeMountService.Configuration configuration = new Configuration(adress, port);
         netconfTopologySchemaAssembler = new NetconfTopologySchemaAssembler(1);
 
@@ -69,6 +69,7 @@ public class NetconfCallhomePlugin extends AbstractLightyModule {
         success &= closeResource(provider);
         success &= closeResource(dispatcher);
         success &= closeResource(netconfTopologySchemaAssembler);
+        success &= closeResource(timer);
         success &= closeResource(mountStatusReporter);
         return success;
     }

--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfCallhomePlugin.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfCallhomePlugin.java
@@ -32,6 +32,7 @@ public class NetconfCallhomePlugin extends AbstractLightyModule {
     private final IetfZeroTouchCallHomeServerProvider provider;
     private final CallHomeMountService dispatcher;
     private final CallHomeMountStatusReporter mountStatusReporter;
+    private final NetconfTopologySchemaAssembler netconfTopologySchemaAssembler;
 
     public NetconfCallhomePlugin(final LightyServices lightyServices, final String topologyId,
             final ExecutorService executorService, final String adress, final int port) {
@@ -45,10 +46,11 @@ public class NetconfCallhomePlugin extends AbstractLightyModule {
                 lightyServices.getBindingDataBroker(), mountStatusReporter);
         final NetconfTimer timer = new DefaultNetconfTimer();
         final CallHomeMountService.Configuration configuration = new Configuration(adress, port);
+        netconfTopologySchemaAssembler = new NetconfTopologySchemaAssembler(1);
 
         this.dispatcher =
             new CallHomeMountService(topologyId, timer,
-                new NetconfTopologySchemaAssembler(1),
+                netconfTopologySchemaAssembler,
                 manager, defaultBaseNetconfSchemas, lightyServices.getBindingDataBroker(),
                 lightyServices.getDOMMountPointService(), new DeviceActionFactoryImpl(), configuration);
         this.provider = new IetfZeroTouchCallHomeServerProvider(timer, dispatcher, authProvider, mountStatusReporter,
@@ -66,6 +68,7 @@ public class NetconfCallhomePlugin extends AbstractLightyModule {
         boolean success = true;
         success &= closeResource(provider);
         success &= closeResource(dispatcher);
+        success &= closeResource(netconfTopologySchemaAssembler);
         success &= closeResource(mountStatusReporter);
         return success;
     }

--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfCallhomePlugin.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfCallhomePlugin.java
@@ -63,14 +63,23 @@ public class NetconfCallhomePlugin extends AbstractLightyModule {
     @SuppressWarnings("checkstyle:illegalCatch")
     @Override
     protected boolean stopProcedure() {
+        boolean success = true;
+        success &= closeResource(dispatcher);
+        return success;
+    }
+
+    @SuppressWarnings({"checkstyle:illegalCatch"})
+    private static boolean closeResource(final AutoCloseable resource) {
+        if (resource == null) {
+            return true;
+        }
         try {
-            this.dispatcher.close();
-            this.provider.close();
-        } catch (final Exception e) {
-            LOG.error("{} failed to close!", this.provider.getClass(), e);
+            resource.close();
+            return true;
+        } catch (Exception e) {
+            LOG.error("{} failed to close!", resource.getClass().getName(), e);
             return false;
         }
-        return true;
     }
 
     public static class Configuration implements CallHomeMountService.Configuration {

--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfTopologyPlugin.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfTopologyPlugin.java
@@ -37,6 +37,7 @@ public final class NetconfTopologyPlugin extends AbstractTopologyPlugin {
     private NetconfTopologyImpl netconfTopologyImpl;
     private final AAAEncryptionService encryptionService;
     private final LightyServices lightyServices;
+    private final NetconfTopologySchemaAssembler assembler;
 
     NetconfTopologyPlugin(final LightyServices lightyServices, final String topologyId,
             final ExecutorService executorService, final AAAEncryptionService encryptionService) {
@@ -44,6 +45,7 @@ public final class NetconfTopologyPlugin extends AbstractTopologyPlugin {
         this.lightyServices = lightyServices;
         this.topologyId = topologyId;
         this.encryptionService = encryptionService;
+        assembler = new NetconfTopologySchemaAssembler(1);
     }
 
     @Override
@@ -58,7 +60,6 @@ public final class NetconfTopologyPlugin extends AbstractTopologyPlugin {
         final SslContextFactoryProvider factoryProvider = new DefaultSslContextFactoryProvider(service);
         final NetconfClientConfigurationBuilderFactory factory = new NetconfClientConfigurationBuilderFactoryImpl(
             encryptionService, credentialProvider, factoryProvider);
-        final NetconfTopologySchemaAssembler assembler = new NetconfTopologySchemaAssembler(1);
         final SchemaResourceManager schemaResourceManager =
                 new DefaultSchemaResourceManager(lightyServices.getYangParserFactory());
         netconfTopologyImpl = new NetconfTopologyImpl(topologyId, netconfFactory, new DefaultNetconfTimer(), assembler,
@@ -72,6 +73,7 @@ public final class NetconfTopologyPlugin extends AbstractTopologyPlugin {
     protected boolean stopProcedure() {
         boolean success = true;
         success &= closeResource(netconfTopologyImpl);
+        success &= closeResource(assembler);
         return success;
     }
 

--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfTopologyPlugin.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfTopologyPlugin.java
@@ -70,14 +70,27 @@ public final class NetconfTopologyPlugin extends AbstractTopologyPlugin {
 
     @Override
     protected boolean stopProcedure() {
-        if (netconfTopologyImpl != null) {
-            netconfTopologyImpl.close();
-        }
-        return true;
+        boolean success = true;
+        success &= closeResource(netconfTopologyImpl);
+        return success;
     }
 
     @Override
     public boolean isClustered() {
         return false;
+    }
+
+    @SuppressWarnings({"checkstyle:illegalCatch"})
+    private static boolean closeResource(final AutoCloseable resource) {
+        if (resource == null) {
+            return true;
+        }
+        try {
+            resource.close();
+            return true;
+        } catch (Exception e) {
+            LOG.error("{} failed to close!", resource.getClass().getName(), e);
+            return false;
+        }
     }
 }


### PR DESCRIPTION
As reported by sonarcloud, these resources should be properly closed.

JIRA: LIGHTY-381