### PR TITLE
Remove operational state from PUT request

### DIFF
--- a/lighty-examples/lighty-gnmi-community-restconf-app/README.md
+++ b/lighty-examples/lighty-gnmi-community-restconf-app/README.md
@@ -127,8 +127,7 @@ curl --request GET 'http://127.0.0.1:8888/restconf/data/network-topology:network
 ```
 
 ### Write configuration to device
-To write authentication information the PUT request `'Put Authentication config/state'` from postman collection can be
-used.
+To write authentication information the PUT request `'Put Authentication config'` from postman collection can be used.
 ```
 curl --request PUT 'http://127.0.0.1:8888/restconf/data/network-topology:network-topology/topology=gnmi-topology/node=gnmi-simulator/yang-ext:mount/openconfig-system:system/aaa/authentication' \
 --header 'Content-Type: application/json' \
@@ -137,11 +136,6 @@ curl --request PUT 'http://127.0.0.1:8888/restconf/data/network-topology:network
         "config": {
             "authentication-method": [
                 "openconfig-aaa-types:TACACS_ALL"
-            ]
-        },
-        "state": {
-            "authentication-method": [
-                "openconfig-aaa-types:RADIUS_ALL"
             ]
         }
     }

--- a/lighty-examples/lighty-gnmi-community-restconf-app/lighty.io gNMI-RESTCONF application.postman_collection.json
+++ b/lighty-examples/lighty-gnmi-community-restconf-app/lighty.io gNMI-RESTCONF application.postman_collection.json
@@ -270,13 +270,13 @@
       "response": []
     },
     {
-      "name": "Put Authentication config/state",
+      "name": "Put Authentication config",
       "request": {
         "method": "PUT",
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\n    \"openconfig-system:authentication\": {\n        \"config\": {\n            \"authentication-method\": [\n                \"openconfig-aaa-types:TACACS_ALL\"\n            ]\n        },\n        \"state\": {\n            \"authentication-method\": [\n                \"openconfig-aaa-types:RADIUS_ALL\"\n            ]\n        }\n    }\n}",
+          "raw": "{\n    \"openconfig-system:authentication\": {\n        \"config\": {\n            \"authentication-method\": [\n                \"openconfig-aaa-types:TACACS_ALL\"\n            ]\n        }\n    }\n}",
           "options": {
             "raw": {
               "language": "json"


### PR DESCRIPTION
Remove configuration of "state" container from GNMI example PUT requests because its marked as config false in corresponding YANG model.

We cannot modify operational data using RESTCONF.

GH issue: #2358