### PR TITLE
Use publish-action versioned in main branch

### DIFF
--- a/.github/workflows/publish-rnc.yml
+++ b/.github/workflows/publish-rnc.yml
@@ -53,7 +53,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: "Publish RNC docker and prepare helm-charts"
-        uses: ./.github/workflows/publish-action
+        uses: PANTHEONtech/lighty/.github/workflows/publish-action@main
         with:
           app-modules: ${{ env.APP-MODULES }}
           app-docker-pom-path: ${{ env.APP-DOCKER-POM-PATH }}


### PR DESCRIPTION
Temporally fix to use publish-action code from main repository because tagged version are using broken one.