### PR TITLE
Close yang library writer

### DIFF
--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/LightyControllerImpl.java
@@ -372,6 +372,9 @@ public class LightyControllerImpl extends AbstractLightyModule implements Lighty
     @Override
     protected boolean stopProcedure() throws InterruptedException, ExecutionException {
         LOG.debug("Lighty Controller stopProcedure");
+        if (yangLibraryWriter != null) {
+            yangLibraryWriter.close();
+        }
         if (this.clusterSingletonServiceProvider != null) {
             this.clusterSingletonServiceProvider.close();
         }


### PR DESCRIPTION
This resource was not being closed which caused
ClusterSingletonServiceProvider to not be closed properly. This caused test failures as ClusterSingletonServiceProvider expected the yang library writer to be closed and failed to close.

JIRA: LIGHTY-340