### PR TITLE
Set correct version 2.7.0 for license-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>license-maven-plugin</artifactId>
-                        <version>5.0.0</version>
+                        <version>2.7.0</version>
                         <executions>
                             <execution>
                                 <id>analyze-license</id>


### PR DESCRIPTION
https://github.com/mojohaus/license-maven-plugin/releases/tag/2.7.0

Calling get-all-licenses profile (mvn validate -P get-all-licenses) now failing with:
Could not find artifact org.codehaus.mojo:license-maven-plugin:jar:5.0.0

Set correct latest version.

JIRA: LIGHTY-394

(cherry picked from commit 7b7c9ccc1245ce4c4922ea17b339c302a9345cd0)