### PR TITLE
Bring back default logging

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModuleConfigUtils.java
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/src/main/java/io/lighty/applications/rcgnmi/module/RcGnmiAppModuleConfigUtils.java
@@ -54,9 +54,11 @@ public final class RcGnmiAppModuleConfigUtils {
         final RestConfConfiguration restconfConfig = RestConfConfigUtils.getDefaultRestConfConfiguration();
         // by default listen on any IP address (0.0.0.0) not only on loopback
         restconfConfig.setInetAddress(new InetSocketAddress(restconfConfig.getHttpPort()).getAddress());
+        LOG.debug("Loading default lighty.io gNMI module configuration...");
+        final GnmiConfiguration gnmiConfiguration = new GnmiConfiguration();
         LOG.debug("Loading default lighty.io app modules configuration...");
         final ModulesConfig modulesConfig = ModulesConfig.getDefaultModulesConfig();
-        return new RcGnmiAppConfiguration(controllerConfig, restconfConfig, new GnmiConfiguration(), modulesConfig);
+        return new RcGnmiAppConfiguration(controllerConfig, restconfConfig, gnmiConfiguration, modulesConfig);
     }
 
     public static RcGnmiAppConfiguration loadConfiguration(final Path path) throws ConfigurationException, IOException {


### PR DESCRIPTION
Although the logic remains the same, keep logging clarifying that default configuration is being applied.

JIRA: LIGHTY-435