### PR TITLE
Reorder incorrect assertion

### DIFF
--- a/lighty-applications/lighty-app-modules-config/src/test/java/io/lighty/applications/util/ModulesConfigTest.java
+++ b/lighty-applications/lighty-app-modules-config/src/test/java/io/lighty/applications/util/ModulesConfigTest.java
@@ -22,7 +22,7 @@ class ModulesConfigTest {
         final var config = ModulesConfig.getModulesConfig(this.getClass().getClassLoader()
                 .getResourceAsStream("sampleModulesConfig.json"));
 
-        assertEquals(config.getModuleTimeoutSeconds(), 180);
+        assertEquals(180, config.getModuleTimeoutSeconds());
     }
 
     @Test
@@ -30,7 +30,7 @@ class ModulesConfigTest {
         final var config = ModulesConfig.getModulesConfig(this.getClass().getClassLoader()
                 .getResourceAsStream("missingModulesConfig.json"));
 
-        assertEquals(config.getModuleTimeoutSeconds(), 60);
+        assertEquals(60, config.getModuleTimeoutSeconds());
     }
 
     @Test

--- a/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerMountPointTest.java
+++ b/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerMountPointTest.java
@@ -30,13 +30,13 @@ class LightyControllerMountPointTest extends LightyControllerTestBase {
         domMountPointService.registerProvisionListener(new DOMMountPointListener() {
             @Override
             public void onMountPointCreated(DOMMountPoint mountPoint) {
-                Assertions.assertEquals(mountPoint.getIdentifier(), testYangIID);
+                Assertions.assertEquals(testYangIID, mountPoint.getIdentifier());
                 listenerMethodsCalled[0]++;
             }
 
             @Override
             public void onMountPointRemoved(final YangInstanceIdentifier path) {
-                Assertions.assertEquals(path, testYangIID);
+                Assertions.assertEquals(testYangIID, path);
                 listenerMethodsCalled[1]++;
             }
         });

--- a/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerNotificationTest.java
+++ b/lighty-core/lighty-controller/src/test/java/io/lighty/core/controller/impl/tests/LightyControllerNotificationTest.java
@@ -45,7 +45,7 @@ class LightyControllerNotificationTest extends LightyControllerTestBase {
         final DOMNotificationService domNotificationService = lightyController.getServices()
                 .getDOMNotificationService();
         domNotificationService.registerNotificationListener(notification -> {
-            Assertions.assertEquals(notification, testNotification);
+            Assertions.assertEquals(testNotification, notification);
             listenerMethodsCalled[0]++;
         }, absolutePath);
 


### PR DESCRIPTION
Some test classes have not had their expected/actual values reordered after moving to junit.

JIRA: LIGHTY-409