### PR TITLE
Update lighty-bgp example postman collection

### DIFF
--- a/lighty-examples/lighty-bgp-community-restconf-app/LIGHTY-BGP.postman_collection.json
+++ b/lighty-examples/lighty-bgp-community-restconf-app/LIGHTY-BGP.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "a109e81e-8940-4d7d-aef3-0aa459b04907",
+		"_postman_id": "903dacee-5543-4b97-b5c6-9fb50722dcce",
 		"name": "LIGHTY-BGP",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -31,11 +31,14 @@
 							"raw": "<topology xmlns=\"urn:TBD:params:xml:ns:yang:network-topology\">\n    <topology-id>bgp-example-ipv4-topology</topology-id>\n    <topology-types>\n        <bgp-ipv4-reachability-topology xmlns=\"urn:opendaylight:params:xml:ns:yang:odl-bgp-topology-types\"></bgp-ipv4-reachability-topology>\n    </topology-types>\n    <rib-id xmlns=\"urn:opendaylight:params:xml:ns:yang:odl-bgp-topology-config\">bgp-example</rib-id>\n</topology>"
 						},
 						"url": {
-							"raw": "{{lighty-host}}restconf/data/network-topology:network-topology",
+							"raw": "http://{{lighty-host}}:{{lighty-port}}/restconf/data/network-topology:network-topology",
+							"protocol": "http",
 							"host": [
-								"{{lighty-host}}restconf"
+								"{{lighty-host}}"
 							],
+							"port": "{{lighty-port}}",
 							"path": [
+								"restconf",
 								"data",
 								"network-topology:network-topology"
 							]
@@ -66,18 +69,19 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "<topology xmlns=\"urn:TBD:params:xml:ns:yang:network-topology\">\n    <topology-id>bgp-example-ipv4-topology</topology-id>\n    <topology-types>\n        <bgp-ipv4-reachability-topology xmlns=\"urn:opendaylight:params:xml:ns:yang:odl-bgp-topology-types\"></bgp-ipv4-reachability-topology>\n    </topology-types>\n    <rib-id xmlns=\"urn:opendaylight:params:xml:ns:yang:odl-bgp-topology-config\">bgp-example</rib-id>\n</topology>"
+							"raw": ""
 						},
 						"url": {
-							"raw": "{{lighty-host}}/restconf/data/network-topology:network-topology/topology=bgp-example-ipv4-topology",
+							"raw": "http://{{lighty-host}}:{{lighty-port}}/restconf/data/network-topology:network-topology",
+							"protocol": "http",
 							"host": [
 								"{{lighty-host}}"
 							],
+							"port": "{{lighty-port}}",
 							"path": [
 								"restconf",
 								"data",
-								"network-topology:network-topology",
-								"topology=bgp-example-ipv4-topology"
+								"network-topology:network-topology"
 							]
 						}
 					},
@@ -110,7 +114,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "<protocol xmlns=\"http://openconfig.net/yang/network-instance\">\n    <name>bgp-example</name>\n    <identifier xmlns:x=\"http://openconfig.net/yang/policy-types\">x:BGP</identifier>\n    <bgp xmlns=\"urn:opendaylight:params:xml:ns:yang:bgp:openconfig-extensions\">\n        <global>\n            <config>\n                <router-id>10.0.0.51</router-id>\n                <as>64496</as>\n            </config>\n            <apply-policy>\n                <config>\n                   <default-export-policy>REJECT-ROUTE</default-export-policy>\n                   <default-import-policy>REJECT-ROUTE</default-import-policy>\n                   <import-policy>default-odl-import-policy</import-policy>\n                   <export-policy>default-odl-export-policy</export-policy>\n                </config>\n            </apply-policy>\n                            <afi-safis>\n                    <afi-safi>\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV4-UNICAST</afi-safi-name>\n                    </afi-safi>\n                    <afi-safi>\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV6-UNICAST</afi-safi-name>\n                    </afi-safi>\n                    <afi-safi>\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV4-LABELLED-UNICAST</afi-safi-name>\n                    </afi-safi>\n                    <afi-safi>\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV6-LABELLED-UNICAST</afi-safi-name>\n                    </afi-safi>\n                    <afi-safi>\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L3VPN-IPV4-UNICAST</afi-safi-name>\n                    </afi-safi>\n                    <afi-safi>\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L3VPN-IPV6-UNICAST</afi-safi-name>\n                    </afi-safi>\n                    <afi-safi>\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L3VPN-IPV4-MULTICAST</afi-safi-name>\n                    </afi-safi>\n                    <afi-safi>\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L3VPN-IPV6-MULTICAST</afi-safi-name>\n                    </afi-safi>\n                    <afi-safi>\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L2VPN-EVPN</afi-safi-name>\n                    </afi-safi>\n                    <afi-safi>\n                        <afi-safi-name>LINKSTATE</afi-safi-name>\n                    </afi-safi>\n                    <afi-safi>\n                        <afi-safi-name>IPV4-FLOW</afi-safi-name>\n                    </afi-safi>\n                    <afi-safi>\n                        <afi-safi-name>IPV6-FLOW</afi-safi-name>\n                    </afi-safi>\n                    <afi-safi>\n                        <afi-safi-name>IPV4-L3VPN-FLOW</afi-safi-name>\n                    </afi-safi>\n                    <afi-safi>\n                        <afi-safi-name>IPV6-L3VPN-FLOW</afi-safi-name>\n                    </afi-safi>\n                    <afi-safi>\n                        <afi-safi-name>IPV4-MCAST-VPN</afi-safi-name>\n                    </afi-safi>\n                    <afi-safi>\n                        <afi-safi-name>IPV6-MCAST-VPN</afi-safi-name>\n                    </afi-safi>\n                    <afi-safi>\n                        <afi-safi-name>ROUTE-TARGET-CONSTRAIN</afi-safi-name>\n                    </afi-safi>\n                </afi-safis>\n        </global>\n    </bgp>\n</protocol>",
+							"raw": "<protocol xmlns=\"http://openconfig.net/yang/network-instance\">\n    <name>bgp-example</name>\n    <identifier xmlns:x=\"http://openconfig.net/yang/policy-types\">x:BGP</identifier>\n    <bgp xmlns=\"urn:opendaylight:params:xml:ns:yang:bgp:openconfig-extensions\">\n        <global>\n            <config>\n                <router-id>{{lighty-host}}</router-id>\n                <as>64496</as>\n            </config>\n            <apply-policy>\n                <config>\n                    <default-export-policy>REJECT-ROUTE</default-export-policy>\n                    <default-import-policy>REJECT-ROUTE</default-import-policy>\n                    <import-policy>default-odl-import-policy</import-policy>\n                    <export-policy>default-odl-export-policy</export-policy>\n                </config>\n            </apply-policy>\n        </global>\n    </bgp>\n</protocol>",
 							"options": {
 								"raw": {
 									"language": "xml"
@@ -118,10 +122,12 @@
 							}
 						},
 						"url": {
-							"raw": "{{lighty-host}}/restconf/data/openconfig-network-instance:network-instances/network-instance=global-bgp/openconfig-network-instance:protocols",
+							"raw": "http://{{lighty-host}}:{{lighty-port}}/restconf/data/openconfig-network-instance:network-instances/network-instance=global-bgp/openconfig-network-instance:protocols",
+							"protocol": "http",
 							"host": [
 								"{{lighty-host}}"
 							],
+							"port": "{{lighty-port}}",
 							"path": [
 								"restconf",
 								"data",
@@ -158,7 +164,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "<protocol xmlns=\"http://openconfig.net/yang/network-instance\">\n    <name>bgp-example</name>\n    <identifier xmlns:x=\"http://openconfig.net/yang/policy-types\">x:BGP</identifier>\n    <bgp xmlns=\"urn:opendaylight:params:xml:ns:yang:bgp:openconfig-extensions\">\n        <global>\n            <config>\n                <router-id>10.0.0.51</router-id>\n                <as>64496</as>\n            </config>\n            <apply-policy>\n                <config>\n                   <default-export-policy>REJECT-ROUTE</default-export-policy>\n                   <default-import-policy>REJECT-ROUTE</default-import-policy>\n                   <import-policy>default-odl-import-policy</import-policy>\n                   <export-policy>default-odl-export-policy</export-policy>\n                </config>\n            </apply-policy>\n        </global>\n    </bgp>\n</protocol>",
+							"raw": "",
 							"options": {
 								"raw": {
 									"language": "xml"
@@ -166,10 +172,12 @@
 							}
 						},
 						"url": {
-							"raw": "{{lighty-host}}/restconf/data/bgp-rib:bgp-rib",
+							"raw": "http://{{lighty-host}}:{{lighty-port}}/restconf/data/bgp-rib:bgp-rib",
+							"protocol": "http",
 							"host": [
 								"{{lighty-host}}"
 							],
+							"port": "{{lighty-port}}",
 							"path": [
 								"restconf",
 								"data",
@@ -206,7 +214,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "<peer-group xmlns=\"urn:opendaylight:params:xml:ns:yang:bgp:openconfig-extensions\">\n    <peer-group-name>external-neighbor</peer-group-name>\n    <config>\n        <peer-type>EXTERNAL</peer-type>\n        <peer-as>64496</peer-as>\n    </config>\n    <transport>\n        <config>\n            <remote-port>179</remote-port>\n        </config>\n    </transport>\n    <graceful-restart>\n        <config>\n            <restart-time>60</restart-time>\n        </config>\n    </graceful-restart>\n    <afi-safis>\n        <afi-safi>\n            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV4-UNICAST</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV6-UNICAST</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV4-LABELLED-UNICAST</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV6-LABELLED-UNICAST</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L3VPN-IPV4-UNICAST</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L3VPN-IPV6-UNICAST</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L3VPN-IPV4-MULTICAST</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L3VPN-IPV6-MULTICAST</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L2VPN-EVPN</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name>LINKSTATE</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name>IPV6-FLOW</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name>IPV4-L3VPN-FLOW</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name>IPV6-L3VPN-FLOW</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name>IPV4-MCAST-VPN</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name>IPV6-MCAST-VPN</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name>ROUTE-TARGET-CONSTRAIN</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n    </afi-safis>\n</peer-group>",
+							"raw": "<peer-group xmlns=\"urn:opendaylight:params:xml:ns:yang:bgp:openconfig-extensions\">\n    <peer-group-name>external-neighbor</peer-group-name>\n    <config>\n        <peer-type>EXTERNAL</peer-type>\n        <peer-as>64496</peer-as>\n    </config>\n    <transport>\n        <config>\n            <remote-port>17900</remote-port>\n        </config>\n    </transport>\n    <graceful-restart>\n        <config>\n            <restart-time>60</restart-time>\n        </config>\n    </graceful-restart>\n    <afi-safis>\n        <afi-safi>\n            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV4-UNICAST</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV6-UNICAST</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV4-LABELLED-UNICAST</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV6-LABELLED-UNICAST</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L3VPN-IPV4-UNICAST</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L3VPN-IPV6-UNICAST</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L3VPN-IPV4-MULTICAST</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L3VPN-IPV6-MULTICAST</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L2VPN-EVPN</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name>LINKSTATE</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name>IPV6-FLOW</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name>IPV4-L3VPN-FLOW</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name>IPV6-L3VPN-FLOW</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name>IPV4-MCAST-VPN</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name>IPV6-MCAST-VPN</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n        <afi-safi>\n            <afi-safi-name>ROUTE-TARGET-CONSTRAIN</afi-safi-name>\n            <graceful-restart>\n                <config>\n                    <enabled>true</enabled>\n                </config>\n            </graceful-restart>\n        </afi-safi>\n    </afi-safis>\n</peer-group>",
 							"options": {
 								"raw": {
 									"language": "xml"
@@ -214,10 +222,12 @@
 							}
 						},
 						"url": {
-							"raw": "{{lighty-host}}/restconf/data/openconfig-network-instance:network-instances/network-instance=global-bgp/openconfig-network-instance:protocols/protocol=openconfig-policy-types%3ABGP,bgp-example/bgp-openconfig-extensions:bgp/peer-groups",
+							"raw": "http://{{lighty-host}}:{{lighty-port}}/restconf/data/openconfig-network-instance:network-instances/network-instance=global-bgp/openconfig-network-instance:protocols/protocol=openconfig-policy-types%3ABGP,bgp-example/bgp-openconfig-extensions:bgp/peer-groups",
+							"protocol": "http",
 							"host": [
 								"{{lighty-host}}"
 							],
+							"port": "{{lighty-port}}",
 							"path": [
 								"restconf",
 								"data",
@@ -234,9 +244,6 @@
 				},
 				{
 					"name": "Connect peer",
-					"protocolProfileBehavior": {
-						"disableBodyPruning": true
-					},
 					"request": {
 						"auth": {
 							"type": "basic",
@@ -253,11 +260,11 @@
 								}
 							]
 						},
-						"method": "GET",
+						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "<neighbor xmlns=\"urn:opendaylight:params:xml:ns:yang:bgp:openconfig-extensions\">\n    <neighbor-address>10.0.0.52</neighbor-address>\n    <config>\n        <peer-group>/bgp/neighbors/neighbor/bgp/peer-groups/peer-group[peer-group-name=\"external-neighbor\"]</peer-group>\n    </config>\n</neighbor>",
+							"raw": "<neighbor xmlns=\"urn:opendaylight:params:xml:ns:yang:bgp:openconfig-extensions\">\n    <neighbor-address>127.0.0.2</neighbor-address>\n    <config>\n        <peer-group>/bgp/neighbors/neighbor/bgp/peer-groups/peer-group[peer-group-name=\"external-neighbor\"]</peer-group>\n    </config>\n</neighbor>",
 							"options": {
 								"raw": {
 									"language": "xml"
@@ -265,10 +272,12 @@
 							}
 						},
 						"url": {
-							"raw": "{{lighty-host}}/restconf/data/openconfig-network-instance:network-instances/network-instance=global-bgp/openconfig-network-instance:protocols/protocol=openconfig-policy-types%3ABGP,bgp-example/bgp-openconfig-extensions:bgp/neighbors",
+							"raw": "http://{{lighty-host}}:{{lighty-port}}/restconf/data/openconfig-network-instance:network-instances/network-instance=global-bgp/openconfig-network-instance:protocols/protocol=openconfig-policy-types%3ABGP,bgp-example/bgp-openconfig-extensions:bgp/neighbors",
+							"protocol": "http",
 							"host": [
 								"{{lighty-host}}"
 							],
+							"port": "{{lighty-port}}",
 							"path": [
 								"restconf",
 								"data",
@@ -315,13 +324,15 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "<protocols xmlns=\"http://openconfig.net/yang/network-instance\">\r\n    <protocol>\r\n        <name>bgp-peer</name>\r\n        <identifier xmlns:x=\"http://openconfig.net/yang/policy-types\">x:BGP</identifier>\r\n        <bgp xmlns=\"urn:opendaylight:params:xml:ns:yang:bgp:openconfig-extensions\">\r\n            <global>\r\n                <config>\r\n                    <!-- configure BGP-AS and router-id for bgp-rr node (lighty-bgp) -->\r\n                    <router-id>172.18.0.3</router-id>\r\n                    <as>65100</as>\r\n                </config>\r\n                <apply-policy>\r\n                    <config>\r\n                        <!-- policies applied for routing information import and export, in this example we want all routes to be accepted -->\r\n                        <default-export-policy>ACCEPT-ROUTE</default-export-policy>\r\n                        <default-import-policy>ACCEPT-ROUTE</default-import-policy>\r\n                        <import-policy>default-odl-import-policy</import-policy>\r\n                        <export-policy>default-odl-export-policy</export-policy>\r\n                    </config>\r\n                </apply-policy>\r\n                <afi-safis>\r\n                    <!-- enable accepting address families, in this case all possible -->\r\n                    <afi-safi>\r\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV4-UNICAST</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV6-UNICAST</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV4-LABELLED-UNICAST</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV6-LABELLED-UNICAST</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L3VPN-IPV4-UNICAST</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L3VPN-IPV6-UNICAST</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L3VPN-IPV4-MULTICAST</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L3VPN-IPV6-MULTICAST</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L2VPN-EVPN</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name>LINKSTATE</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name>IPV4-FLOW</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name>IPV6-FLOW</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name>IPV4-L3VPN-FLOW</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name>IPV6-L3VPN-FLOW</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name>IPV4-MCAST-VPN</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name>IPV6-MCAST-VPN</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name>ROUTE-TARGET-CONSTRAIN</afi-safi-name>\r\n                    </afi-safi>\r\n                </afi-safis>\r\n            </global>\r\n            <neighbors>\r\n                <neighbor>\r\n                    <!-- ip address of the neighbor (CEOS3) -->\r\n                    <neighbor-address>172.18.0.4</neighbor-address>\r\n                    <config>\r\n        \t\t\t\t<peer-type>INTERNAL</peer-type>\r\n        \t\t\t\t<peer-as>65100</peer-as>\r\n    \t\t\t\t</config>\r\n                    <!-- define BGP peering under AFI IPv4 and L2VPN SAFI EVPN -->\r\n                    <afi-safis>\r\n                    \t<afi-safi>\r\n                            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV4-UNICAST</afi-safi-name>\r\n                        </afi-safi>\r\n                    \t<afi-safi>\r\n                            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L2VPN-EVPN</afi-safi-name>\r\n                        </afi-safi>\r\n                    </afi-safis>\r\n                    <!-- define BGP hold-time timer -->\r\n                    <timers>\r\n                        <config>\r\n                            <hold-time>180</hold-time>\r\n                            <connect-retry>5</connect-retry>\r\n                        </config>\r\n                    </timers>\r\n                    <!-- define TCP transport capabilities -->\r\n                    <transport>\r\n                        <config>\r\n                            <remote-port>179</remote-port>\r\n                            <passive-mode>true</passive-mode>\r\n                            <local-address>172.18.0.4</local-address>\r\n                        </config>\r\n                    </transport>\r\n                </neighbor>\r\n            </neighbors>\r\n        </bgp>\r\n    </protocol>\r\n</protocols>"
+							"raw": ""
 						},
 						"url": {
-							"raw": "{{lighty-host}}/restconf/data/openconfig-network-instance:network-instances/network-instance=global-bgp/openconfig-network-instance:protocols/protocol=openconfig-policy-types%3ABGP,bgp-example/bgp-openconfig-extensions:bgp/neighbors/neighbor=10.0.0.52/state",
+							"raw": "http://{{lighty-host}}:{{lighty-port}}/restconf/data/openconfig-network-instance:network-instances/network-instance=global-bgp/openconfig-network-instance:protocols/protocol=openconfig-policy-types%3ABGP,bgp-example/bgp-openconfig-extensions:bgp/neighbors/neighbor=127.0.0.2/state",
+							"protocol": "http",
 							"host": [
 								"{{lighty-host}}"
 							],
+							"port": "{{lighty-port}}",
 							"path": [
 								"restconf",
 								"data",
@@ -331,8 +342,58 @@
 								"protocol=openconfig-policy-types%3ABGP,bgp-example",
 								"bgp-openconfig-extensions:bgp",
 								"neighbors",
-								"neighbor=10.0.0.52",
+								"neighbor=127.0.0.2",
 								"state"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Connect multiple peers",
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "<neighbors xmlns=\"urn:opendaylight:params:xml:ns:yang:bgp:openconfig-extensions\">\n    <neighbor>\n        <neighbor-address>127.0.0.2</neighbor-address>\n        <config>\n            <peer-group>/bgp/neighbors/neighbor/bgp/peer-groups/peer-group[peer-group-name=\"external-neighbor\"]</peer-group>\n        </config>\n    </neighbor>\n    <neighbor>\n        <neighbor-address>127.0.0.3</neighbor-address>\n        <config>\n            <peer-group>/bgp/neighbors/neighbor/bgp/peer-groups/peer-group[peer-group-name=\"external-neighbor\"]</peer-group>\n        </config>\n    </neighbor>\n    <neighbor>\n        <neighbor-address>127.0.0.4</neighbor-address>\n        <config>\n            <peer-group>/bgp/neighbors/neighbor/bgp/peer-groups/peer-group[peer-group-name=\"external-neighbor\"]</peer-group>\n        </config>\n    </neighbor>\n    <neighbor>\n        <neighbor-address>127.0.0.5</neighbor-address>\n        <config>\n            <peer-group>/bgp/neighbors/neighbor/bgp/peer-groups/peer-group[peer-group-name=\"external-neighbor\"]</peer-group>\n        </config>\n    </neighbor>\n        <neighbor>\n        <neighbor-address>127.0.0.6</neighbor-address>\n        <config>\n            <peer-group>/bgp/neighbors/neighbor/bgp/peer-groups/peer-group[peer-group-name=\"external-neighbor\"]</peer-group>\n        </config>\n    </neighbor>\n</neighbors>",
+							"options": {
+								"raw": {
+									"language": "xml"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://{{lighty-host}}:{{lighty-port}}/restconf/data/openconfig-network-instance:network-instances/network-instance=global-bgp/openconfig-network-instance:protocols/protocol=openconfig-policy-types%3ABGP,bgp-example/bgp-openconfig-extensions:bgp/neighbors",
+							"protocol": "http",
+							"host": [
+								"{{lighty-host}}"
+							],
+							"port": "{{lighty-port}}",
+							"path": [
+								"restconf",
+								"data",
+								"openconfig-network-instance:network-instances",
+								"network-instance=global-bgp",
+								"openconfig-network-instance:protocols",
+								"protocol=openconfig-policy-types%3ABGP,bgp-example",
+								"bgp-openconfig-extensions:bgp",
+								"neighbors"
 							]
 						}
 					},
@@ -372,13 +433,15 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "<protocols xmlns=\"http://openconfig.net/yang/network-instance\">\r\n    <protocol>\r\n        <name>bgp-peer</name>\r\n        <identifier xmlns:x=\"http://openconfig.net/yang/policy-types\">x:BGP</identifier>\r\n        <bgp xmlns=\"urn:opendaylight:params:xml:ns:yang:bgp:openconfig-extensions\">\r\n            <global>\r\n                <config>\r\n                    <!-- configure BGP-AS and router-id for bgp-rr node (lighty-bgp) -->\r\n                    <router-id>172.18.0.3</router-id>\r\n                    <as>65100</as>\r\n                </config>\r\n                <apply-policy>\r\n                    <config>\r\n                        <!-- policies applied for routing information import and export, in this example we want all routes to be accepted -->\r\n                        <default-export-policy>ACCEPT-ROUTE</default-export-policy>\r\n                        <default-import-policy>ACCEPT-ROUTE</default-import-policy>\r\n                        <import-policy>default-odl-import-policy</import-policy>\r\n                        <export-policy>default-odl-export-policy</export-policy>\r\n                    </config>\r\n                </apply-policy>\r\n                <afi-safis>\r\n                    <!-- enable accepting address families, in this case all possible -->\r\n                    <afi-safi>\r\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV4-UNICAST</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV6-UNICAST</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV4-LABELLED-UNICAST</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV6-LABELLED-UNICAST</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L3VPN-IPV4-UNICAST</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L3VPN-IPV6-UNICAST</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L3VPN-IPV4-MULTICAST</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L3VPN-IPV6-MULTICAST</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L2VPN-EVPN</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name>LINKSTATE</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name>IPV4-FLOW</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name>IPV6-FLOW</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name>IPV4-L3VPN-FLOW</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name>IPV6-L3VPN-FLOW</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name>IPV4-MCAST-VPN</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name>IPV6-MCAST-VPN</afi-safi-name>\r\n                    </afi-safi>\r\n                    <afi-safi>\r\n                        <afi-safi-name>ROUTE-TARGET-CONSTRAIN</afi-safi-name>\r\n                    </afi-safi>\r\n                </afi-safis>\r\n            </global>\r\n            <neighbors>\r\n                <neighbor>\r\n                    <!-- ip address of the neighbor (CEOS3) -->\r\n                    <neighbor-address>172.18.0.4</neighbor-address>\r\n                    <config>\r\n        \t\t\t\t<peer-type>INTERNAL</peer-type>\r\n        \t\t\t\t<peer-as>65100</peer-as>\r\n    \t\t\t\t</config>\r\n                    <!-- define BGP peering under AFI IPv4 and L2VPN SAFI EVPN -->\r\n                    <afi-safis>\r\n                    \t<afi-safi>\r\n                            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:IPV4-UNICAST</afi-safi-name>\r\n                        </afi-safi>\r\n                    \t<afi-safi>\r\n                            <afi-safi-name xmlns:x=\"http://openconfig.net/yang/bgp-types\">x:L2VPN-EVPN</afi-safi-name>\r\n                        </afi-safi>\r\n                    </afi-safis>\r\n                    <!-- define BGP hold-time timer -->\r\n                    <timers>\r\n                        <config>\r\n                            <hold-time>180</hold-time>\r\n                            <connect-retry>5</connect-retry>\r\n                        </config>\r\n                    </timers>\r\n                    <!-- define TCP transport capabilities -->\r\n                    <transport>\r\n                        <config>\r\n                            <remote-port>179</remote-port>\r\n                            <passive-mode>true</passive-mode>\r\n                            <local-address>172.18.0.4</local-address>\r\n                        </config>\r\n                    </transport>\r\n                </neighbor>\r\n            </neighbors>\r\n        </bgp>\r\n    </protocol>\r\n</protocols>"
+					"raw": ""
 				},
 				"url": {
-					"raw": "{{lighty-host}}/restconf/data/openconfig-routing-policy:routing-policy/policy-definitions",
+					"raw": "http://{{lighty-host}}:{{lighty-port}}/restconf/data/openconfig-routing-policy:routing-policy/policy-definitions",
+					"protocol": "http",
 					"host": [
 						"{{lighty-host}}"
 					],
+					"port": "{{lighty-port}}",
 					"path": [
 						"restconf",
 						"data",
@@ -413,7 +476,13 @@
 	"variable": [
 		{
 			"key": "lighty-host",
-			"value": "http://127.0.0.1:8888"
+			"value": "127.0.0.1",
+			"type": "default"
+		},
+		{
+			"key": "lighty-port",
+			"value": "8888",
+			"type": "default"
 		}
 	]
 }


### PR DESCRIPTION
- Fix the "router-id" to localhost, based on the request URL
  where lighty is running.
- Remove unnecessary GET request body.
- Fix "Connect peer" to POST type.
- Add "Connect multiple peers" PUT request to demonstrate adding
  multiple BGP peers at once
- Remove redundant <afi-safi> configuration from "Create BGP protocol
  instance" based on the ODL BGP [Protocol Configuration](https://docs.opendaylight.org/projects/bgpcep/en/latest/bgp/bgp-user-guide-protocol-configuration.html) documentation.