### PR TITLE
Skip gNMI device simulator from deployment

### DIFF
--- a/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-gnmi-device-simulator/pom.xml
+++ b/lighty-applications/lighty-rcgnmi-app-aggregator/lighty-gnmi-device-simulator/pom.xml
@@ -21,6 +21,13 @@
     <groupId>io.lighty.applications.rcgnmi</groupId>
     <artifactId>lighty-gnmi-device-simulator</artifactId>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+    <url>https://github.com/PANTHEONtech/lighty</url>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.opendaylight.gnmi</groupId>

--- a/lighty-core/lighty-minimal-parent/pom.xml
+++ b/lighty-core/lighty-minimal-parent/pom.xml
@@ -108,6 +108,7 @@
                                 <artifactId>lighty-community-restconf-netconf-app</artifactId>
                                 <artifactId>lighty-controller-springboot</artifactId>
                                 <artifactId>lighty-core-aggregator</artifactId>
+                                <artifactId>lighty-gnmi-device-simulator</artifactId>
                                 <artifactId>lighty-gnmi</artifactId>
                                 <artifactId>lighty-guice-app</artifactId>
                                 <artifactId>lighty-models-aggregator</artifactId>


### PR DESCRIPTION
We do not want to deploy gNMI device simulator since its being used for testing only.

When at place add correct artifact name and URL to project POM.

JIRA: LIGHTY-434