### PR TITLE
Bump protobuf-java to 3.33.1

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
@@ -25,7 +25,7 @@
     <url>https://github.com/PANTHEONtech/lighty</url>
 
     <properties>
-        <protobuf.version>3.25.8</protobuf.version>
+        <protobuf.version>3.33.1</protobuf.version>
         <grpc.version>1.78.0</grpc.version>
     </properties>
 


### PR DESCRIPTION
https://github.com/protocolbuffers/protobuf/releases/tag/v29.5 https://github.com/protocolbuffers/protobuf/releases/tag/v31.1 https://github.com/protocolbuffers/protobuf/releases/tag/v32.0 https://github.com/protocolbuffers/protobuf/releases/tag/v32.1 https://github.com/protocolbuffers/protobuf/releases/tag/v33.0 https://github.com/protocolbuffers/protobuf/releases/tag/v33.1