### PR TITLE
Revert "[maven-release-plugin] prepare release 24.0.0"

### DIFF
--- a/.github/workflows/lighty-rcgnmi-app/tests-lighty-rcgnmi-app.sh
+++ b/.github/workflows/lighty-rcgnmi-app/tests-lighty-rcgnmi-app.sh
@@ -44,7 +44,7 @@ ls -1 yangs
 #Run simulator for testing purpose
 printLine
 echo -e "-- Starting gNMI simulator device --\n"
-java -jar ${GITHUB_WORKSPACE}/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-gnmi-device-simulator/target/lighty-gnmi-device-simulator-24.0.0.jar -c ./simulator/example_config.json > /dev/null 2>&1 &
+java -jar ${GITHUB_WORKSPACE}/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-gnmi-device-simulator/target/lighty-gnmi-device-simulator-24.0.0-SNAPSHOT.jar -c ./simulator/example_config.json > /dev/null 2>&1 &
 
 # check if simulator has opened port
 for i in {1..5} ; do

--- a/lighty-applications/lighty-app-modules-config/pom.xml
+++ b/lighty-applications/lighty-app-modules-config/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-gnmi-device-simulator/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-gnmi-device-simulator/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../../lighty-core/lighty-app-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-docker/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>io.lighty.applications.rcgnmi</groupId>
     <artifactId>lighty-rcgnmi-app-docker</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
 
     <properties>
         <image.name>lighty-rcgnmi</image.name>

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app-module/pom.xml
@@ -13,13 +13,13 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../../lighty-core/lighty-parent/pom.xml</relativePath>
     </parent>
 
     <groupId>io.lighty.applications.rcgnmi</groupId>
     <artifactId>lighty-rcgnmi-app-module</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <url>https://github.com/PANTHEONtech/lighty</url>

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/pom.xml
@@ -13,13 +13,13 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../../lighty-core/lighty-app-parent/pom.xml</relativePath>
     </parent>
 
     <groupId>io.lighty.applications.rcgnmi</groupId>
     <artifactId>lighty-rcgnmi-app</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <url>https://github.com/PANTHEONtech/lighty</url>

--- a/lighty-applications/lighty-rcgnmi-app-aggregator/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>io.lighty.applications.rcgnmi</groupId>
     <artifactId>lighty-rcgnmi-app-aggregator</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app-docker/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.applications.rnc</groupId>
     <artifactId>lighty-rnc-app-docker</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
 
     <properties>
         <image.name>lighty-rnc</image.name>

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-app/pom.xml
@@ -12,13 +12,13 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../../lighty-core/lighty-app-parent/pom.xml</relativePath>
     </parent>
 
     <groupId>io.lighty.applications.rnc</groupId>
     <artifactId>lighty-rnc-app</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/lighty-rnc-module/pom.xml
@@ -12,13 +12,13 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../../lighty-core/lighty-parent/pom.xml</relativePath>
     </parent>
 
     <groupId>io.lighty.applications.rnc</groupId>
     <artifactId>lighty-rnc-module</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <url>https://github.com/PANTHEONtech/lighty</url>

--- a/lighty-applications/lighty-rnc-app-aggregator/pom.xml
+++ b/lighty-applications/lighty-rnc-app-aggregator/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.applications.rnc</groupId>
     <artifactId>lighty-rnc-aggregator</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-applications/pom.xml
+++ b/lighty-applications/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.applications</groupId>
     <artifactId>lighty-applications-aggregator</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.lighty.core</groupId>
     <artifactId>dependency-versions</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -251,7 +251,7 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-        <tag>24.0.0</tag>
+        <tag>HEAD</tag>
     </scm>
     <developers>
         <developer>

--- a/lighty-core/lighty-app-parent/pom.xml
+++ b/lighty-core/lighty-app-parent/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../lighty-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../lighty-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-core/lighty-bom/pom.xml
+++ b/lighty-core/lighty-bom/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-bom</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -26,182 +26,182 @@
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-codecs-util</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-common</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-controller</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-clustering</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
 
             <!-- DI framework integrations -->
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-controller-guice-di</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-controller-spring-di</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
 
             <!-- Modules -->
             <dependency>
                 <groupId>io.lighty.modules.tests</groupId>
                 <artifactId>integration-tests</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules.tests</groupId>
                 <artifactId>integration-tests-aaa</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-aaa</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-jetty-server</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-netconf-sb</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-restconf-nb-community</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-openapi</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-aaa-encryption-service</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules</groupId>
                 <artifactId>lighty-bgp</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.modules.gnmi.southbound</groupId>
                 <artifactId>lighty-gnmi</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
 
             <!-- lighty applications -->
             <dependency>
                 <groupId>io.lighty.applications.rcgnmi</groupId>
                 <artifactId>lighty-rcgnmi-app</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.applications.rcgnmi</groupId>
                 <artifactId>lighty-rcgnmi-app-module</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.applications.rnc</groupId>
                 <artifactId>lighty-rnc-app</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.applications.rnc</groupId>
                 <artifactId>lighty-rnc-module</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.applications</groupId>
                 <artifactId>lighty-app-modules-config</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
 
             <!-- lighty examples -->
             <dependency>
                 <groupId>io.lighty.kit.examples.controllers</groupId>
                 <artifactId>lighty-community-aaa-restconf-app</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.kit.examples.controllers</groupId>
                 <artifactId>lighty-community-restconf-netconf-app</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.kit.examples.controllers</groupId>
                 <artifactId>lighty-bgp-community-restconf-app</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-controller-springboot</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.kit.examples.controllers</groupId>
                 <artifactId>lighty-guice-app</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.kit.examples.controllers</groupId>
                 <artifactId>lighty-community-restconf-actions-app</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
 
             <!-- Utility resources -->
             <dependency>
                 <groupId>io.lighty.resources</groupId>
                 <artifactId>controller-application-assembly</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>io.lighty.resources</groupId>
                 <artifactId>singlenode-configuration</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.lighty.resources</groupId>
                 <artifactId>start-script</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
             </dependency>
 
             <!-- Dependencies and resources which should not normally leak into production -->
             <dependency>
                 <groupId>io.lighty.models.test</groupId>
                 <artifactId>lighty-test-models</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>io.lighty.models.test</groupId>
                 <artifactId>lighty-toaster</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>io.lighty.resources</groupId>
                 <artifactId>log4j2-config</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>
@@ -251,7 +251,7 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-        <tag>24.0.0</tag>
+        <tag>HEAD</tag>
     </scm>
     <developers>
         <developer>

--- a/lighty-core/lighty-clustering/pom.xml
+++ b/lighty-core/lighty-clustering/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../lighty-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-core/lighty-codecs-util/pom.xml
+++ b/lighty-core/lighty-codecs-util/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../lighty-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-core/lighty-common/pom.xml
+++ b/lighty-core/lighty-common/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../lighty-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-core/lighty-controller-guice-di/pom.xml
+++ b/lighty-core/lighty-controller-guice-di/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../lighty-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-core/lighty-controller-spring-di/pom.xml
+++ b/lighty-core/lighty-controller-spring-di/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../lighty-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-core/lighty-controller/README.md
+++ b/lighty-core/lighty-controller/README.md
@@ -17,7 +17,7 @@ To use Lighty controller in your project:
   <dependency>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-controller</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
   </dependency>
 ```
 

--- a/lighty-core/lighty-controller/pom.xml
+++ b/lighty-core/lighty-controller/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../lighty-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-core/lighty-minimal-parent/pom.xml
+++ b/lighty-core/lighty-minimal-parent/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-minimal-parent</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -30,14 +30,14 @@
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>dependency-versions</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-bom</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -142,7 +142,7 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-        <tag>24.0.0</tag>
+        <tag>HEAD</tag>
     </scm>
     <developers>
         <developer>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-minimal-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../lighty-minimal-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-core/pom.xml
+++ b/lighty-core/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-core-aggregator</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-examples/README.md
+++ b/lighty-examples/README.md
@@ -15,7 +15,7 @@ ODL core services represent MD-SAL layer, controller, DataStore, global schema c
    <dependency>
       <groupId>io.lighty.core</groupId>
       <artifactId>lighty-bom</artifactId>
-      <version>24.0.0</version>
+      <version>24.0.0-SNAPSHOT</version>
       <type>pom</type>
       <scope>import</scope>
    </dependency>

--- a/lighty-examples/lighty-bgp-community-restconf-app/pom.xml
+++ b/lighty-examples/lighty-bgp-community-restconf-app/pom.xml
@@ -13,13 +13,13 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-app-parent/pom.xml</relativePath>
     </parent>
 
     <groupId>io.lighty.kit.examples.controllers</groupId>
     <artifactId>lighty-bgp-community-restconf-app</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/lighty-examples/lighty-community-aaa-restconf-app/pom.xml
+++ b/lighty-examples/lighty-community-aaa-restconf-app/pom.xml
@@ -12,13 +12,13 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-app-parent/pom.xml</relativePath>
     </parent>
 
     <groupId>io.lighty.kit.examples.controllers</groupId>
     <artifactId>lighty-community-aaa-restconf-app</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/lighty-examples/lighty-community-netty-restconf-app/README.md
+++ b/lighty-examples/lighty-community-netty-restconf-app/README.md
@@ -23,13 +23,13 @@ build the project: ```mvn clean install```
 ### Start this demo example
 * build the project using ```mvn clean install```
 * go to target directory ```cd lighty-examples/lighty-community-netty-restconf-app/target```
-* unzip example application bundle ```unzip lighty-community-netty-restconf-app-24.0.0-bin.zip```
-* go to unzipped application directory ```cd lighty-community-netty-restconf-app-24.0.0```
-* start the example controller application ```java -jar lighty-community-netty-restconf-app-24.0.0.jar```
+* unzip example application bundle ```unzip lighty-community-netty-restconf-app-24.0.0-SNAPSHOT-bin.zip```
+* go to unzipped application directory ```cd lighty-community-netty-restconf-app-24.0.0-SNAPSHOT```
+* start the example controller application ```java -jar lighty-community-netty-restconf-app-24.0.0-SNAPSHOT.jar```
 
 ### Test example application
 Once the example application has been started using the command
-```java -jar lighty-community-netty-restconf-app-24.0.0.jar```
+```java -jar lighty-community-netty-restconf-app-24.0.0-SNAPSHOT.jar```
 RESTCONF web interface is available at URL ```http://localhost:8888/restconf/*```
 
 Unlike `lighty-community-restconf-netconf-app`, this application requires HTTP Basic authentication on every

--- a/lighty-examples/lighty-community-netty-restconf-app/pom.xml
+++ b/lighty-examples/lighty-community-netty-restconf-app/pom.xml
@@ -12,7 +12,7 @@ and is available at http://www.eclipse.org/legal/epl-v10.html
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-app-parent/pom.xml</relativePath>
     </parent>
 
@@ -35,7 +35,7 @@ and is available at http://www.eclipse.org/legal/epl-v10.html
         <dependency>
             <groupId>io.lighty.modules</groupId>
             <artifactId>lighty-restconf-netty-nb-community</artifactId>
-            <version>24.0.0</version>
+            <version>24.0.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/lighty-examples/lighty-community-restconf-actions-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-actions-app/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-app-parent/pom.xml</relativePath>
     </parent>
 
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>io.lighty.models.test</groupId>
             <artifactId>example-data-center</artifactId>
-            <version>24.0.0</version>
+            <version>24.0.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/lighty-examples/lighty-community-restconf-netconf-app/README.md
+++ b/lighty-examples/lighty-community-restconf-netconf-app/README.md
@@ -21,12 +21,12 @@ build the project: ```mvn clean install```
 ### Start this demo example
 * build the project using ```mvn clean install```
 * go to target directory ```cd lighty-examples/lighty-community-restconf-netconf-app/target``` 
-* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-24.0.0-bin.zip```
-* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-24.0.0```
-* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-24.0.0.jar``` 
+* unzip example application bundle ```unzip  lighty-community-restconf-netconf-app-24.0.0-SNAPSHOT-bin.zip```
+* go to unzipped application directory ```cd lighty-community-restconf-netconf-app-24.0.0-SNAPSHOT```
+* start controller example controller application ```java -jar lighty-community-restconf-netconf-app-24.0.0-SNAPSHOT.jar``` 
 
 ### Test example application
-Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-24.0.0.jar``` 
+Once example application has been started using command ```java -jar lighty-community-restconf-netconf-app-24.0.0-SNAPSHOT.jar``` 
 RESTCONF web interface is available at URL ```http://localhost:8888/restconf/*```
 
 ##### URLs to start with
@@ -42,7 +42,7 @@ URLs for OpenApi: https://datatracker.ietf.org/doc/html/rfc8040
 
 ### Use custom config files
 There are two separated config files: for NETCONF SBP single node and for cluster.
-`java -jar lighty-community-restconf-netconf-app-24.0.0.jar /path/to/singleNodeConfig.json`
+`java -jar lighty-community-restconf-netconf-app-24.0.0-SNAPSHOT.jar /path/to/singleNodeConfig.json`
 
 Example configuration for single node is [here](src/main/assembly/resources/sampleConfigSingleNode.json)
 

--- a/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
+++ b/lighty-examples/lighty-community-restconf-netconf-app/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-app-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-examples/lighty-controller-springboot-netconf/README.md
+++ b/lighty-examples/lighty-controller-springboot-netconf/README.md
@@ -46,7 +46,7 @@ mvn spring-boot:run
 or
 
 ```
-java -jar target/lighty-controller-springboot-24.0.0.jar
+java -jar target/lighty-controller-springboot-24.0.0-SNAPSHOT.jar
 ```
 
 or in any IDE, run main in 

--- a/lighty-examples/lighty-controller-springboot-netconf/pom.xml
+++ b/lighty-examples/lighty-controller-springboot-netconf/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-controller-springboot</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <description>Demo lighty.io project for SpringBoot</description>
 
@@ -33,14 +33,14 @@
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>lighty-bom</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>io.lighty.core</groupId>
                 <artifactId>dependency-versions</artifactId>
-                <version>24.0.0</version>
+                <version>24.0.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -156,7 +156,7 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-        <tag>24.0.0</tag>
+        <tag>HEAD</tag>
     </scm>
     <developers>
         <developer>

--- a/lighty-examples/lighty-gnmi-community-restconf-app/README.md
+++ b/lighty-examples/lighty-gnmi-community-restconf-app/README.md
@@ -43,22 +43,22 @@ cd lighty-examples/lighty-gnmi-community-restconf-app
 ### Start RCgNMI controller app
 Unzip lighty-rcgnmi-app to current location
 ```
-unzip ../../lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/target/lighty-rcgnmi-app-24.0.0-bin.zip
+unzip ../../lighty-applications/lighty-rcgnmi-app-aggregator/lighty-rcgnmi-app/target/lighty-rcgnmi-app-24.0.0-SNAPSHOT-bin.zip
 ```
 Start application with pre-prepared configuration [example_config.json](example_config.json).
 ```
-java -jar lighty-rcgnmi-app-24.0.0/lighty-rcgnmi-app-24.0.0.jar -c example_config.json
+java -jar lighty-rcgnmi-app-24.0.0-SNAPSHOT/lighty-rcgnmi-app-24.0.0-SNAPSHOT.jar -c example_config.json
 ```
 
 ### Start lighty.io gNMI device simulator
 Copy gNMI simulator app to current folder.
 ```
-cp ../../lighty-applications/lighty-rcgnmi-app-aggregator/lighty-gnmi-device-simulator/target/lighty-gnmi-device-simulator-24.0.0.jar .
+cp ../../lighty-applications/lighty-rcgnmi-app-aggregator/lighty-gnmi-device-simulator/target/lighty-gnmi-device-simulator-24.0.0-SNAPSHOT.jar .
 ```
 
 Start the application with pre-prepared configuration [simulator_config.json](simulator/simulator_config.json)
 ```
-java -jar lighty-gnmi-device-simulator-24.0.0.jar -c simulator/simulator_config.json 
+java -jar lighty-gnmi-device-simulator-24.0.0-SNAPSHOT.jar -c simulator/simulator_config.json 
 ```
 
 ### Add client certificates to lighty.io gNMI keystore

--- a/lighty-examples/lighty-guice-app/pom.xml
+++ b/lighty-examples/lighty-guice-app/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>lighty-app-parent</artifactId>
         <groupId>io.lighty.core</groupId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-app-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-examples/pom.xml
+++ b/lighty-examples/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.kit.examples</groupId>
     <artifactId>example-applications-aggregator</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-models/README.md
+++ b/lighty-models/README.md
@@ -56,7 +56,7 @@ my-model/pom.xml
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/lighty-models/pom.xml
+++ b/lighty-models/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.models</groupId>
     <artifactId>lighty-models-aggregator</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-models/test/lighty-example-data-center/pom.xml
+++ b/lighty-models/test/lighty-example-data-center/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../../lighty-core/lighty-binding-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-models/test/lighty-test-models/pom.xml
+++ b/lighty-models/test/lighty-test-models/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../../lighty-core/lighty-binding-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-models/test/lighty-toaster/pom.xml
+++ b/lighty-models/test/lighty-toaster/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-binding-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../../lighty-core/lighty-binding-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-models/test/pom.xml
+++ b/lighty-models/test/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.models.test</groupId>
     <artifactId>lighty-models-test-aggregator</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-modules/integration-tests-aaa/pom.xml
+++ b/lighty-modules/integration-tests-aaa/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-modules/integration-tests/pom.xml
+++ b/lighty-modules/integration-tests/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-aaa-aggregator/lighty-aaa-encryption-service/pom.xml
+++ b/lighty-modules/lighty-aaa-aggregator/lighty-aaa-encryption-service/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>lighty-parent</artifactId>
         <groupId>io.lighty.core</groupId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../../lighty-core/lighty-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-aaa-aggregator/lighty-aaa/pom.xml
+++ b/lighty-modules/lighty-aaa-aggregator/lighty-aaa/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../../lighty-core/lighty-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-aaa-aggregator/pom.xml
+++ b/lighty-modules/lighty-aaa-aggregator/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-aaa-aggregator</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/lighty-modules/lighty-bgp/README.md
+++ b/lighty-modules/lighty-bgp/README.md
@@ -11,7 +11,7 @@ To use lighty BGP plugin in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-bgp</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
   </dependency>
 ```
 * Initialize and start BgpModule instance:

--- a/lighty-modules/lighty-bgp/pom.xml
+++ b/lighty-modules/lighty-bgp/pom.xml
@@ -13,13 +13,13 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent/pom.xml</relativePath>
     </parent>
 
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-bgp</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <url>https://github.com/PANTHEONtech/lighty</url>

--- a/lighty-modules/lighty-gnmi/pom.xml
+++ b/lighty-modules/lighty-gnmi/pom.xml
@@ -13,13 +13,13 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent/pom.xml</relativePath>
     </parent>
 
     <groupId>io.lighty.modules.gnmi.southbound</groupId>
     <artifactId>lighty-gnmi</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/lighty-modules/lighty-jetty-server/pom.xml
+++ b/lighty-modules/lighty-jetty-server/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-netconf-sb/README.md
+++ b/lighty-modules/lighty-netconf-sb/README.md
@@ -42,7 +42,7 @@ To use NETCONF in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-netconf-sb</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
   </dependency>  
 ```
 2. Initialize and start an instance of NETCONF SBP in your code:

--- a/lighty-modules/lighty-netconf-sb/pom.xml
+++ b/lighty-modules/lighty-netconf-sb/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-openapi/pom.xml
+++ b/lighty-modules/lighty-openapi/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-restconf-nb-community/README.md
+++ b/lighty-modules/lighty-restconf-nb-community/README.md
@@ -12,7 +12,7 @@ To use RESTCONF in your project:
   <dependency>
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-restconf-nb-community</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
   </dependency>
 ```
 

--- a/lighty-modules/lighty-restconf-nb-community/pom.xml
+++ b/lighty-modules/lighty-restconf-nb-community/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-modules/lighty-restconf-netty-nb-community/pom.xml
+++ b/lighty-modules/lighty-restconf-netty-nb-community/pom.xml
@@ -11,7 +11,7 @@ and is available at http://www.eclipse.org/legal/epl-v10.html
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-modules/pom.xml
+++ b/lighty-modules/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.modules</groupId>
     <artifactId>lighty-modules-aggregator</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
 

--- a/lighty-resources/controller-application-assembly/pom.xml
+++ b/lighty-resources/controller-application-assembly/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-resources/log4j2-config/pom.xml
+++ b/lighty-resources/log4j2-config/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty.resources</groupId>
     <artifactId>log4j2-config</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -68,7 +68,7 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-        <tag>24.0.0</tag>
+        <tag>HEAD</tag>
     </scm>
     <developers>
         <developer>

--- a/lighty-resources/pom.xml
+++ b/lighty-resources/pom.xml
@@ -12,7 +12,7 @@
     <groupId>io.lighty.resources</groupId>
     <artifactId>lighty-resources-aggregator</artifactId>
     <packaging>pom</packaging>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/lighty-resources/singlenode-configuration/pom.xml
+++ b/lighty-resources/singlenode-configuration/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../../lighty-core/lighty-parent/pom.xml</relativePath>
     </parent>
 

--- a/lighty-resources/start-script/pom.xml
+++ b/lighty-resources/start-script/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>io.lighty.core</groupId>
     <artifactId>lighty-parent</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
     <relativePath>../../lighty-core/lighty-parent/pom.xml</relativePath>
   </parent>
 

--- a/lighty-tests-report/pom.xml
+++ b/lighty-tests-report/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>24.0.0</version>
+        <version>24.0.0-SNAPSHOT</version>
         <relativePath>../lighty-core/lighty-parent/pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.lighty</groupId>
     <artifactId>lighty-aggregator</artifactId>
-    <version>24.0.0</version>
+    <version>24.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>lighty</name>
 
@@ -91,7 +91,7 @@
         <connection>scm:git:https://github.com/PANTHEONtech/lighty.git</connection>
         <developerConnection>scm:git:https://github.com/PANTHEONtech/lighty.git</developerConnection>
         <url>https://github.com/PANTHEONtech/lighty</url>
-        <tag>24.0.0</tag>
+        <tag>HEAD</tag>
     </scm>
     <developers>
         <developer>


### PR DESCRIPTION
This reverts commit 81932b61d6c0378587a929f951ea6c6c9c59cb82.

The deployment has failed central verification:
pkg:maven/io.lighty.applications.rcgnmi/lighty-gnmi-device-simulator@24.0.0 Error: Sources must be provided but not found in entries Error: Javadocs must be provided but not found in entries Error: Project name is missing

Since no artifacts were deployed, we can revert, fix packaging and try again.

JIRA: LIGHTY-434