### PR TITLE
Revert "Auto-inject controller YANG models into gNMI module"

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModuleConfigUtils.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModuleConfigUtils.java
@@ -82,16 +82,8 @@ public final class RcGnmiAppModuleConfigUtils {
         }
 
         LOG.debug("Loading lighty.io gNMI module configuration...");
-        GnmiConfiguration gnmiConfiguration;
-        try (InputStream is = Files.newInputStream(path)) {
-            gnmiConfiguration = getGnmiConfiguration(is);
-        }
-        if (gnmiConfiguration == null) {
-            gnmiConfiguration = new GnmiConfiguration();
-        }
-        if (gnmiConfiguration.getYangModulesInfo() == null || gnmiConfiguration.getYangModulesInfo().isEmpty()) {
-            gnmiConfiguration.setYangModulesInfo(controllerConfig.getSchemaServiceConfig().getModels());
-        }
+        final GnmiConfiguration gnmiConfiguration = getGnmiConfiguration(Files.newInputStream(path));
+
         LOG.debug("Loading lighty.io app modules configuration...");
         final ModulesConfig modulesConfig;
         try (InputStream is = Files.newInputStream(path)) {


### PR DESCRIPTION
This reverts commit 159e733ce3bc6def93a9f4ac8a684e5567b191b2.

Since we have 070e95c0143daa490d42dbd85cb63e312bfbf6f5 we do not need to silently switch to controller's models.

JIRA: LIGHTY-435