### PR TITLE
Adopt Spring 4.1.0

### DIFF
--- a/lighty-core/lighty-controller-spring-di/pom.xml
+++ b/lighty-core/lighty-controller-spring-di/pom.xml
@@ -27,7 +27,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.5.15</version>
+                <version>4.0.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-controller-spring-di/pom.xml
+++ b/lighty-core/lighty-controller-spring-di/pom.xml
@@ -27,7 +27,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>4.0.3</version>
+                <version>4.1.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-examples/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/lighty-controller-springboot-netconf/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.15</version>
+        <version>4.0.3</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -43,6 +43,13 @@
                 <version>24.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!-- jcasbin pulls an older jackson-databind whose matching jackson-annotations lacks
+                 JsonSerializeAs, which Spring Boot 4's Jackson 3 databind requires at runtime. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.21</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/lighty-examples/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/lighty-controller-springboot-netconf/pom.xml
@@ -57,7 +57,7 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webmvc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/lighty-examples/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/lighty-controller-springboot-netconf/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.3</version>
+        <version>4.1.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/lighty-examples/lighty-controller-springboot-netconf/src/main/java/io/lighty/core/controller/springboot/config/SecurityConfigurationDeployed.java
+++ b/lighty-examples/lighty-controller-springboot-netconf/src/main/java/io/lighty/core/controller/springboot/config/SecurityConfigurationDeployed.java
@@ -38,9 +38,7 @@ public class SecurityConfigurationDeployed {
     @Order(1)
     protected SecurityFilterChain auth0FilterChain(HttpSecurity httpSecurity) throws Exception {
         return httpSecurity
-                .csrf()
-                .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-                .and()
+                .csrf(csrf -> csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()))
                 .addFilterBefore(new JCasBinFilter(enforcer, userAccessService), BasicAuthenticationFilter.class)
                 .securityMatcher("/services/data/**")
                 .build();

--- a/lighty-examples/lighty-controller-springboot-netconf/src/main/java/io/lighty/core/controller/springboot/config/SecurityConfigurationNotDeployed.java
+++ b/lighty-examples/lighty-controller-springboot-netconf/src/main/java/io/lighty/core/controller/springboot/config/SecurityConfigurationNotDeployed.java
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
@@ -37,8 +38,7 @@ public class SecurityConfigurationNotDeployed {
     @Order(1)
     protected SecurityFilterChain auth0FilterChain(HttpSecurity httpSecurity) throws Exception {
         return httpSecurity
-                .csrf()
-                .disable()
+                .csrf(AbstractHttpConfigurer::disable)
                 .addFilterBefore(new JCasBinFilter(enforcer, userAccessService), BasicAuthenticationFilter.class)
                 .securityMatcher("/services/data/**")
                 .build();


### PR DESCRIPTION
Migrate the removed HttpSecurity.csrf()/.and() fluent DSL (Spring Security 7) to the lambda-based Customizer DSL, and pin jackson-annotations to 2.21 so Jackson 3 (bundled with Spring Boot 4) gets the JsonSerializeAs class it needs, instead of the older 2.19.4 transitively pulled in by jcasbin's jackson-databind.

JIRA: LIGHTY-405