### PR TITLE
Bump protobuf-java to 3.25.9

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
@@ -25,7 +25,7 @@
     <url>https://github.com/PANTHEONtech/lighty</url>
 
     <properties>
-        <protobuf.version>3.25.8</protobuf.version>
+        <protobuf.version>3.25.9</protobuf.version>
         <grpc.version>1.78.0</grpc.version>
     </properties>
 


### PR DESCRIPTION
https://github.com/protocolbuffers/protobuf/releases/tag/v3.25.9


(cherry picked from commit 8474cc40430f84ecd6c20e31517d3a83f4de1e45)