### PR TITLE
Use default number of Netty threads

### DIFF
--- a/lighty-modules/lighty-restconf-netty-nb-community/src/main/java/io/lighty/modules/northbound/netty/restconf/community/impl/NettyRestConf.java
+++ b/lighty-modules/lighty-restconf-netty-nb-community/src/main/java/io/lighty/modules/northbound/netty/restconf/community/impl/NettyRestConf.java
@@ -88,16 +88,13 @@ public class NettyRestConf extends AbstractLightyModule {
 
         final PrincipalService service = new AAAShiroPrincipalService((AAAShiroWebEnvironment) webEnvironment);
         final var serverStackGrouping = new HttpServerStackConfiguration(new TcpBuilder().setTcp(tcpConfig).build());
-        final BootstrapFactory factory = new BootstrapFactory("lighty-restconf-nb-worker", 1);
         final NettyEndpointConfiguration configuration = new NettyEndpointConfiguration(ErrorTagMapping.RFC8040,
             PrettyPrintParam.FALSE, Uint16.valueOf(0), Uint32.valueOf(10000), restconfServletContextPath,
             MessageEncoding.JSON, serverStackGrouping);
         this.mdsalRestconfStreamRegistry = new MdsalRestconfStreamRegistry(domDataBroker, domNotificationService,
             domSchemaService, new JaxRsLocationProvider(), databindProvider);
-
-        nettyEndpoint =
-            new SimpleNettyEndpoint(server, service, mdsalRestconfStreamRegistry, factory,
-            configuration);
+        nettyEndpoint = new SimpleNettyEndpoint(server, service, mdsalRestconfStreamRegistry,
+            new BootstrapFactory("lighty-restconf-nb-worker", 0), configuration);
 
         return true;
     }


### PR DESCRIPTION
Do not throttle Netty based RESTCONF by using 1 thread.

Instead use 0 to allow Netty to use its well performing defaults tailored for different number of CPU cores available.

JIRA: LIGHTY-395