### PR TITLE
Update maven badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Software-Defined Networking (SDN) solutions in Java. Developed by [PANTHEON.tech
 It utilizes core [OpenDaylight](https://www.opendaylight.org/) components, which are available as a set of libraries and are adapted to run in a __plain Java SE environment__.
 
 [![Build Status](https://github.com/PANTHEONtech/lighty/workflows/Build/badge.svg?branch=master)](https://github.com/PANTHEONtech/lighty/actions)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.lighty.core/lighty-bom/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.lighty.core/lighty-bom)
+[![Maven Central](https://maven-badges.sml.io/maven-central/io.lighty.core/lighty-bom/badge.svg)](https://maven-badges.sml.io/maven-central/io.lighty.core/lighty-bom)
 [![License](https://img.shields.io/badge/License-EPL%201.0-blue.svg)](https://opensource.org/licenses/EPL-1.0)
 
 _This branch maintains compatibility with __OpenDaylight 2025-09 Vanadium,__ release._


### PR DESCRIPTION
Since 2026 maven-badges.herokuapp.com has been migrated to maven-badges.sml.io.

Update our README accordingly.

For more info see:
https://github.com/softwaremill/maven-badges/blob/master/readme.md