### PR TITLE
Bump Jakarta Activation to 2.1.4

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -93,7 +93,7 @@
             <dependency>
                 <groupId>jakarta.activation</groupId>
                 <artifactId>jakarta.activation-api</artifactId>
-                <version>2.1.3</version>
+                <version>2.1.4</version>
             </dependency>
             <dependency>
                 <groupId>com.google.inject</groupId>


### PR DESCRIPTION
https://github.com/jakartaee/jaf-api/releases/tag/2.1.4

JIRA: LIGHTY-394