### PR TITLE
Bump to latest titanium versions

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -31,7 +31,7 @@
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
-                <version>14.1.0</version>
+                <version>14.1.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -40,49 +40,49 @@
             <dependency>
                 <groupId>org.opendaylight.aaa</groupId>
                 <artifactId>aaa-artifacts</artifactId>
-                <version>0.21.0</version>
+                <version>0.21.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.controller</groupId>
                 <artifactId>controller-artifacts</artifactId>
-                <version>11.0.0</version>
+                <version>11.0.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.infrautils</groupId>
                 <artifactId>infrautils-artifacts</artifactId>
-                <version>7.1.4</version>
+                <version>7.1.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.mdsal</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>14.0.13</version>
+                <version>14.0.18</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.netconf</groupId>
                 <artifactId>netconf-artifacts</artifactId>
-                <version>9.0.0</version>
+                <version>9.0.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yangtools-artifacts</artifactId>
-                <version>14.0.14</version>
+                <version>14.0.17</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.bgpcep</groupId>
                 <artifactId>bgpcep-artifacts</artifactId>
-                <version>0.23.0</version>
+                <version>0.23.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -49,12 +49,12 @@
             <plugin>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yang-maven-plugin</artifactId>
-                <version>14.0.14</version>
+                <version>14.0.17</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.opendaylight.yangtools</groupId>
                         <artifactId>binding-codegen</artifactId>
-                        <version>14.0.14</version>
+                        <version>14.0.17</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -202,7 +202,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>14.1.0</version>
+                            <version>14.1.3</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -219,7 +219,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>spotbugs</artifactId>
-                            <version>14.1.0</version>
+                            <version>14.1.3</version>
                         </dependency>
                         <!-- The SpotBugs Maven plugin uses SLF4J-2 -->
                         <dependency>


### PR DESCRIPTION
Adopt:
- odlparent-14.1.3
- infrautils-7.1.7
- yangtools-14.0.17
- mdsal-14.0.18
- controller-11.0.2
- aaa-0.21.2
- netconf-9.0.1
- bgpcep-0.23.1

JIRA: LIGHTY-391

(cherry picked from commit 9a7be54a08cae2a5dd4922aa5a0e38f8840bc711)