### PR TITLE
Fix incorrect artifactId in documentation

### DIFF
--- a/lighty-examples/README.md
+++ b/lighty-examples/README.md
@@ -13,8 +13,8 @@ ODL core services represent MD-SAL layer, controller, DataStore, global schema c
 ```
 <dependencies>
    <dependency>
-      <groupId>io.lighty.core.parents</groupId>
-      <artifactId>lighty-dependency-artifacts</artifactId>
+      <groupId>io.lighty.core</groupId>
+      <artifactId>lighty-bom</artifactId>
       <version>22.1.0-SNAPSHOT</version>
       <type>pom</type>
       <scope>import</scope>


### PR DESCRIPTION
The artifact io.lighty.core.parents:lighty-dependency-artifacts mentioned in this documentation is incorrect. Based on other pom.xml files, users should import a Bill of Materials (BOM) like io.lighty.core:lighty-bom to manage dependencies.

JIRA: LIGHTY-392


(cherry picked from commit ada3bb637274d16e76caf8bc28e11b0025da0acb)