### PR TITLE
Fix netconf-node-optional revision

### DIFF
--- a/lighty-examples/lighty-community-restconf-actions-app/src/main/assembly/resources/sampleConfigSingleNode.json
+++ b/lighty-examples/lighty-community-restconf-actions-app/src/main/assembly/resources/sampleConfigSingleNode.json
@@ -40,7 +40,7 @@
                 { "usedBy":"RESTCONF","name":"sal-remote-augment","revision":"2023-11-03","nameSpace":"urn:sal:restconf:event:subscription"},
                 { "usedBy":"NETCONF","name":"netconf-keystore","revision":"2024-07-08","nameSpace":"urn:opendaylight:netconf:keystore"},
                 { "usedBy":"NETCONF","name":"netconf-node-topology","revision":"2024-09-11","nameSpace":"urn:opendaylight:netconf-node-topology"},
-                { "usedBy":"NETCONF","name":"netconf-node-optional","revision":"2024-06-11","nameSpace":"urn:opendaylight:netconf-node-optional"},
+                { "usedBy":"NETCONF","name":"netconf-node-optional","revision":"2022-12-25","nameSpace":"urn:opendaylight:netconf-node-optional"},
                 { "usedBy":"NETCONF","name":"ietf-netconf","revision":"2011-06-01","nameSpace":"urn:ietf:params:xml:ns:netconf:base:1.0"},
                 { "usedBy":"NETCONF_ACTION","name":"example-data-center","revision":"2018-08-07","nameSpace":"urn:example:data-center"}
             ]

--- a/lighty-examples/lighty-community-restconf-netconf-app/src/main/assembly/resources/sampleConfigSingleNode.json
+++ b/lighty-examples/lighty-community-restconf-netconf-app/src/main/assembly/resources/sampleConfigSingleNode.json
@@ -40,7 +40,7 @@
                 { "usedBy":"RESTCONF","name":"sal-remote-augment","revision":"2023-11-03","nameSpace":"urn:sal:restconf:event:subscription"},
                 { "usedBy":"NETCONF","name":"netconf-keystore","revision":"2024-07-08","nameSpace":"urn:opendaylight:netconf:keystore"},
                 { "usedBy":"NETCONF","name":"netconf-node-topology","revision":"2024-09-11","nameSpace":"urn:opendaylight:netconf-node-topology"},
-                { "usedBy":"NETCONF","name":"netconf-node-optional","revision":"2024-06-11","nameSpace":"urn:opendaylight:netconf-node-optional"},
+                { "usedBy":"NETCONF","name":"netconf-node-optional","revision":"2022-12-25","nameSpace":"urn:opendaylight:netconf-node-optional"},
                 { "usedBy":"NETCONF","name":"ietf-netconf","revision":"2011-06-01","nameSpace":"urn:ietf:params:xml:ns:netconf:base:1.0"}
             ]
         }

--- a/lighty-modules/lighty-netconf-sb/src/main/resources/sampleConfigCluster.json
+++ b/lighty-modules/lighty-netconf-sb/src/main/resources/sampleConfigCluster.json
@@ -30,7 +30,7 @@
                 { "usedBy":"CONTROLLER","name":"odl-entity-owners","nameSpace":"urn:opendaylight:params:xml:ns:yang:controller:entity-owners"},
                 { "usedBy":"NETCONF","name":"netconf-keystore","revision":"2024-07-08","nameSpace":"urn:opendaylight:netconf:keystore"},
                 { "usedBy":"NETCONF","name":"netconf-node-topology","revision":"2024-09-11","nameSpace":"urn:opendaylight:netconf-node-topology"},
-                { "usedBy":"NETCONF","name":"netconf-node-optional","revision":"2024-06-11","nameSpace":"urn:opendaylight:netconf-node-optional"},
+                { "usedBy":"NETCONF","name":"netconf-node-optional","revision":"2022-12-25","nameSpace":"urn:opendaylight:netconf-node-optional"},
                 { "usedBy":"NETCONF","name":"ietf-netconf","revision":"2011-06-01","nameSpace":"urn:ietf:params:xml:ns:netconf:base:1.0"},
                 { "usedBy":"CLUSTER","name": "netconf-clustered-topology-config","revision":"2017-04-19","nameSpace":"urn:opendaylight:netconf:topology:singleton:config" }
             ]

--- a/lighty-modules/lighty-netconf-sb/src/main/resources/sampleConfigSingleNode.json
+++ b/lighty-modules/lighty-netconf-sb/src/main/resources/sampleConfigSingleNode.json
@@ -30,7 +30,7 @@
                 { "usedBy":"CONTROLLER","name":"odl-entity-owners","nameSpace":"urn:opendaylight:params:xml:ns:yang:controller:entity-owners"},
                 { "usedBy":"NETCONF","name":"netconf-keystore","revision":"2024-07-08","nameSpace":"urn:opendaylight:netconf:keystore"},
                 { "usedBy":"NETCONF","name":"netconf-node-topology","revision":"2024-09-11","nameSpace":"urn:opendaylight:netconf-node-topology"},
-                { "usedBy":"NETCONF","name":"netconf-node-optional","revision":"2024-06-11","nameSpace":"urn:opendaylight:netconf-node-optional"},
+                { "usedBy":"NETCONF","name":"netconf-node-optional","revision":"2022-12-25","nameSpace":"urn:opendaylight:netconf-node-optional"},
                 { "usedBy":"NETCONF","name":"ietf-netconf","revision":"2011-06-01","nameSpace":"urn:ietf:params:xml:ns:netconf:base:1.0"}
             ]
         }


### PR DESCRIPTION
Current latest netconf-node-optional revision is 2022-12-25.

JIRA: LIGHTY-408

(cherry picked from commit a70985928f95c8775039b520424821ce3f4b1467)