### PR TITLE
Bump docker-maven-plugin to 0.48.0

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/pom.xml
@@ -92,7 +92,7 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.45.1</version>
+                <version>0.48.0</version>
                 <configuration>
                     <images>
                         <image>

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
@@ -91,7 +91,7 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.45.1</version>
+                <version>0.48.0</version>
                 <configuration>
                     <images>
                         <image>


### PR DESCRIPTION
https://github.com/fabric8io/docker-maven-plugin/releases/tag/v0.46.0 
https://github.com/fabric8io/docker-maven-plugin/releases/tag/v0.47.0 
https://github.com/fabric8io/docker-maven-plugin/releases/tag/v0.48.0

JIRA: LIGHTY-394