### PR TITLE
Bump log4j to 2.25.3

### DIFF
--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <!-- Overrides Spring Boot slf4j and log4j2 dependency version -->
         <slf4j.version>2.0.17</slf4j.version>
-        <log4j2.version>2.25.2</log4j2.version>
+        <log4j2.version>2.25.3</log4j2.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Bumps org.apache.logging.log4j:log4j-core from 2.25.2 to 2.25.3.

https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.25.3



(cherry picked from commit e62e8e27042d943d93c1ca2d8156636448a4b06f)