### PR TITLE
Add persistence files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,11 @@ dist
 *.iws
 *.log
 
+# Auto-generated persistence files.
 persistence
 
 datastore-config.properties
 datastore-operational.properties
+
+**/incarnation-v1
+**/TermInfo.properties


### PR DESCRIPTION
Building lighty with tests produces incarnation-v1 and TermInfo.properties files, which are currently not ignored by Git.

Add these files to the .gitignore list.

JIRA: LIGHTY-404