### PR TITLE
Do not depend on lighty-restconf-nb-community

### DIFF
--- a/lighty-examples/lighty-community-netty-restconf-app/src/main/java/io/lighty/controllers/nettyrestconfapp/Main.java
+++ b/lighty-examples/lighty-community-netty-restconf-app/src/main/java/io/lighty/controllers/nettyrestconfapp/Main.java
@@ -24,9 +24,8 @@ import io.lighty.core.controller.impl.config.ControllerConfiguration;
 import io.lighty.core.controller.impl.util.ControllerConfigUtils;
 import io.lighty.modules.northbound.netty.restconf.community.impl.NettyRestConf;
 import io.lighty.modules.northbound.netty.restconf.community.impl.NettyRestConfBuilder;
+import io.lighty.modules.northbound.netty.restconf.community.impl.config.NettyRestConfConfiguration;
 import io.lighty.modules.northbound.netty.restconf.community.impl.util.NettyRestConfUtils;
-import io.lighty.modules.northbound.restconf.community.impl.config.RestConfConfiguration;
-import io.lighty.modules.northbound.restconf.community.impl.util.RestConfConfigUtils;
 import io.lighty.modules.southbound.netconf.impl.NetconfTopologyPluginBuilder;
 import io.lighty.modules.southbound.netconf.impl.config.NetconfConfiguration;
 import io.lighty.modules.southbound.netconf.impl.util.NetconfConfigUtils;
@@ -77,7 +76,7 @@ public class Main {
         LOG.info("https://github.com/PANTHEONtech/lighty");
         try {
             final ControllerConfiguration singleNodeConfiguration;
-            final RestConfConfiguration restconfConfiguration;
+            final NettyRestConfConfiguration restconfConfiguration;
             final AAAConfiguration aaaConfiguration;
             final NetconfConfiguration netconfSBPConfiguration;
             if (args.length > 0) {
@@ -86,7 +85,8 @@ public class Main {
                 //1. get controller configuration
                 singleNodeConfiguration = ControllerConfigUtils.getConfiguration(Files.newInputStream(configPath));
                 //2. get RESTCONF NBP configuration
-                restconfConfiguration = RestConfConfigUtils.getRestConfConfiguration(Files.newInputStream(configPath));
+                restconfConfiguration = NettyRestConfUtils.getNettyRestConfConfiguration(
+                    Files.newInputStream(configPath));
                 //3. get AAA config
                 aaaConfiguration = AAAConfigUtils.getAAAConfiguration(Files.newInputStream(configPath));
                 if (!aaaConfiguration.isEnableAAA()) {
@@ -99,7 +99,7 @@ public class Main {
                     NetconfConfigUtils.createNetconfConfiguration(Files.newInputStream(configPath));
             } else {
                 LOG.info("using default configuration ...");
-                Set<YangModuleInfo> modelPaths = Stream.concat(RestConfConfigUtils.YANG_MODELS.stream(),
+                Set<YangModuleInfo> modelPaths = Stream.concat(NettyRestConfUtils.YANG_MODELS.stream(),
                     NetconfConfigUtils.NETCONF_TOPOLOGY_MODELS.stream()).collect(Collectors.toSet());
                 modelPaths.add(org.opendaylight.yang.svc.v1.urn.opendaylight.yang.aaa.cert.mdsal.rev160321
                         .YangModuleInfoImpl.getInstance());
@@ -113,7 +113,7 @@ public class Main {
                 //1. get controller configuration
                 singleNodeConfiguration = ControllerConfigUtils.getDefaultSingleNodeConfiguration(modelPaths);
                 //2. get RESTCONF NBP configuration
-                restconfConfiguration = RestConfConfigUtils.getDefaultRestConfConfiguration();
+                restconfConfiguration = NettyRestConfUtils.getDefaultNettyRestConfConfiguration();
                 //3. AAA configuration
                 aaaConfiguration = AAAConfigUtils.createDefaultAAAConfiguration();
                 //4. NETCONF SBP configuration
@@ -138,7 +138,7 @@ public class Main {
     }
 
     private void startLighty(final ControllerConfiguration controllerConfiguration,
-        final RestConfConfiguration restconfConfiguration,
+        final NettyRestConfConfiguration restconfConfiguration,
         final AAAConfiguration aaaConfiguration,
         final NetconfConfiguration netconfSBPConfiguration)
         throws ConfigurationException, ExecutionException, InterruptedException, TimeoutException,
@@ -158,7 +158,7 @@ public class Main {
                 lightyController.getServices().getRpcProviderService()));
 
         this.restconf = NettyRestConfBuilder
-            .from(RestConfConfigUtils.getRestConfConfiguration(restconfConfiguration,
+            .from(NettyRestConfUtils.getNettyRestConfConfiguration(restconfConfiguration,
                 this.lightyController.getServices()))
             .withWebEnvironment(NettyRestConfUtils.getAaaWebEnvironment(
                 lightyController.getServices().getBindingDataBroker(),

--- a/lighty-modules/lighty-restconf-netty-nb-community/pom.xml
+++ b/lighty-modules/lighty-restconf-netty-nb-community/pom.xml
@@ -26,6 +26,14 @@ and is available at http://www.eclipse.org/legal/epl-v10.html
             <artifactId>lighty-controller</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.lighty.modules</groupId>
+            <artifactId>lighty-aaa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opendaylight.netconf</groupId>
+            <artifactId>odl-device-notification</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.opendaylight.netconf</groupId>
             <artifactId>restconf-server</artifactId>
         </dependency>
@@ -34,12 +42,25 @@ and is available at http://www.eclipse.org/legal/epl-v10.html
             <artifactId>restconf-server-mdsal</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.lighty.modules</groupId>
-            <artifactId>lighty-restconf-nb-community</artifactId>
+            <groupId>org.opendaylight.netconf.model</groupId>
+            <artifactId>sal-remote</artifactId>
+        </dependency>
+
+        <!--Tests-->
+        <dependency>
+            <groupId>io.lighty.resources</groupId>
+            <artifactId>singlenode-configuration</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.lighty.modules</groupId>
-            <artifactId>lighty-aaa</artifactId>
+            <groupId>org.opendaylight.netconf</groupId>
+            <artifactId>restconf-server-api-testlib</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.opendaylight.netconf.model</groupId>
+            <artifactId>test-models</artifactId>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/lighty-modules/lighty-restconf-netty-nb-community/src/main/java/io/lighty/modules/northbound/netty/restconf/community/impl/NettyRestConfBuilder.java
+++ b/lighty-modules/lighty-restconf-netty-nb-community/src/main/java/io/lighty/modules/northbound/netty/restconf/community/impl/NettyRestConfBuilder.java
@@ -7,24 +7,24 @@
  */
 package io.lighty.modules.northbound.netty.restconf.community.impl;
 
-import io.lighty.modules.northbound.restconf.community.impl.config.RestConfConfiguration;
+import io.lighty.modules.northbound.netty.restconf.community.impl.config.NettyRestConfConfiguration;
 import org.apache.shiro.web.env.WebEnvironment;
 
 public final class NettyRestConfBuilder {
 
-    private final RestConfConfiguration restconfConfiguration;
+    private final NettyRestConfConfiguration restconfConfiguration;
     private WebEnvironment webEnvironment;
 
-    private NettyRestConfBuilder(final RestConfConfiguration configuration) {
+    private NettyRestConfBuilder(final NettyRestConfConfiguration configuration) {
         this.restconfConfiguration = configuration;
     }
 
     /**
-     * Create new instance of {@link NettyRestConfBuilder} from {@link RestConfConfiguration}.
+     * Create new instance of {@link NettyRestConfBuilder} from {@link NettyRestConfConfiguration}.
      * @param configuration input RestConf configuration.
      * @return instance of {@link NettyRestConfBuilder}.
      */
-    public static NettyRestConfBuilder from(final RestConfConfiguration configuration) {
+    public static NettyRestConfBuilder from(final NettyRestConfConfiguration configuration) {
         return new NettyRestConfBuilder(configuration);
     }
 
@@ -50,7 +50,7 @@ public final class NettyRestConfBuilder {
             restconfConfiguration.getDomNotificationService(),
             restconfConfiguration.getDomActionService(),
             restconfConfiguration.getDomMountPointService(),
-            restconfConfiguration.getDomSchemaService(),
+            restconfConfiguration.getSchemaService(),
             restconfConfiguration.getInetAddress(),
             restconfConfiguration.getHttpPort(),
             restconfConfiguration.getRestconfServletContextPath(),

--- a/lighty-modules/lighty-restconf-netty-nb-community/src/main/java/io/lighty/modules/northbound/netty/restconf/community/impl/config/NettyRestConfConfiguration.java
+++ b/lighty-modules/lighty-restconf-netty-nb-community/src/main/java/io/lighty/modules/northbound/netty/restconf/community/impl/config/NettyRestConfConfiguration.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2025 PANTHEON.tech, s.r.o. and others.  All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.lighty.modules.northbound.netty.restconf.community.impl.config;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.net.InetAddress;
+import java.util.Objects;
+import org.opendaylight.mdsal.dom.api.DOMActionService;
+import org.opendaylight.mdsal.dom.api.DOMDataBroker;
+import org.opendaylight.mdsal.dom.api.DOMMountPointService;
+import org.opendaylight.mdsal.dom.api.DOMNotificationService;
+import org.opendaylight.mdsal.dom.api.DOMRpcService;
+import org.opendaylight.mdsal.dom.api.DOMSchemaService;
+
+public class NettyRestConfConfiguration {
+
+    @JsonIgnore
+    private DOMDataBroker domDataBroker;
+    @JsonIgnore
+    private DOMSchemaService schemaService;
+    @JsonIgnore
+    private DOMRpcService domRpcService;
+    @JsonIgnore
+    private DOMActionService domActionService;
+    @JsonIgnore
+    private DOMNotificationService domNotificationService;
+    @JsonIgnore
+    private DOMMountPointService domMountPointService;
+
+    private InetAddress inetAddress = InetAddress.getLoopbackAddress();
+    private int httpPort = 8888;
+    private String restconfServletContextPath = "restconf";
+
+    public NettyRestConfConfiguration() {
+    }
+
+    public NettyRestConfConfiguration(final NettyRestConfConfiguration restConfConfiguration) {
+        this.inetAddress = restConfConfiguration.getInetAddress();
+        this.httpPort = restConfConfiguration.getHttpPort();
+        this.restconfServletContextPath = restConfConfiguration.getRestconfServletContextPath();
+        this.domDataBroker = restConfConfiguration.getDomDataBroker();
+        this.schemaService = restConfConfiguration.getSchemaService();
+        this.domRpcService = restConfConfiguration.getDomRpcService();
+        this.domActionService = restConfConfiguration.getDomActionService();
+        this.domNotificationService = restConfConfiguration.getDomNotificationService();
+        this.domMountPointService = restConfConfiguration.getDomMountPointService();
+    }
+
+    public NettyRestConfConfiguration(final DOMDataBroker domDataBroker, final DOMSchemaService schemaService,
+        final DOMRpcService domRpcService, final DOMActionService domActionService,
+        final DOMNotificationService domNotificationService, final DOMMountPointService domMountPointService) {
+        this.domDataBroker = domDataBroker;
+        this.schemaService = schemaService;
+        this.domRpcService = domRpcService;
+        this.domActionService = domActionService;
+        this.domNotificationService = domNotificationService;
+        this.domMountPointService = domMountPointService;
+    }
+
+    public InetAddress getInetAddress() {
+        return this.inetAddress;
+    }
+
+    public void setInetAddress(final InetAddress inetAddress) {
+        this.inetAddress = inetAddress;
+    }
+
+    public DOMDataBroker getDomDataBroker() {
+        return this.domDataBroker;
+    }
+
+    public void setDomDataBroker(final DOMDataBroker domDataBroker) {
+        this.domDataBroker = domDataBroker;
+    }
+
+    public DOMSchemaService getSchemaService() {
+        return this.schemaService;
+    }
+
+    public void setSchemaService(final DOMSchemaService schemaService) {
+        this.schemaService = schemaService;
+    }
+
+    public DOMRpcService getDomRpcService() {
+        return this.domRpcService;
+    }
+
+    public void setDomRpcService(final DOMRpcService domRpcService) {
+        this.domRpcService = domRpcService;
+    }
+
+    public DOMActionService getDomActionService() {
+        return this.domActionService;
+    }
+
+    public void setDomActionService(final DOMActionService domActionService) {
+        this.domActionService = domActionService;
+    }
+
+    public DOMNotificationService getDomNotificationService() {
+        return this.domNotificationService;
+    }
+
+    public void setDomNotificationService(final DOMNotificationService domNotificationService) {
+        this.domNotificationService = domNotificationService;
+    }
+
+    public DOMMountPointService getDomMountPointService() {
+        return this.domMountPointService;
+    }
+
+    public void setDomMountPointService(final DOMMountPointService domMountPointService) {
+        this.domMountPointService = domMountPointService;
+    }
+
+    public int getHttpPort() {
+        return this.httpPort;
+    }
+
+    public void setHttpPort(final int httpPort) {
+        this.httpPort = httpPort;
+    }
+
+    public String getRestconfServletContextPath() {
+        return restconfServletContextPath;
+    }
+
+    public void setRestconfServletContextPath(final String restconfServletContextPath) {
+        this.restconfServletContextPath = restconfServletContextPath.startsWith("/")
+            ? restconfServletContextPath.substring(1) : restconfServletContextPath;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        NettyRestConfConfiguration that = (NettyRestConfConfiguration) obj;
+        return httpPort == that.httpPort
+            && Objects.equals(domDataBroker, that.domDataBroker)
+            && Objects.equals(schemaService, that.schemaService)
+            && Objects.equals(domRpcService, that.domRpcService)
+            && Objects.equals(domActionService, that.domActionService)
+            && Objects.equals(domNotificationService, that.domNotificationService)
+            && Objects.equals(domMountPointService, that.domMountPointService)
+            && Objects.equals(inetAddress, that.inetAddress)
+            && Objects.equals(restconfServletContextPath, that.restconfServletContextPath);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(domDataBroker, schemaService, domRpcService, domActionService, domNotificationService,
+            domMountPointService, inetAddress, httpPort, restconfServletContextPath);
+    }
+
+}


### PR DESCRIPTION
When implementing Netty module do not depend on
lighty-restconf-nb-community which is going to be removed.

Additionally we can got further and do not depend on the whole restconf-nb in both Netty and JAXRS modules and select dependencies we need instead.

JIRA: LIGHTY-333