### PR TITLE
Sanitize ServletContextPath on JSON read

### DIFF
--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/config/RestConfConfiguration.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/config/RestConfConfiguration.java
@@ -36,7 +36,7 @@ public class RestConfConfiguration {
 
     private InetAddress inetAddress = InetAddress.getLoopbackAddress();
     private int httpPort = 8888;
-    private String restconfServletContextPath = "/restconf";
+    private String restconfServletContextPath = "restconf";
 
     public RestConfConfiguration() {
     }
@@ -132,8 +132,7 @@ public class RestConfConfiguration {
     }
 
     public String getRestconfServletContextPath() {
-        return restconfServletContextPath.startsWith("/")
-            ? this.restconfServletContextPath.substring(1) : this.restconfServletContextPath;
+        return this.restconfServletContextPath;
     }
 
     public void setRestconfServletContextPath(final String restconfServletContextPath) {

--- a/lighty-modules/lighty-restconf-netty-nb-community/src/main/java/io/lighty/modules/northbound/netty/restconf/community/impl/config/NettyRestConfConfiguration.java
+++ b/lighty-modules/lighty-restconf-netty-nb-community/src/main/java/io/lighty/modules/northbound/netty/restconf/community/impl/config/NettyRestConfConfiguration.java
@@ -127,8 +127,7 @@ public class NettyRestConfConfiguration {
     }
 
     public String getRestconfServletContextPath() {
-        return restconfServletContextPath.startsWith("/")
-            ? restconfServletContextPath.substring(1) : restconfServletContextPath;
+        return restconfServletContextPath;
     }
 
     @Override


### PR DESCRIPTION
Updating the restconf path in the getter method may cause incorrect behavior in the equals() and hashCode() methods.

Move this logic into the ConfigUtils classes to fix this while reading the JSON configuration with Jackson.

JIRA: LIGHTY-333