### PR TITLE
Ensure Netty restconf path is well formatted

### DIFF
--- a/lighty-modules/lighty-restconf-netty-nb-community/src/main/java/io/lighty/modules/northbound/netty/restconf/community/impl/config/NettyRestConfConfiguration.java
+++ b/lighty-modules/lighty-restconf-netty-nb-community/src/main/java/io/lighty/modules/northbound/netty/restconf/community/impl/config/NettyRestConfConfiguration.java
@@ -127,12 +127,12 @@ public class NettyRestConfConfiguration {
     }
 
     public String getRestconfServletContextPath() {
-        return restconfServletContextPath;
+        return restconfServletContextPath.startsWith("/")
+            ? restconfServletContextPath.substring(1) : restconfServletContextPath;
     }
 
     public void setRestconfServletContextPath(final String restconfServletContextPath) {
-        this.restconfServletContextPath = restconfServletContextPath.startsWith("/")
-            ? restconfServletContextPath.substring(1) : restconfServletContextPath;
+        this.restconfServletContextPath = restconfServletContextPath;
     }
 
     @Override


### PR DESCRIPTION
Ensure that Netty restconf path does not starts with '/'.

We would like to:
- do not touch JSON configuration as we have it
- make solution compatible with JAXRS logic

Thus remove additional '/' when user asks for it from Netty config.

JIRA: LIGHTY-333