### PR TITLE
Bump jcasbin to 1.84.0

### DIFF
--- a/lighty-examples/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/lighty-controller-springboot-netconf/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.casbin</groupId>
             <artifactId>jcasbin</artifactId>
-            <version>1.82.0</version>
+            <version>1.84.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Bump jcasbin from 1.82.0 to 1.84.0

JIRA: LIGHTY-365

(cherry picked from commit 90ded01ccbde1616edafb2744229a921663808c4)