### PR TITLE
Revert "Remove redundant publish-action step"

### DIFF
--- a/.github/workflows/publish-action/action.yml
+++ b/.github/workflows/publish-action/action.yml
@@ -26,16 +26,27 @@ inputs:
     required: true
 runs:
   using: "composite"
-  env:
-    APP_MODULES: ${{ inputs.app-modules }}
-    APP_DOCKER_POM_PATH: ${{ inputs.app-docker-pom-path }}
-    APP_HELM_VALUES_PATH: ${{ inputs.app-helm-values-path }}
-    DOCKER_IMAGE_NAME: ghcr.io/pantheontech/${{ inputs.image-name }}
-    DOCKER_IMAGE_VERSION: ${{ inputs.version }}\
-    DOCKER_IMAGE_TAG_LATEST: ${{ inputs.image-tag-latest }}
-    PUBLISH_ACCESS_KEY: ${{ inputs.publish-access-key }}
-    DOCKER_IMAGE_NAME_TAG: $DOCKER_IMAGE_NAME:${{ inputs.version }}
   steps:
+    - name: Env docker image name
+      env:
+        APP_MODULES: ${{ inputs.app-modules }}
+        APP_DOCKER_POM_PATH: ${{ inputs.app-docker-pom-path }}
+        APP_HELM_VALUES_PATH: ${{ inputs.app-helm-values-path }}
+        DOCKER_IMAGE_NAME: ghcr.io/pantheontech/${{ inputs.image-name }}
+        DOCKER_IMAGE_VERSION: ${{ inputs.version }}\
+        DOCKER_IMAGE_TAG_LATEST: ${{ inputs.image-tag-latest }}
+        PUBLISH_ACCESS_KEY: ${{ inputs.publish-access-key }}
+        DOCKER_IMAGE_NAME_TAG: $DOCKER_IMAGE_NAME:${{ inputs.version }}
+      shell: bash
+      run: |
+        echo "APP_MODULES=$(echo $APP_MODULES)" >> $GITHUB_ENV
+        echo "APP_DOCKER_POM_PATH=$(echo $APP_DOCKER_POM_PATH)" >> $GITHUB_ENV
+        echo "APP_HELM_VALUES_PATH=$(echo $APP_HELM_VALUES_PATH)" >> $GITHUB_ENV      
+        echo "DOCKER_IMAGE_NAME=$(echo $DOCKER_IMAGE_NAME)" >> $GITHUB_ENV
+        echo "DOCKER_IMAGE_VERSION=$(echo $DOCKER_IMAGE_VERSION)" >> $GITHUB_ENV
+        echo "DOCKER_IMAGE_TAG_LATEST=$(echo $DOCKER_IMAGE_TAG_LATEST)" >> $GITHUB_ENV
+        echo "PUBLISH_ACCESS_KEY=$(echo PUBLISH_ACCESS_KEY)" >> $GITHUB_ENV
+        echo "DOCKER_IMAGE_NAME_TAG=$(echo $DOCKER_IMAGE_NAME_TAG)" >> $GITHUB_ENV
     - name: Build docker image
       shell: bash
       run: mvn install -B -pl $APP_MODULES -P docker


### PR DESCRIPTION
This reverts commit 420cb8b3bc1963538b9c5fa6dc07d44a0423162f.

reason to revert: This syntax is not valid for a composite action.


(cherry picked from commit 542a4880ad792ec80a4d98c080ce2f01a6652c12)