### PR TITLE
Convert client.key to RSA format

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-connector/src/main/scripts/generate_certs.sh
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-connector/src/main/scripts/generate_certs.sh
@@ -90,4 +90,8 @@ openssl verify -verbose -CAfile ca.crt client.crt
 echo ""
 echo " == Validate Client with passphrase"
 openssl verify -verbose -CAfile ca.crt client.encrypted.crt
-
+echo ""
+echo " == Transform Client from PEM to RSA format"
+openssl rsa -in client.key -out client_new.key -traditional
+rm client.key
+mv client_new.key client.key


### PR DESCRIPTION
GNMI app cannot read PEM encoded client key. Our only option is to use RSA encoding.

GH issue: #2355