### PR TITLE
Close netconf topology and callhome resources

### DIFF
--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfTopologyPlugin.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfTopologyPlugin.java
@@ -38,6 +38,8 @@ public final class NetconfTopologyPlugin extends AbstractTopologyPlugin {
     private NetconfTopologyImpl netconfTopologyImpl;
     private final AAAEncryptionService encryptionService;
     private final LightyServices lightyServices;
+    private NetconfTopologySchemaAssembler assembler;
+    private DefaultNetconfTimer timer;
 
     NetconfTopologyPlugin(final LightyServices lightyServices, final String topologyId,
             final ExecutorService executorService, final AAAEncryptionService encryptionService) {
@@ -54,15 +56,16 @@ public final class NetconfTopologyPlugin extends AbstractTopologyPlugin {
         final NetconfKeystoreService service = new DefaultNetconfKeystoreService(
                 lightyServices.getBindingDataBroker(), lightyServices.getRpcProviderService(),
                 lightyServices.getClusterSingletonServiceProvider(), encryptionService);
-        final NetconfClientFactory netconfFactory = new NetconfClientFactoryImpl(new DefaultNetconfTimer());
+        timer = new DefaultNetconfTimer();
+        final NetconfClientFactory netconfFactory = new NetconfClientFactoryImpl(timer);
         final CredentialProvider credentialProvider = new DefaultCredentialProvider(service);
         final SslContextFactoryProvider factoryProvider = new DefaultSslContextFactoryProvider(service);
         final NetconfClientConfigurationBuilderFactory factory = new NetconfClientConfigurationBuilderFactoryImpl(
             encryptionService, credentialProvider, factoryProvider);
-        final NetconfTopologySchemaAssembler assembler = new NetconfTopologySchemaAssembler(1,1,10, TimeUnit.SECONDS);
+        assembler = new NetconfTopologySchemaAssembler(1,1,10, TimeUnit.SECONDS);
         final SchemaResourceManager schemaResourceManager =
                 new DefaultSchemaResourceManager(lightyServices.getYangParserFactory());
-        netconfTopologyImpl = new NetconfTopologyImpl(topologyId, netconfFactory, new DefaultNetconfTimer(), assembler,
+        netconfTopologyImpl = new NetconfTopologyImpl(topologyId, netconfFactory, timer, assembler,
                 schemaResourceManager, lightyServices.getBindingDataBroker(), lightyServices.getDOMMountPointService(),
                 encryptionService, factory, lightyServices.getRpcProviderService(),
                 defaultBaseNetconfSchemas, new LightyDeviceActionFactory());
@@ -71,14 +74,29 @@ public final class NetconfTopologyPlugin extends AbstractTopologyPlugin {
 
     @Override
     protected boolean stopProcedure() {
-        if (netconfTopologyImpl != null) {
-            netconfTopologyImpl.close();
-        }
-        return true;
+        boolean success = true;
+        success &= closeResource(netconfTopologyImpl);
+        success &= closeResource(assembler);
+        success &= closeResource(timer);
+        return success;
     }
 
     @Override
     public boolean isClustered() {
         return false;
+    }
+
+    @SuppressWarnings({"checkstyle:illegalCatch"})
+    private boolean closeResource(AutoCloseable resource) {
+        if (resource == null) {
+            return true;
+        }
+        try {
+            resource.close();
+            return true;
+        } catch (Exception e) {
+            LOG.error("{} failed to close!", resource.getClass().getName(), e);
+            return false;
+        }
     }
 }

--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/CommunityRestConf.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/CommunityRestConf.java
@@ -62,6 +62,7 @@ public class CommunityRestConf extends AbstractLightyModule {
     private final int httpPort;
     private final InetAddress inetAddress;
     private final String restconfServletContextPath;
+    private MdsalRestconfServer server;
     private Server jettyServer;
     private LightyServerBuilder lightyServerBuilder;
     private JaxRsEndpoint jaxRsEndpoint;
@@ -102,7 +103,7 @@ public class CommunityRestConf extends AbstractLightyModule {
         LOG.info("Starting RestconfApplication with configuration {}", streamsConfiguration);
 
         final MdsalDatabindProvider databindProvider = new MdsalDatabindProvider(domSchemaService);
-        final var server = new MdsalRestconfServer(databindProvider, domDataBroker, domRpcService, domActionService,
+        server = new MdsalRestconfServer(databindProvider, domDataBroker, domRpcService, domActionService,
             domMountPointService);
 
         this.jaxRsEndpoint = new JaxRsEndpoint(new JettyWebServer(httpPort), new LightyWebContextSecurer(),
@@ -177,6 +178,9 @@ public class CommunityRestConf extends AbstractLightyModule {
         }
         if (this.lightyServerBuilder != null) {
             this.lightyServerBuilder = null;
+        }
+        if (this.server != null) {
+            server.close();
         }
         return !stopFailed;
     }


### PR DESCRIPTION
As reported by sonarcloud, these resources should be properly closed.

JIRA: LIGHTY-381

(cherry picked from commit fe0e33937fe72b666cdbcfde3bab6a30846d53c8)