### PR TITLE
Fix lighty.io development version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lighty.io 22
+# lighty.io 23
 __lighty.io__ is a Software Development Kit powered by [OpenDaylight](https://www.opendaylight.org/) to support, ease & accelerate the development of
 Software-Defined Networking (SDN) solutions in Java. Developed by [PANTHEON.tech](https://pantheon.tech).
 


### PR DESCRIPTION
We are developing lighty.io 23 compatible with ODL Vanadium. Fix future lighty version in README.


(cherry picked from commit 96f346daccf362c2c92aa316c52f7f5ef72542b7)