### PR TITLE
Bump protobuf-java to 4.33.4

### DIFF
--- a/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
+++ b/lighty-modules/lighty-gnmi/lighty-gnmi-proto/pom.xml
@@ -25,7 +25,7 @@
     <url>https://github.com/PANTHEONtech/lighty</url>
 
     <properties>
-        <protobuf.version>3.25.8</protobuf.version>
+        <protobuf.version>4.33.4</protobuf.version>
         <grpc.version>1.78.0</grpc.version>
     </properties>
 


### PR DESCRIPTION
https://github.com/protocolbuffers/protobuf/releases/tag/v33.4

Bump to the latest protoc version v33.4 and its Java runtime 4.33.4 using Java major protocolbuffer version 4.

Please note that major version represents Java runtime version while protoc version is reflected in minor and patch.