### PR TITLE
Fix jcommander scope

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/pom.xml
@@ -48,7 +48,6 @@
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 </project>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -110,7 +110,6 @@
                 <groupId>com.beust</groupId>
                 <artifactId>jcommander</artifactId>
                 <version>1.82</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.skyscreamer</groupId>

--- a/lighty-examples/lighty-bgp-community-restconf-app/pom.xml
+++ b/lighty-examples/lighty-bgp-community-restconf-app/pom.xml
@@ -56,7 +56,6 @@
         <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
-            <scope>compile</scope>
         </dependency>
 
         <!-- Test -->


### PR DESCRIPTION
com.beust:jcommander is only ever used from src/main (CLI argument parsing in lighty-rcgnmi-app, lighty-rnc-app, gnmi-device-simulator and lighty-bgp-community-restconf-app), never from tests, so managing it as scope=test in lighty-core/dependency-versions was wrong.

That mistake was previously patched around by redeclaring the dependency with an explicit scope=compile in each consuming module. Fix the managed scope at the source and drop the now-redundant overrides.

JIRA: LIGHTY-435