### PR TITLE
Set correct lighty.io Vanadium version 23

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lighty.io 22
+# lighty.io 23
 __lighty.io__ is a Software Development Kit powered by [OpenDaylight](https://www.opendaylight.org/) to support, ease & accelerate the development of
 Software-Defined Networking (SDN) solutions in Java. Developed by [PANTHEON.tech](https://pantheon.tech).
 


### PR DESCRIPTION
Change lighty.io version from 22 to 23 in README file.

JIRA: LIGHTY-394